### PR TITLE
docs: clarify contribution requirements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @RandallLiuXin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
 env:
   PYTHON_VERSION: "3.12"
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   doc-i18n:
     name: Doc i18n

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,14 +3,12 @@ name: Docs
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "docs/**"
-      - "mkdocs.yml"
   push:
     branches: [main]
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
 
 permissions:
   contents: read
@@ -24,16 +22,39 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Check whether docs build is needed
+        id: docs-changes
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE="${{ github.event.pull_request.base.sha }}"
+          if git diff --name-only "$BASE" "$GITHUB_SHA" -- docs mkdocs.yml .github/workflows/docs.yml | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/setup-python@v6
+        if: steps.docs-changes.outputs.changed == 'true'
         with:
           python-version: "3.12"
           cache: pip
 
       - name: Install docs dependencies
+        if: steps.docs-changes.outputs.changed == 'true'
         run: pip install mkdocs-material mkdocs-static-i18n
 
       - name: Build docs
+        if: steps.docs-changes.outputs.changed == 'true'
         run: mkdocs build
+
+      - name: Skip docs build
+        if: steps.docs-changes.outputs.changed != 'true'
+        run: echo "No docs or MkDocs changes detected."
 
   deploy:
     name: Deploy to GitHub Pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,15 +28,17 @@ GodotMaker is licensed under the Business Source License 1.1 (see [LICENSE](LICE
 1. Fork the repo and create a branch from `main`.
 2. Follow the coding conventions below.
 3. Write or update tests for your changes.
-4. **Run benchmarks** — you must verify your changes do not regress performance before submitting. Include benchmark results in the PR description.
+4. For performance-sensitive changes, run benchmarks and include the results in the PR description.
 5. Run the full validation pipeline locally:
    ```bash
    # Run tests
-   pytest
+   python -m pytest
+
+   # Run gdUnit4 for Godot project changes
    godot --headless --path . -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd --add res://test/ --ignoreHeadlessMode
 
    # Gitleaks (runs automatically via pre-commit hook)
-   gitleaks detect --source .
+   gitleaks detect --source . --config .gitleaks.toml
    ```
 6. Add a changelog entry to [`docs/update/next.md`](docs/update/next.md) describing your change. Rules:
    - **One sentence per bullet.** If you can't fit it, your bullet is doing two things — split it.
@@ -62,8 +64,11 @@ cd GodotMaker
 # Install git hooks (gitleaks pre-commit)
 bash scripts/install-hooks.sh
 
-# Install Python dependencies
-pip install -r requirements.txt
+# Install development dependencies used by CI
+python -m pip install pytest ruff mkdocs mkdocs-material
+
+# Optional: install asset/API provider dependencies when working on tools/
+python -m pip install -r tools/requirements.txt
 ```
 
 ## Coding Conventions
@@ -97,7 +102,7 @@ pip install -r requirements.txt
 
 1. All PRs require at least one review.
 2. CI must pass before merge.
-3. Benchmark verification is mandatory — reviewers will check for performance data in the PR description.
+3. Performance-sensitive PRs must include benchmark data in the PR description.
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

Clarify the public contribution path before opening the repository.

## Changes

- Make benchmark data required only for performance-sensitive PRs.
- Replace the stale root `requirements.txt` install command with the actual development dependency setup.
- Add a repository CODEOWNERS file so the main branch ruleset's code-owner review setting has an owner to resolve.

## Validation

- `python tools/check_doc_i18n.py --base main --head HEAD`
- `git diff --check main..HEAD`
- `mkdocs build`

Note: `mkdocs build` still reports the existing nav/link warnings for non-nav docs and `decisions/disable-gdtoolkit.md`; this PR does not change those files.