### PR TITLE
docs: align prerequisite versions

### DIFF
--- a/docs/wiki/04-troubleshooting/common-problems.md
+++ b/docs/wiki/04-troubleshooting/common-problems.md
@@ -52,14 +52,14 @@ To make it permanent, add the export line to your shell profile (`~/.bashrc`, `~
 or:
 
 ```
-[FAIL] Godot 4.3.x too old (>= 4.4 required)
+[FAIL] Godot 4.3.x too old (>= 4.5 required)
 ```
 
-**Cause:** Godot 4.4 or later is not installed, or its folder is not on your system PATH.
+**Cause:** Godot 4.5 or later is not installed, or its folder is not on your system PATH.
 
 **Fix:**
 
-1. Download Godot 4.4+ from https://godotengine.org/download
+1. Download Godot 4.5+ from https://godotengine.org/download
 2. Either add its folder to PATH, or open `.claude/godotmaker.yaml` in your game project and set the `godot_path` key to the full path of the Godot executable.
 
 Verify with:

--- a/docs/wiki/05-tools/check-env.md
+++ b/docs/wiki/05-tools/check-env.md
@@ -23,7 +23,7 @@ If anything is missing, you'll see a list of failed checks and what to do about 
 
 ### Python
 
-- Python 3.9 or later is running this script.
+- Python 3.10 or later is running this script.
 - Core packages are installed: `requests`, `pillow`, `numpy`.
 - Provider packages are checked based on `.godotmaker/config.yaml`: `google-genai` for Gemini, `openai` for OpenAI, and `xai-sdk` for Grok image or video generation.
 

--- a/docs/zh/wiki/04-troubleshooting/common-problems.md
+++ b/docs/zh/wiki/04-troubleshooting/common-problems.md
@@ -52,14 +52,14 @@ $env:XAI_API_KEY = "your-key-here"
 或者：
 
 ```
-[FAIL] Godot 4.3.x too old (>= 4.4 required)
+[FAIL] Godot 4.3.x too old (>= 4.5 required)
 ```
 
-**原因：** Godot 4.4 或更高版本没有安装，或者安装目录不在系统 PATH 里。
+**原因：** Godot 4.5 或更高版本没有安装，或者安装目录不在系统 PATH 里。
 
 **解决办法：**
 
-1. 从 https://godotengine.org/download 下载 Godot 4.4+
+1. 从 https://godotengine.org/download 下载 Godot 4.5+
 2. 要么把它的目录加进 PATH，要么打开你游戏项目里的 `.claude/godotmaker.yaml`，把 `godot_path` 字段设为 Godot 可执行文件的完整路径。
 
 验证是否正常：

--- a/docs/zh/wiki/05-tools/check-env.md
+++ b/docs/zh/wiki/05-tools/check-env.md
@@ -23,7 +23,7 @@ All required checks passed! Ready to use GodotMaker.
 
 ### Python
 
-- 运行本脚本的 Python 版本为 3.9 或更高。
+- 运行本脚本的 Python 版本为 3.10 或更高。
 - 已安装核心包：`requests`、`pillow`、`numpy`。
 - 根据 `.godotmaker/config.yaml` 检查提供方包：Gemini 需要 `google-genai`，OpenAI 需要 `openai`，Grok 图片或视频生成需要 `xai-sdk`。
 


### PR DESCRIPTION
## Summary

Align remaining prerequisite references with the public README baseline.

## Changes

- Update check-env docs from Python 3.9+ to Python 3.10+.
- Update troubleshooting docs from Godot 4.4+ to Godot 4.5+.
- Keep English and Chinese wiki pages in sync.

## Validation

- `python tools/check_doc_i18n.py --base main --head HEAD`
- `git diff --check`
- `mkdocs build`

Note: `mkdocs build` still reports the existing non-nav docs and `decisions/disable-gdtoolkit.md` link warnings; this PR does not change those files.