### PR TITLE
feat: pause after first project config creation

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -18,6 +18,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Added
 
 - (WIP) Diagnostic log at `.godotmaker/log_agent_tool_debug.log` that records every phase of `log_agent_tool.py` so the next failure mode is localizable from artifacts.
+- First publish now creates `.godotmaker/config.yaml` before the pipeline starts and pauses so users can edit model settings; automation can pass `--no-config-review` to skip the pause.
 
 ## Changed
 

--- a/shell/publish.ps1
+++ b/shell/publish.ps1
@@ -1,5 +1,5 @@
 # Publish GodotMaker skills into a target Godot project directory.
-# Usage: .\shell\publish.ps1 [-Force|--force] [-Agent claude-code|codex|--agent <agent>] <target_godot_project_dir>
+# Usage: .\shell\publish.ps1 [-Force|--force] [--no-config-review] [-Agent claude-code|codex|--agent <agent>] <target_godot_project_dir>
 #
 # On upgrade, compares VERSION against the target's .godotmaker/version:
 #   PATCH  -> auto-proceed
@@ -16,6 +16,7 @@ $Script = Join-Path $RepoRoot "tools\publish.py"
 
 # Parse args manually to accept both PowerShell-style and POSIX-style flags.
 $ForceFlag = $false
+$NoConfigReview = $false
 $Agent = $null
 $Target = $null
 
@@ -23,6 +24,8 @@ for ($i = 0; $i -lt $args.Count; $i++) {
     $a = $args[$i]
     if ($a -eq "-Force" -or $a -eq "--force") {
         $ForceFlag = $true
+    } elseif ($a -eq "--no-config-review") {
+        $NoConfigReview = $true
     } elseif ($a -eq "-Agent" -or $a -eq "--agent") {
         $i += 1
         if ($i -ge $args.Count) {
@@ -36,12 +39,13 @@ for ($i = 0; $i -lt $args.Count; $i++) {
 }
 
 if (-not $Target) {
-    Write-Host "Usage: .\shell\publish.ps1 [-Force|--force] [-Agent claude-code|codex|--agent <agent>] <target_godot_project_dir>"
+    Write-Host "Usage: .\shell\publish.ps1 [-Force|--force] [--no-config-review] [-Agent claude-code|codex|--agent <agent>] <target_godot_project_dir>"
     exit 1
 }
 
 $pyArgs = @($Script)
 if ($ForceFlag) { $pyArgs += "--force" }
+if ($NoConfigReview) { $pyArgs += "--no-config-review" }
 if ($Agent) { $pyArgs += @("--agent", $Agent) }
 $pyArgs += $Target
 

--- a/shell/publish.sh
+++ b/shell/publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Publish GodotMaker skills into a target Godot project directory.
-# Usage: bash shell/publish.sh [--force] [--agent claude-code|codex] <target_godot_project_dir>
+# Usage: bash shell/publish.sh [--force] [--no-config-review] [--agent claude-code|codex] <target_godot_project_dir>
 #
 # On upgrade, compares VERSION against the target's .godotmaker/version:
 #   PATCH  -> auto-proceed

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.join(
 
 import publish
 import agent_runtime
+from project_config import DEFAULT_CONFIG_TEMPLATE, ProjectConfigResult
 from publish import (
     read_godot_path,
     create_godotmaker_yaml,
@@ -31,7 +32,6 @@ from publish import (
     register_godot_permissions,
     rmtree_force,
     _verify_godot_path,
-    DEFAULT_CONFIG_TEMPLATE,
 )
 
 
@@ -113,7 +113,13 @@ def _publish_codex_project(tmp_path, monkeypatch):
     monkeypatch.setattr(publish, "run_migrations",
                         lambda *_args, **_kwargs: True)
     monkeypatch.setattr(sys, "argv",
-                        ["publish.py", "--agent", "codex", "--force", str(target)])
+                        [
+                            "publish.py",
+                            "--agent", "codex",
+                            "--force",
+                            "--no-config-review",
+                            str(target),
+                        ])
 
     publish.main()
     return target, codex_mcp_calls
@@ -422,8 +428,9 @@ class TestRegisterCodexMcp:
 
 class TestCreateProjectConfig:
     def test_creates_config_with_defaults(self, tmp_path):
-        create_project_config(tmp_path)
+        result = create_project_config(tmp_path)
         config = tmp_path / ".godotmaker" / "config.yaml"
+        assert result == ProjectConfigResult(path=config, created=True)
         assert config.exists()
         content = config.read_text()
         assert "agent: claude-code" in content
@@ -437,10 +444,15 @@ class TestCreateProjectConfig:
         config_dir.mkdir()
         config = config_dir / "config.yaml"
         config.write_text("vqa_model: custom-model\n")
-        create_project_config(tmp_path, publish.AGENT_CODEX)
+        result = create_project_config(tmp_path, publish.AGENT_CODEX)
         content = config.read_text()
+        assert result == ProjectConfigResult(path=config, created=False)
         assert "vqa_model: custom-model" in content
         assert "agent: codex" in content
+
+    def test_create_project_config_does_not_stamp_version(self, tmp_path):
+        create_project_config(tmp_path)
+        assert not (tmp_path / ".godotmaker" / "version").exists()
 
     def test_published_agent_selects_runtime_config(self, tmp_path):
         create_project_config(tmp_path, publish.AGENT_CODEX)
@@ -467,6 +479,38 @@ class TestCreateProjectConfig:
         lines = [line for line in content.splitlines() if line and not line.startswith("#")]
         for line in lines:
             assert ":" in line, f"Non-comment line missing ':' — {line}"
+
+
+    def test_review_created_project_config_waits_for_enter(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        config = tmp_path / ".godotmaker" / "config.yaml"
+        result = ProjectConfigResult(path=config, created=True)
+        calls = []
+        monkeypatch.setattr("builtins.input", lambda: calls.append("input") or "")
+
+        publish.review_created_project_config(result)
+
+        assert calls == ["input"]
+        out = capsys.readouterr().out
+        assert "Project config created:" in out
+        assert str(config.resolve()) in out
+
+    def test_review_created_project_config_aborts_on_eof(
+        self, tmp_path, monkeypatch
+    ):
+        result = ProjectConfigResult(
+            path=tmp_path / ".godotmaker" / "config.yaml",
+            created=True,
+        )
+
+        def _raise_eof():
+            raise EOFError()
+
+        monkeypatch.setattr("builtins.input", _raise_eof)
+        with pytest.raises(SystemExit) as exc:
+            publish.review_created_project_config(result)
+        assert exc.value.code == 1
 
 
 SELECTIVE_ENTRIES = [

--- a/tools/project_config.py
+++ b/tools/project_config.py
@@ -1,0 +1,80 @@
+"""Project config creation helpers for GodotMaker."""
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from agent_runtime import AGENT_CLAUDE_CODE
+
+
+DEFAULT_CONFIG_TEMPLATE = (
+    Path(__file__).resolve().parent.parent / "config" / "config.yaml.default"
+)
+
+
+@dataclass(frozen=True)
+class ProjectConfigResult:
+    path: Path
+    created: bool
+
+
+def resolve_config_template(_agent: str) -> Path:
+    """Return the config template for the selected coding agent.
+
+    The current release uses one shared project config template. Keeping this
+    resolver as the public seam lets future agent-specific defaults land
+    without changing callers or wrapper flags.
+    """
+    return DEFAULT_CONFIG_TEMPLATE
+
+
+def set_simple_yaml_value(path: Path, key: str, value: str) -> None:
+    """Set a top-level scalar key in a simple YAML file."""
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    updated = False
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped.startswith("#") or ":" not in stripped:
+            continue
+        current_key = stripped.split(":", 1)[0].strip()
+        if current_key == key:
+            lines[i] = f"{key}: {value}"
+            updated = True
+            break
+    if not updated:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append(f"{key}: {value}")
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def create_project_config(
+    target: Path,
+    agent: str = AGENT_CLAUDE_CODE,
+) -> ProjectConfigResult:
+    """Create or update .godotmaker/config.yaml with project settings.
+
+    This helper has deliberately narrow scope: it only creates/preserves the
+    user-editable project config. It does not publish framework runtime files,
+    write version stamps, initialize git, or run migrations.
+    """
+    config_dir = target / ".godotmaker"
+    config_file = config_dir / "config.yaml"
+    if config_file.exists():
+        set_simple_yaml_value(config_file, "agent", agent)
+        print(".godotmaker/config.yaml already exists, updated agent")
+        return ProjectConfigResult(path=config_file, created=False)
+
+    config_dir.mkdir(parents=True, exist_ok=True)
+    template = resolve_config_template(agent)
+    if template.exists():
+        shutil.copy2(template, config_file)
+    else:
+        config_file.write_text(
+            "# GodotMaker config - template not found\n",
+            encoding="utf-8",
+        )
+    set_simple_yaml_value(config_file, "agent", agent)
+    print("Created .godotmaker/config.yaml")
+    return ProjectConfigResult(path=config_file, created=True)

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -26,6 +26,11 @@ from pathlib import Path
 from typing import NamedTuple
 
 from agent_runtime import AGENT_CLAUDE_CODE, AGENT_CODEX
+from project_config import (
+    ProjectConfigResult,
+    create_project_config as create_project_config_file,
+    set_simple_yaml_value,
+)
 
 from _version import SemVer, parse_version
 from migrate import (
@@ -55,9 +60,6 @@ AGENT_RUNTIME_REFERENCES = {
 AGENT_ROOT_BOOTSTRAP_TEMPLATES = {
     AGENT_CODEX: Path("templates") / "agents-bootstrap.md",
 }
-
-DEFAULT_CONFIG_TEMPLATE = Path(__file__).resolve().parent.parent / "config" / "config.yaml.default"
-
 
 @dataclass(frozen=True)
 class AgentPublishAdapter:
@@ -682,41 +684,28 @@ def create_godotmaker_yaml(config_file: Path) -> bool:
 
 
 def _set_simple_yaml_value(path: Path, key: str, value: str) -> None:
-    """Set a top-level scalar key in a simple YAML file."""
-    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
-    updated = False
-    for i, line in enumerate(lines):
-        stripped = line.strip()
-        if stripped.startswith("#") or ":" not in stripped:
-            continue
-        current_key = stripped.split(":", 1)[0].strip()
-        if current_key == key:
-            lines[i] = f"{key}: {value}"
-            updated = True
-            break
-    if not updated:
-        if lines and lines[-1].strip():
-            lines.append("")
-        lines.append(f"{key}: {value}")
-    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    """Backward-compatible wrapper for tests and older imports."""
+    set_simple_yaml_value(path, key, value)
 
 
 def create_project_config(target: Path, agent: str = AGENT_CLAUDE_CODE):
     """Create or update .godotmaker/config.yaml with project settings."""
-    config_dir = target / ".godotmaker"
-    config_file = config_dir / "config.yaml"
-    if config_file.exists():
-        _set_simple_yaml_value(config_file, "agent", agent)
-        print(".godotmaker/config.yaml already exists, updated agent")
-        return
+    return create_project_config_file(target, agent)
 
-    config_dir.mkdir(parents=True, exist_ok=True)
-    if DEFAULT_CONFIG_TEMPLATE.exists():
-        shutil.copy2(DEFAULT_CONFIG_TEMPLATE, config_file)
-    else:
-        config_file.write_text("# GodotMaker config — template not found\n", encoding="utf-8")
-    _set_simple_yaml_value(config_file, "agent", agent)
-    print("Created .godotmaker/config.yaml")
+
+def review_created_project_config(result: ProjectConfigResult) -> None:
+    """Give the operator a chance to edit a newly-created project config."""
+    print()
+    print("Project config created:")
+    print(f"  {result.path.resolve()}")
+    print()
+    print("Edit this file now if you want to change model settings.")
+    print("When finished, return here and press Enter to continue.")
+    try:
+        input()
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted before publish continued.")
+        sys.exit(1)
 
 
 def deploy_stage_schemas(repo_root: Path, target: Path):
@@ -1105,6 +1094,8 @@ def main():
     parser.add_argument("--force", action="store_true",
                         help="Clean existing agent skills before publishing; "
                              "skip upgrade confirmation prompts")
+    parser.add_argument("--no-config-review", action="store_true",
+                        help="Do not pause after creating .godotmaker/config.yaml")
     args = parser.parse_args()
 
     # Resolve paths
@@ -1183,7 +1174,13 @@ def main():
 
     # Interactive config generation
     config_ready = create_godotmaker_yaml(config_file)
-    create_project_config(target, agent)
+    project_config = create_project_config(target, agent)
+    if (
+        isinstance(project_config, ProjectConfigResult)
+        and project_config.created
+        and not args.no_config_review
+    ):
+        review_created_project_config(project_config)
     deploy_stage_schemas(repo_root, target)
     create_project_dirs(target)
 


### PR DESCRIPTION
## Summary

Create project config before the rest of publish continues, and pause interactive publishes so users can edit model settings before the pipeline starts.

## Motivation

New projects did not have `.godotmaker/config.yaml` until after the first publish was already underway, so users could see resolved model defaults but had no project-level file to edit before the run began.

## Changes

- [x] Add a single-purpose `tools/project_config.py` helper for creating `.godotmaker/config.yaml`.
- [x] Pause interactive `publish.py` runs after first config creation, with `--no-config-review` for automation.
- [x] Pass the skip flag through shell wrappers and cover the behavior in publish tests.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable

## Benchmark Verification

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: executed`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

No migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR

## Validation

```text
pytest tests/tools/test_publish.py -q
74 passed

python -m ruff check .
All checks passed!

python -m pytest --tb=short
764 passed

gitleaks detect --source . --config .gitleaks.toml
no leaks found
```