### PR TITLE
[codex] Dispatch build workers by game mechanic

### DIFF
--- a/agents/decomposer.md
+++ b/agents/decomposer.md
@@ -73,12 +73,12 @@ PLAN.md is **per-tag scope**. Always overwrite the root PLAN.md from `.claude/te
 Required structure (matches the template):
 
 - `**Tag:** {Current Tag}` header at the top
-- **Tag Mechanics:** for each user-observable mechanic this tag delivers, add a line `[{Tag}-M{N}] <description>`. Each is a concrete behaviour the user can verify by playing the game. Every tag's mechanics MUST combine into one playable unit.
+- **Tag Mechanics:** for each game mechanic this tag delivers, add a line `[{Tag}-M{N}] <description>`. Describe gameplay behavior. Every tag's mechanics MUST combine into one playable unit.
 - **Inherited Mechanics:**
   - Initial mode: omit this section entirely.
   - Subsequent mode: paste verbatim every `[{prior_tag}-M{N}] <description>` line from every prior tag's `Tag Mechanics` section, MINUS any mechanics this tag is intentionally removing (those go to the Main Build refactor task that prunes the related code/tests). Inherited mechanics are NOT renamed, NOT renumbered, NOT consolidated — keep their original `[v0.X.Y-MN]` ids stable forever.
 - **Risk Tasks (R1, R2, ...):** scan this tag's GDD scope (limited by ROADMAP entry) for features matching the risk taxonomy listed in the template comment (procedural generation, complex physics, custom shaders, etc.). Isolate as risk tasks.
-- **Main Build (M01, M02, ...):** convert remaining mechanics + entities + cross-tag refactor hints into the Main Build section per the template structure.
+- **Main Build (M01, M02, ...):** convert game mechanics + entities + cross-tag refactor hints into mechanic-function build tasks per the template structure.
   - Subsequent mode with `Cross-Tag Refactor Hints`: turn each hint into one or more concrete tasks. E.g. `M03 — Refactor LevelUpCardPool into TalentTree (replaces v0.2.0 cardpool per superseded design)`.
 - **Playable Unit:** describe the game content the player can experience after this tag ships. For each mechanic, state the player operation or content, expected effect, required visible content, and evidence.
 - If the current ROADMAP entry cannot form a playable unit, report `failed` and state that ROADMAP.md needs a playable-unit tag.
@@ -126,7 +126,7 @@ STRUCTURE.md is **per-tag scope** — overwrite root from `.claude/templates/STR
 - `**Tag:** {Current Tag}` header at the top.
 - Captures the structure as it exists at the END of this tag — i.e., previous tags' systems plus this tag's additions / refactors. Subsequent mode: read prior tags' archived STRUCTURE.md to know what already exists; carry forward Components / Systems that remain, add this tag's new ones, and explicitly mark refactored ones (e.g. `LevelUpCardPool — REPLACED in v0.3.0 by TalentTree`).
 
-Each task in PLAN.md must reference a specific system — not "implement movement" but "implement PlayerMovementSystem: reads PlayerInput + Velocity, writes Transform".
+Each Main Build task in PLAN.md must name its game mechanic function, player-facing outcome, affected systems/scenes/UI, integration point, and verify expectation.
 
 ### Step 5: project.godot (only if needed)
 

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -12,7 +12,7 @@ You are a worker agent implementing a bounded unit of work for a Godot game proj
 
 1. **Execute directly.** Do NOT spawn sub-agents. You are the implementer.
 2. **Stay in scope.** Implement ONLY what the brief asks. Do not refactor, add features, or "improve" files outside your deliverables.
-3. **Write unit tests.** Minimum 2 unit tests per system using gdUnit4.
+3. **Write unit tests.** Minimum 2 unit tests per changed system using gdUnit4.
 4. **Expose e2e-testable interfaces.** Public methods, signals, and `simulate_*` helpers that an external e2e test could drive. Write UNIT tests that cover those interfaces (e.g., `test_simulate_jump_emits_signal`). Do NOT write files in `e2e/` — that directory is owned by the Evaluator.
 5. **Verify compilation.** Run headless-build before reporting. A broken build is automatic failure.
 6. **Report honestly.** If something failed, say so with error output. Never claim success without verification.
@@ -27,7 +27,7 @@ You are a worker agent implementing a bounded unit of work for a Godot game proj
 2. Read ALL Input Files listed in the brief
 3. Read relevant skill references if listed (gecs API, godot-api, reviewer gotchas)
 4. Implement the deliverables
-5. Write unit tests (minimum 2 per system, gdUnit4)
+5. Write unit tests (minimum 2 per changed system, gdUnit4)
 6. Confirm your unit tests cover every e2e-testable interface (public methods, signals, simulate_* helpers)
 7. Run headless-build to confirm compilation. If you added new `class_name` declarations, run `godot --headless --import` once instead of `--quit` so the class cache reflects them.
 8. Run unit tests
@@ -53,6 +53,12 @@ The lead agent provides your brief with these fields. REQUIRED fields are always
 
 ### Input Files (Read These First)                       [REQUIRED]
 - {path}: {what it contains}
+
+### Game Mechanic Function                               [REQUIRED]
+- Mechanic ID(s): {e.g. v0.1.0-M1}
+- Player-facing outcome: {what the player can do or see}
+- Integration point: {playable path connection}
+- Affected systems/scenes/UI: {paths or names}
 
 ### Deliverables                                         [REQUIRED]
 - [ ] {file path}: {what it should contain}

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -23,6 +23,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - Tags are now planned and evaluated as minimal playable units, with runtime proof required for the playable path before evaluation can approve.
 - Evaluate completion now validates that every Playable Unit row has a recorded E2E test and non-empty runtime evidence.
+- Build workers now receive one game-mechanic function per task instead of system-first work units.
 
 ## Fixed
 

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -21,7 +21,7 @@ Agent({
 ## Task: {name}                                         [REQUIRED]
 
 ### Objective                                            [REQUIRED]
-{1-2 sentences: what to build and why it matters to the game}
+{1-2 sentences: the game mechanic function to build}
 
 ### Context                                              [REQUIRED]
 - Project: {game name and type}
@@ -30,10 +30,16 @@ Agent({
 ### Input Files (Read These First)                       [REQUIRED]
 - {path}: {what it contains}
 
+### Game Mechanic Function                               [REQUIRED]
+- Mechanic ID(s): {e.g. v0.1.0-M1}
+- Player-facing outcome: {what the player can do or see}
+- Integration point: {playable path connection}
+- Affected systems/scenes/UI: {paths or names}
+
 ### Deliverables                                         [REQUIRED]
 - [ ] {file path}: {what it should contain}
-- [ ] {unit test file path}: {test scenarios — minimum 2 unit tests}
-- [ ] e2e-testable interface: public methods / signals / simulate_* helpers exposed on this system, with unit tests covering each one
+- [ ] {unit test file path}: {test scenarios — minimum 2 unit tests per changed system}
+- [ ] e2e-testable interface: public methods / signals / simulate_* helpers for affected systems/scenes/UI, with unit tests covering each one
 - [ ] Run headless-build and confirm compilation
 - [ ] Run unit tests and include pass/fail output
 - [ ] Summary of what was implemented (<200 words)
@@ -69,14 +75,14 @@ Agent({
 ## Dispatch Rules
 
 1. **Never delegate understanding.** Your brief must include specific file paths, Component fields, expected behavior. Not "implement movement based on the design."
-2. **One objective per worker.** ONE system + its tests, or ONE scene, or ONE UI screen.
-3. **Workers write their own tests.** Minimum 2 unit tests per system.
+2. **One objective per worker.** ONE game mechanic function + its tests.
+3. **Workers write their own tests.** Minimum 2 unit tests per changed system.
 4. **Workers must not spawn sub-workers.**
-5. **Include the WHY.** Workers who understand the game context make better decisions.
+5. **Include game context.** Add the relevant Playable Unit fields to the brief.
 6. **MEMORY entry is mandatory.** Every worker reports what they learned.
 7. **Test file naming**: `test_{source_file_stem}.gd` — e.g., system file `s_movement.gd` → test file `test_s_movement.gd`. check_project.py enforces this pattern.
 8. **gdUnit4 version compatibility**: Godot 4.4 → gdUnit4 v5.x, Godot 4.5+ → gdUnit4 v6.x. Headless mode requires `--ignoreHeadlessMode`.
-9. **E2E input handling**: do NOT use `Input.is_action_just_pressed()` in ECS systems. Use `_input()` callback + flag variable pattern, expose `simulate_*()` methods so the Evaluator's e2e tests can drive the system.
+9. **E2E input handling**: do NOT use `Input.is_action_just_pressed()` in ECS systems. Use `_input()` callback + flag variable pattern, expose `simulate_*()` methods so the Evaluator's e2e tests can drive the mechanic function.
 10. **UI scene root must be Control**: Any scene containing UI (menus, HUD, panels) must use a Control node as root, not Node2D. Control anchor/layout only works when the entire ancestor chain is Control nodes.
 11. **Entity.name must be set explicitly**: When creating Entity instances programmatically, set `entity.name = "MyEntity"` before `add_entity()`. Without this, Godot assigns unpredictable auto-names (`@Node@2`), breaking E2E test node paths.
 12. **Worker self-check is mandatory**: Workers must run the self-check protocol before submitting their report. If self-check is not mentioned in the report, reject it.
@@ -127,7 +133,7 @@ workspace support for each parallel worker:
 ```
 Agent({
   subagent_type: "worker",
-  description: "Worker: implement {system_A}",
+  description: "Worker: implement {mechanic_function_A}",
   model: "{worker_model}",
   isolation: "worktree",
   prompt: "{worker brief A}"
@@ -135,7 +141,7 @@ Agent({
 
 Agent({
   subagent_type: "worker",
-  description: "Worker: implement {system_B}",
+  description: "Worker: implement {mechanic_function_B}",
   model: "{worker_model}",
   isolation: "worktree",
   prompt: "{worker brief B}"

--- a/skills/core/gm-build/SKILL.md
+++ b/skills/core/gm-build/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gm-build
 description: |
-  Implement game systems via worker dispatch. Covers risk-first then main implementation.
+  Implement game mechanic functions via worker dispatch. Covers risk-first then main implementation.
   Dispatches workers until PLAN is clean, then runs one verify+review pass; loops until convergence.
   Explicit invocation only — use /gm-build.
 disable-model-invocation: true
@@ -103,7 +103,7 @@ Do NOT delete project code as a "fix" for a tool crash.
 ### Step 1 — Dispatch Workers (until PLAN is clean)
 
 - Read `references/worker-dispatch.md` for the brief template
-- Use `subagent_type: "worker"`. Each worker implements ONE system + its unit tests.
+- Use `subagent_type: "worker"`. Each worker implements ONE game mechanic function + its tests.
 - Include the relevant Playable Unit fields in each worker brief.
 - Max 3 in parallel with disjoint file sets via `isolation: "worktree"` (send all Agent calls in one message).
 - After each worker reports DONE, mark its task in PLAN.md as `completed`.

--- a/templates/PLAN.md
+++ b/templates/PLAN.md
@@ -11,9 +11,8 @@
 
 ## Tag Mechanics
 
-<!-- Mechanics this tag MUST deliver. Each gets a stable id `<Tag>-M<N>`
-     so later tags can reference it as something they inherit. State the
-     observable behavior — not how it'll be verified. -->
+<!-- Game mechanics this tag MUST deliver. Each gets a stable id `<Tag>-M<N>`.
+     State gameplay behavior. -->
 
 - [{Tag}-M1] {what mechanic + observable behavior, e.g. "WASD player movement: holding D moves the player right"}
 - [{Tag}-M2] {...}
@@ -75,11 +74,18 @@
 
 ## Main Build
 
-{What to build — all routine systems. High-level, not implementation recipes.}
+{Game-mechanic functions and integration tasks.}
+
+### Build Tasks
+
+| Task | Game Mechanic Function | Player-Facing Outcome | Affected Systems / Scenes / UI | Integration Point | Verify |
+|------|------------------------|-----------------------|--------------------------------|-------------------|--------|
+| M01 | {mechanic function to implement} | {what the player can do or see} | {systems, scenes, UI touched} | {playable path connection} | {unit/build/manual check} |
+| M02 | {...} | {...} | {...} | {...} | {...} |
 
 ### Systems & Components
 
-<!-- List the systems and components implemented in this phase. -->
+<!-- List the systems and components touched by the build tasks. -->
 
 | System | Components (reads) | Components (writes) | Purpose |
 |--------|--------------------|---------------------|---------|
@@ -118,4 +124,5 @@
 |---|------|--------|-------|
 | R1 | {Risk task 1} | pending | |
 | R2 | {Risk task 2} | pending | |
-| M | Main build | pending | |
+| M01 | {mechanic function task} | pending | |
+| M02 | {mechanic function task} | pending | |

--- a/tests/test_playable_unit_contract_docs.py
+++ b/tests/test_playable_unit_contract_docs.py
@@ -60,9 +60,19 @@ def test_gdd_gate_checks_playable_unit():
 
 def test_build_and_reviewer_check_playable_unit_authenticity():
     build = _read("skills/core/gm-build/SKILL.md")
+    dispatch = _read("skills/core/_shared/worker-dispatch.md")
+    plan = _read("templates/PLAN.md")
     reviewer = _read("agents/reviewer.md")
+    worker = _read("agents/worker.md")
 
     assert "**Build the Playable Unit.**" in build
+    assert "Each worker implements ONE game mechanic function + its tests" in build
+    assert "ONE game mechanic function + its tests" in dispatch
+    assert "Minimum 2 unit tests per changed system" in dispatch
+    assert "Minimum 2 unit tests per changed system" in worker
+    assert "Game Mechanic Function" in dispatch
+    assert "Affected Systems / Scenes / UI" in plan
+    assert "Player-Facing Outcome" in plan
     assert "Ask the reviewer to check gameplay authenticity" in build
     assert "### Gameplay Authenticity Review" in reviewer
     assert "Running the game or test suite" in reviewer


### PR DESCRIPTION
## Summary

Align build planning and worker dispatch around game-mechanic functions while keeping unit tests scoped to changed systems.

## Motivation

Build work should produce playable mechanics that may span systems, scenes, and UI. Unit tests should still validate local system contracts, while E2E evaluation validates the playable mechanic loop.

## Changes

- [x] PLAN.md now describes Main Build tasks as game-mechanic functions with player-facing outcomes, affected systems/scenes/UI, integration points, and verification expectations.
- [x] gm-build and worker dispatch now assign one game-mechanic function per worker.
- [x] worker and dispatch test requirements now require minimum 2 unit tests per changed system.
- [x] Contract tests now lock the game-mechanic dispatch and per-changed-system unit test language.

## Testing

- [x] New or updated tests pass (`python -m pytest tests/test_playable_unit_contract_docs.py`)
- [x] Full pytest passes (`python -m pytest`)
- [x] Ruff passes (`ruff check .`)
- [x] Diff whitespace check passes (`git diff --check`)
- [x] Gitleaks passes (`gitleaks detect --source . --config .gitleaks.toml`)
- [x] Manual testing completed, if applicable

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: executed`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR