### PR TITLE
Improve agent pipeline prompts from case-study feedback

### DIFF
--- a/agent-runtimes/claude-code/references/runtime-mapping.md
+++ b/agent-runtimes/claude-code/references/runtime-mapping.md
@@ -21,7 +21,7 @@ current Claude Code behavior so other runtime mappings can stay symmetric.
 | `dispatch_verifier` | Use Claude Code `Task` with the verifier agent and the verifier report contract. |
 | `track_plan` | Use `TodoWrite` for visible session planning, separate from editing project files such as `PLAN.md` or `GAP.md`. |
 | `native_image_inspection` | Use the active Claude Code runtime image-reading path. If unavailable, gate before visual QA. |
-| `native_image_generation` | Use the selected runtime-native image-generation path. Finalize each generated source image with `tools/asset_image_finalize.py` and write the generation group JSON from `gm-asset/references/asset-gen.md`. If unavailable, gate before asset generation. |
+| `native_image_generation` | For `asset_image_model: native`, use the active Claude Code runtime image-generation path if available. For `asset_image_model: codex`, invoke Codex non-interactively through `codex exec` and require Codex to use `$imagegen` / built-in `image_gen`; then copy the generated PNG into the project before finalizing it. Finalize each generated source image with `tools/asset_image_finalize.py` and write the generation group JSON from `gm-asset/references/asset-gen.md`. If the selected path is unavailable, gate before asset generation instead of switching providers. |
 | `run_shell_command` | Use Claude Code shell execution, preserving working directory, exit status, and important output in reports. |
 | `access_godot_mcp` | Use the registered Claude MCP server for Godot when available; gate if MCP is required and not configured. |
 | `apply_permission_policy` | Use the published Claude settings, hooks, and permission policy. Do not bypass `.godotmaker/hooks` or role locks. |

--- a/agents/decomposer.md
+++ b/agents/decomposer.md
@@ -78,7 +78,7 @@ Required structure (matches the template):
   - Initial mode: omit this section entirely.
   - Subsequent mode: paste verbatim every `[{prior_tag}-M{N}] <description>` line from every prior tag's `Tag Mechanics` section, MINUS any mechanics this tag is intentionally removing (those go to the Main Build refactor task that prunes the related code/tests). Inherited mechanics are NOT renamed, NOT renumbered, NOT consolidated — keep their original `[v0.X.Y-MN]` ids stable forever.
 - **Risk Tasks (R1, R2, ...):** scan this tag's GDD scope (limited by ROADMAP entry) for features matching the risk taxonomy listed in the template comment (procedural generation, complex physics, custom shaders, etc.). Isolate as risk tasks.
-- **Main Build (M01, M02, ...):** convert game mechanics + entities + cross-tag refactor hints into mechanic-function build tasks per the template structure.
+- **Main Build (M01, M02, ...):** convert game mechanics + entities + cross-tag refactor hints into mechanic-function build tasks per the template structure. Add normal M-series tasks for player-facing state, feedback, and presentation needed to play the current tag.
   - Subsequent mode with `Cross-Tag Refactor Hints`: turn each hint into one or more concrete tasks. E.g. `M03 — Refactor LevelUpCardPool into TalentTree (replaces v0.2.0 cardpool per superseded design)`.
 - **Playable Unit:** describe the game content the player can experience after this tag ships. For each mechanic, state the player operation or content, expected effect, required visible content, and evidence.
 - If the current ROADMAP entry cannot form a playable unit, report `failed` and state that ROADMAP.md needs a playable-unit tag.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -22,6 +22,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Changed
 
 - Tags are now planned and evaluated as minimal playable units, with runtime proof required for the playable path before evaluation can approve.
+- Finalize now uses faster scoped document consistency gates while preserving tag archives, changelogs, reports, git tags, and reset behavior.
 - Evaluate completion now validates that every Playable Unit row has a recorded E2E test and non-empty runtime evidence.
 - Build workers now receive one game-mechanic function per task instead of system-first work units.
 - Visual prompt style guide now gives asset generation a shared visual language.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -27,6 +27,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Visual prompt style guide now gives asset generation a shared visual language.
 - Finalize now archives the current tag's E2E tests and screenshots under `docs/tags/<Tag>/evidence/` for later review and debugging.
 - Claude Code projects can now use `asset_image_model: codex` to select Codex image generation.
+- GDD planning now checks that each playable unit includes the player-facing state, feedback, and presentation needed to play the current tag.
 
 ## Fixed
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -29,6 +29,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- GDD planning now scopes "your call" delegation to the current question or round instead of treating it as permission to auto-decide the rest of the design.
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -26,6 +26,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Build workers now receive one game-mechanic function per task instead of system-first work units.
 - Visual prompt style guide now gives asset generation a shared visual language.
 - Finalize now archives the current tag's E2E tests and screenshots under `docs/tags/<Tag>/evidence/` for later review and debugging.
+- Claude Code projects can now use `asset_image_model: codex` to select Codex image generation.
 
 ## Fixed
 

--- a/docs/wiki/01-getting-started/installation.md
+++ b/docs/wiki/01-getting-started/installation.md
@@ -18,7 +18,7 @@ Install each one, then continue.
 
 GodotMaker can use runtime-native image and vision capabilities or API-backed providers depending on `.godotmaker/config.yaml`.
 
-API keys are required only when the project selects an API-backed provider. GodotMaker itself does not provide the external model service. If you want Codex to provide image generation in a Claude Code project, set `asset_image_model: codex`.
+API keys are required only when the project selects an API-backed provider. GodotMaker itself does not provide the external model service. If you want Codex to provide image generation in a Claude Code project, set `asset_image_model: codex`; this requires Codex CLI on PATH and does not require an image API key.
 
 | Key | Required when | What it unlocks |
 |-----|---------------|-----------------|

--- a/docs/wiki/05-tools/check-env.md
+++ b/docs/wiki/05-tools/check-env.md
@@ -51,7 +51,7 @@ If Godot is not on your PATH, this check shows a warning rather than a hard fail
 | `XAI_API_KEY` | Required when selected | xAI Grok image or video generation |
 | `TRIPO3D_API_KEY` | Optional | 3D model generation (3D games only) |
 
-API-backed selectors fail when the matching key is absent. `asset_image_model: native` passes for Codex and warns for Claude Code because the checker cannot prove a Claude-side native generation tool is available. `asset_video_model: none` does not require `XAI_API_KEY`.
+API-backed selectors fail when the matching key is absent. `asset_image_model: native` passes for Codex and warns for Claude Code because the checker cannot prove a Claude-side native generation tool is available. `asset_image_model: codex` in a Claude Code project passes when the Codex CLI is on PATH. `asset_video_model: none` does not require `XAI_API_KEY`.
 
 The checker also verifies that the selected provider package can be imported, catching installation issues that version checks alone would miss.
 

--- a/docs/wiki/06-configuration/project-config.md
+++ b/docs/wiki/06-configuration/project-config.md
@@ -59,6 +59,9 @@ For a Claude Code project that should use Codex image generation:
 asset_image_model: codex
 ```
 
+This selects Codex as the image-generation provider. It requires Codex CLI on
+PATH and does not require an image API key.
+
 ## API keys
 
 Provider-prefixed selectors require the matching API key:
@@ -73,7 +76,7 @@ Asset generation does not silently fall back when a key is missing. VQA can fall
 
 ## How to change a setting
 
-Open `.godotmaker/config.yaml` and change the value after the colon. For example, to use Codex native image generation:
+Open `.godotmaker/config.yaml` and change the value after the colon. For example, to use Codex image generation:
 
 ```yaml
 asset_image_model: codex

--- a/docs/zh/wiki/01-getting-started/installation.md
+++ b/docs/zh/wiki/01-getting-started/installation.md
@@ -18,7 +18,7 @@ GodotMaker 能把你的游戏想法变成一个可以运行的 Godot 4 项目。
 
 GodotMaker 可以根据 `.godotmaker/config.yaml` 使用 runtime 原生图片和视觉能力，或者使用 API 后端 provider。
 
-只有项目选择 API 后端 provider 时，才需要 API key。GodotMaker 本身不提供外部模型服务。如果你希望 Claude Code 项目由 Codex 负责生图，可以设置 `asset_image_model: codex`。
+只有项目选择 API 后端 provider 时，才需要 API key。GodotMaker 本身不提供外部模型服务。如果你希望 Claude Code 项目由 Codex 负责生图，可以设置 `asset_image_model: codex`；这需要 Codex CLI 位于 PATH 中，不需要图片 API key。
 
 | Key | 什么时候需要 | 用途 |
 |-----|--------------|------|

--- a/docs/zh/wiki/05-tools/check-env.md
+++ b/docs/zh/wiki/05-tools/check-env.md
@@ -51,7 +51,7 @@ All required checks passed! Ready to use GodotMaker.
 | `XAI_API_KEY` | 选中时必填 | xAI Grok 图片或视频生成 |
 | `TRIPO3D_API_KEY` | 可选 | 3D 模型生成（仅 3D 游戏需要） |
 
-API 后端选择器缺少对应 key 时会失败。`asset_image_model: native` 对 Codex 会通过；对 Claude Code 会给出警告，因为环境检查无法证明 Claude 侧原生生图工具可用。`asset_video_model: none` 不需要 `XAI_API_KEY`。
+API 后端选择器缺少对应 key 时会失败。`asset_image_model: native` 对 Codex 会通过；对 Claude Code 会给出警告，因为环境检查无法证明 Claude 侧原生生图工具可用。Claude Code 项目中的 `asset_image_model: codex` 会在 Codex CLI 位于 PATH 时通过。`asset_video_model: none` 不需要 `XAI_API_KEY`。
 
 检查工具还会验证被选中提供方的 Python 包能否正常导入，从而捕获单靠版本号检查无法发现的安装问题。
 

--- a/docs/zh/wiki/06-configuration/project-config.md
+++ b/docs/zh/wiki/06-configuration/project-config.md
@@ -55,6 +55,8 @@ decomposer_model: sonnet
 asset_image_model: codex
 ```
 
+这会选择 Codex 作为图片生成 provider。它需要 Codex CLI 位于 PATH 中，不需要图片 API key。
+
 ## API Key
 
 带提供方前缀的选择器需要对应 API key：
@@ -69,7 +71,7 @@ asset_image_model: codex
 
 ## 如何修改配置
 
-打开 `.godotmaker/config.yaml`，修改冒号后的值即可。例如使用 Codex native 图片生成：
+打开 `.godotmaker/config.yaml`，修改冒号后的值即可。例如使用 Codex 图片生成：
 
 ```yaml
 asset_image_model: codex

--- a/skills/core/game-planner/SKILL.md
+++ b/skills/core/game-planner/SKILL.md
@@ -38,7 +38,7 @@ through implications:
 1. **Skip what's already answered.** If the user said "pixel art platformer", don't ask about art style or perspective.
 2. **Use smart defaults.** For common genres, fill in obvious answers and confirm them rather than asking from scratch.
 3. **Ask about gray areas.** Focus questions on decisions that could go multiple ways.
-4. **Help, don't interrogate.** If the user says "just pick reasonable defaults", respect that — fill in sensible choices and move on.
+4. **Help, don't interrogate.** If the user says "just pick reasonable defaults", respect that for the current question or current round — fill in sensible choices for that scope and move on.
 5. **Sections are flexible.** Different game types need different GDD sections. Skip sections that don't apply (e.g., no "Characters" for Tetris, no "Level Design" for endless runners).
 
 ## Initial User Concept
@@ -46,7 +46,7 @@ through implications:
 When `/gm-gdd` provides an `Initial User Concept`, treat it as the user's freeform pre-brief. Extract concrete decisions before asking Round 1 questions:
 
 - game idea, genre, references, intended platform/input, art style, tone, mechanics, win/loss conditions, scope, constraints
-- explicit "your call" areas where you should choose defaults instead of asking
+- explicit "your call" areas where you should choose defaults for that topic or round instead of asking
 - ambiguities that still need user input
 
 Do not re-ask anything the concept already answers. Start Round 1 by briefly stating the assumptions you extracted, then ask only the remaining high-leverage gaps.
@@ -146,7 +146,7 @@ Rules for synthesis:
 - Use the template as a reference, NOT a rigid requirement
 - Skip sections that don't apply (mark as "N/A — {reason}" or omit entirely)
 - Add custom sections if the game needs them
-- Fill in smart defaults for anything the user said "your call" about
+- Fill in smart defaults for anything the user said "your call" about in that question or round
 
 ### Round 6 — Audit Pass 1 (GDD v1 → v2)
 

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -57,7 +57,10 @@ Asset is re-runnable per tag, so the gate is the current state of `ASSETS.md` pl
 Read `.godotmaker/config.yaml` before generation. Use `asset_image_model` for image assets and scene references:
 
 - `native`: use the active agent runtime's native image-generation provider/tool.
-- `codex`: use the runtime-native image-generation provider/tool for the explicit `codex` selector.
+- `codex`: use Codex image generation explicitly. If the active runtime is
+  Codex, use the active Codex runtime-native image-generation provider/tool. If
+  the active runtime is Claude Code, invoke non-interactive `codex exec` through
+  Bash and instruct Codex to use `$imagegen` / built-in `image_gen`.
 - `gemini:<model>`, `openai:<model>`, `grok:<model>`: call `tools/asset_gen.py image --model <selector> ...`.
 
 If the selected provider is unavailable, STOP and ask the user to choose another `asset_image_model`.
@@ -118,11 +121,18 @@ After confirmation, generate each asset through the selected `asset_image_model`
 Run up to 3 generation groups in parallel. Each group owns one or more target image paths. If isolated generation groups are unavailable, run the batch sequentially and state the fallback.
 
 - API-backed selectors: each group runs `python tools/asset_gen.py image --model <asset_image_model> ... -o <target.png>` for each target. The tool finalizes and validates the output.
-- `native` / `codex`: each group uses the selected runtime-native provider/tool, records each generated image path, then runs:
+- `native` / `codex`: each group uses the selected runtime-native provider/tool,
+  records each generated image path, then runs:
   ```bash
   python tools/asset_image_finalize.py --source <generated_image_path> \
     --out <target.png> --label <asset_id> [--resize WIDTHxHEIGHT]
   ```
+- For `codex` under Claude Code, call Codex through Bash. Put the prompt in a
+  temp file. The Codex prompt must explicitly require `$imagegen` / built-in
+  `image_gen`, copy the selected PNG from `$CODEX_HOME/generated_images/...` to
+  a requested source path under `.godotmaker/asset-generation/codex/`, and
+  report failure if the image-generation tool is unavailable. After `codex exec`
+  returns, verify that source path exists before finalizing it.
 - Each group writes one JSON report under `.godotmaker/asset-generation/`: `{"ok": true, "provider": "<asset_image_model>", "assets": [<finalize result>, ...]}`.
 - Do not select images by scanning a global "latest generated image" list. Use the generated paths reported by the group.
 

--- a/skills/core/gm-asset/references/asset-gen.md
+++ b/skills/core/gm-asset/references/asset-gen.md
@@ -19,6 +19,41 @@ Project default is controlled by `.godotmaker/config.yaml`'s
 `asset_image_model` field. `native` and `codex` are runtime providers and are
 not valid `tools/asset_gen.py` backends.
 
+### Codex handoff from Claude Code
+
+When `asset_image_model: codex` is selected in a Claude Code project, use
+non-interactive Codex as the image-generation provider. This is not an
+`asset_gen.py` backend.
+
+Write one prompt file per asset or generation group and run `codex exec` from
+the project root:
+
+```bash
+mkdir -p .godotmaker/asset-generation/codex
+cat > .godotmaker/asset-generation/codex_<asset_id>.prompt.txt <<'EOF'
+Use the $imagegen skill and built-in image_gen tool to generate this project
+asset.
+
+Generate a PNG for:
+<prompt>
+
+After generation, copy the selected generated PNG from
+$CODEX_HOME/generated_images/... to:
+.godotmaker/asset-generation/codex/<asset_id>_source.png
+
+If built-in image generation is unavailable, do not create an image file.
+Report the failure clearly.
+EOF
+
+codex exec --json --dangerously-bypass-approvals-and-sandbox \
+  -C "$PWD" --output-last-message .godotmaker/asset-generation/codex_<asset_id>.summary.txt \
+  - < .godotmaker/asset-generation/codex_<asset_id>.prompt.txt
+```
+
+Then check that `.godotmaker/asset-generation/codex/<asset_id>_source.png`
+exists and pass that file to `tools/asset_image_finalize.py`. Do not silently
+switch providers when the configured provider is `codex`.
+
 ### Gemini sizes and costs
 
 | Size | Cost |

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -65,7 +65,7 @@ Craft each prompt for its specific goal.
 
 #### Backend selection
 
-Read `.godotmaker/config.yaml` and use `asset_image_model` as the default image path. `native` uses the active runtime-native image-generation provider/tool. `codex` uses the runtime-native image-generation provider/tool for the explicit `codex` selector. API-backed selectors use `tools/asset_gen.py image --model <selector>`. Every generated image must pass through `tools/asset_image_finalize.py` before ASSETS.md is updated. Runtime-native generation groups write the JSON report described in `asset-gen.md`.
+Read `.godotmaker/config.yaml` and use `asset_image_model` as the default image path. `native` uses the active runtime-native image-generation provider/tool. `codex` uses Codex image generation explicitly; in Claude Code, follow the `codex exec` handoff in `asset-gen.md` instead of calling `tools/asset_gen.py`. API-backed selectors use `tools/asset_gen.py image --model <selector>`. Every generated image must pass through `tools/asset_image_finalize.py` before ASSETS.md is updated. Runtime-native generation groups write the JSON report described in `asset-gen.md`.
 
 Use Gemini or another precise provider where prompt precision matters: reference images, character design, 3D model references, animated sprite refs/poses, and backgrounds with exact layout. Use Grok (`grok:<model>`) for textures, simple objects, item kits, and simple scenic backgrounds only when `XAI_API_KEY` is configured. Use OpenAI (`openai:<model>`) when the project is configured for OpenAI Images API. Missing API keys are hard failures; do not silently switch providers.
 

--- a/skills/core/gm-finalize/SKILL.md
+++ b/skills/core/gm-finalize/SKILL.md
@@ -60,19 +60,15 @@ If any check fails, STOP and tell the user which one — finalize must not seal 
 
 ### 3. Document Consistency Check (current tag scope)
 
-For each per-tag document, verify it matches what was actually built **in this tag**. Do NOT update prior tags' archives.
+Run these fast gates before archiving. For passing gates, continue silently. For failures, update the root doc to match reality and remember the path for `doc_updates`.
 
-- **GDD.md**: Cross-tag "north star". If the user changed design intent during this tag's gm-gdd round, GDD should already reflect it. Check that no claims about future tags have leaked in.
-- **PLAN.md**: All tasks `verified`. Tag Mechanics + Inherited Mechanics sections present and complete. Task file references and system/component names match the final code, not the original worker plan.
-- **STRUCTURE.md**: Components and Systems listed match what actually exists in code. Run a quick scan: list `extends Component` / `extends System` files and reconcile names, responsibilities, and schedules against the final files under `src/`.
-- **STYLE.md**: Visual prompt style guide exists.
-- **ASSETS.md**: Verify rows match `assets/` directory contents.
-- **SCENES.md**: Scene descriptions match actual scenes added in this tag.
-- **MEMORY.md**: Cross-tag accumulator. Append-only since the previous tag — don't rewrite history; if a previous discovery was later proven wrong, mark it `(superseded by …)` instead of deleting.
+- **PLAN.md**: All tasks are `verified`; Tag Mechanics and Inherited Mechanics sections exist.
+- **STRUCTURE.md**: `extends Component` and `extends System` filenames under `src/` appear in the component/system listings.
+- **ASSETS.md**: Asset paths for current-tag generated rows exist under `assets/` or `references/`.
+- **SCENES.md**: Scene paths referenced for this tag exist on disk.
+- **MEMORY.md**: If a current-tag discovery is now superseded by the final implementation, mark it `(superseded by …)`.
 
-Before archiving, search the root docs for stale implementation names that no longer exist in `src/` (for example renamed Systems or Components). If a name appears only in docs and not in code, either update it to the actual name or remove the stale claim. This is a documentation fix only; do not rename code in finalize.
-
-For any inconsistency: update the doc to match reality. Do NOT change code here — finalize is a paper-trail step.
+Apply documentation fixes only. Finalize does not change code.
 
 ### 4. Archive into `docs/tags/<Tag>/`
 
@@ -120,7 +116,7 @@ The bundle JSON on stdout has:
 - `test_count.unit` (count of `test/**/*.gd`) + `test_count.e2e` (count of `e2e/**/test_*.py`)
 - `evidence.archive_path`, `evidence.e2e_files`, `evidence.screenshots`, `evidence.warnings`
 
-Combine that with PLAN.md task table and `evaluation.json` `minor_issues`, and write `docs/tags/<Tag>/CHANGELOG.md` in this format:
+Combine that with PLAN.md task table and `evaluation.json` `minor_issues`, and write `docs/tags/<Tag>/CHANGELOG.md` directly. Keep the entry concise. Use this format:
 
 ```markdown
 # Changelog — <Tag>
@@ -232,24 +228,18 @@ Captures the truncated stage.jsonl plus the new finalize marker — runtime meta
 
 Delete `.godotmaker/current_role` AFTER step 10 has completed — that write needs the role lock in place so `check_file_permissions.py` keeps the finalize permission scope active.
 
-Then print:
+Then print a compact result:
 
 ```
 ## Tag <Tag> Sealed
 
-**{game_name}** — tag <Tag> archived and git-tagged.
-
 - Archive: docs/tags/<Tag>/
 - Git tag: <Tag> (local; not pushed)
-- Tag mechanics delivered: {Tag Mechanics list}
+- Tag mechanics: {Tag Mechanics IDs or "none"}
 - Doc updates this round: {list or "none needed"}
-- Known limitations: {list or "none"}
-
-Remaining tags in ROADMAP.md: {list of unshipped tags}
+- Known limitations: {list only if non-empty; otherwise "none"}
 
 To start the next tag: /gm-gdd
-To package this tag as a release: use the release skill (separate)
-To stop here: just don't run anything else — the archive is permanent.
 ```
 
 ## What this skill explicitly does NOT do

--- a/skills/core/gm-gdd/SKILL.md
+++ b/skills/core/gm-gdd/SKILL.md
@@ -52,6 +52,7 @@ Before invoking `game-planner` in initial mode, collect the user's rough idea in
 - If `$ARGUMENTS` is empty, ask the user for one open-ended paragraph: what they want to make, any references, mechanics, visual style, constraints, and anything they already decided. Make clear that rough notes are enough.
 - Pass this freeform intake verbatim into the `game-planner` brief as "Initial User Concept".
 - `game-planner` must skip questions that the freeform intake already answers and use those details to choose smarter defaults.
+- Any "your call" / "you decide" language in the intake is scoped to the named topic or the current intake round unless the user explicitly grants broader delegation.
 
 This intake is NOT a confirmation gate. Keep `AskUserQuestion` for explicit GDD and ROADMAP confirmations only.
 

--- a/skills/core/gm-gdd/SKILL.md
+++ b/skills/core/gm-gdd/SKILL.md
@@ -95,6 +95,7 @@ This sub-stage exists in BOTH modes but does different work.
 2. Derive a tag list following the SemVer convention from `templates/ROADMAP.md`:
    - First tag is always `v0.1.0` and MUST deliver the first playable unit.
    - Every tag is a minimal playable unit: the player can experience a complete slice of gameplay with a completion, fail, or exit state.
+   - Every tag includes the player-facing information needed to understand and play that slice.
    - Subsequent tags add one playable unit at a time.
 3. Write a draft `ROADMAP.md` populated with this tag list.
 4. **MANDATORY gate:** Use `AskUserQuestion` to ask the user:
@@ -139,6 +140,7 @@ directly if needed. PLAN.md must be stable before Phase B starts:
 - [ ] Inherited Mechanics section is populated for subsequent mode, or omitted for v0.1.0
 - [ ] Playable Unit section is populated and references existing mechanic ids
 - [ ] Playable Unit describes player experience, unit outcome, scenes involved, and per-mechanic player operation / effect / visible evidence
+- [ ] PLAN covers the player-facing state, feedback, and presentation needed to play the current tag normally
 - [ ] Risk/Main tasks have stable task IDs and all Task Status rows start as `pending`
 - [ ] Tasks list affected systems/scenes/assets clearly enough for downstream artifacts
 

--- a/templates/PLAN.md
+++ b/templates/PLAN.md
@@ -74,13 +74,14 @@
 
 ## Main Build
 
-{Game-mechanic functions and integration tasks.}
+{Game-mechanic functions and integration tasks. Add normal M-series tasks for
+the player-facing state, feedback, and presentation needed to play this tag.}
 
 ### Build Tasks
 
 | Task | Game Mechanic Function | Player-Facing Outcome | Affected Systems / Scenes / UI | Integration Point | Verify |
 |------|------------------------|-----------------------|--------------------------------|-------------------|--------|
-| M01 | {mechanic function to implement} | {what the player can do or see} | {systems, scenes, UI touched} | {playable path connection} | {unit/build/manual check} |
+| M01 | {mechanic function to implement} | {what the player can do or understand} | {systems, scenes, UI touched} | {playable path connection} | {unit/build/manual check} |
 | M02 | {...} | {...} | {...} | {...} | {...} |
 
 ### Systems & Components

--- a/templates/ROADMAP.md
+++ b/templates/ROADMAP.md
@@ -14,7 +14,8 @@
 - **MINOR** (v0.X.0): new full system or playable module added on top
 - **PATCH** (v0.X.Y): in-tag fixes / small tweaks (rare; usually used after a tag is shipped and a follow-up correction is needed)
 
-The first tag is always **v0.1.0**. Every tag is a minimal playable unit.
+The first tag is always **v0.1.0**. Every tag is a minimal playable unit:
+describe both the player experience and the features that implement it.
 
 ## Mid-flow edits
 
@@ -30,21 +31,35 @@ next tag.
 
 <!-- The first tag MUST deliver a playable closed loop:
      - main scene boots without crashing (`godot --headless --quit`)
+     - the tag's scope is grouped by what the player does, understands, and achieves
      - the tag's mechanics produce player-experienced game content
      - the unit's completion, fail, or exit state is reachable through play -->
 
+**Expected player experience**
+- {experience 1, e.g. start a run, move around the arena, and avoid the first enemy}
+- {experience 2, e.g. take damage, understand the run state, and reach death or restart}
+
+**Features / mechanics**
 - {feature 1, e.g. WASD player movement}
 - {feature 2, e.g. one enemy type with melee attack}
-- {feature 3, e.g. health + death + restart}
+- {feature 3, e.g. health display, damage feedback, death, and restart}
 
 ## v0.2.0 — {next theme, e.g. "Combat depth"}
 
+**Expected player experience**
+- {experience 1}
+
+**Features / mechanics**
 - {feature 1}
 - {feature 2}
 - {feature 3}
 
 ## v0.3.0 — {next theme}
 
+**Expected player experience**
+- {experience 1}
+
+**Features / mechanics**
 - {feature 1}
 - {feature 2}
 

--- a/tests/test_playable_unit_contract_docs.py
+++ b/tests/test_playable_unit_contract_docs.py
@@ -13,6 +13,8 @@ def test_roadmap_template_defines_playable_unit_tag_contract():
     roadmap = _read("templates/ROADMAP.md")
 
     assert "Every tag is a minimal playable unit" in roadmap
+    assert "Expected player experience" in roadmap
+    assert "Features / mechanics" in roadmap
     assert "player-experienced game content" in roadmap
     assert "reachable through play" in roadmap
 
@@ -37,6 +39,7 @@ def test_plan_template_defines_playable_unit_contract():
         "Player operation / content",
         "Expected effect",
         "Required visible content",
+        "player-facing state, feedback, and presentation",
         "Review focus",
     ]:
         assert token in plan
@@ -46,7 +49,7 @@ def test_decomposer_must_generate_playable_unit():
     decomposer = _read("agents/decomposer.md")
 
     assert "Every tag's mechanics MUST combine into one playable unit" in decomposer
-    assert "player operation or content, expected effect, required visible content" in decomposer
+    assert "player-facing state, feedback, and presentation" in decomposer
     assert "ROADMAP.md needs a playable-unit tag" in decomposer
 
 
@@ -55,6 +58,8 @@ def test_gdd_gate_checks_playable_unit():
 
     assert "Every tag is a minimal playable unit" in gdd
     assert "Playable Unit section is populated" in gdd
+    assert "completion, fail, or exit state" in gdd
+    assert "player-facing state, feedback, and presentation" in gdd
     assert "Playable Unit scene check" in gdd
 
 

--- a/tests/tools/test_check_env.py
+++ b/tests/tools/test_check_env.py
@@ -350,7 +350,7 @@ class TestCheckFunctions:
 
     @patch("check_env.shutil.which", return_value="/usr/bin/codex")
     @patch.dict(os.environ, {}, clear=True)
-    def test_claude_codex_image_model_accepts_codex_cli(self, mock_which):
+    def test_claude_codex_image_model_accepts_codex_exec_handoff(self, mock_which):
         from check_env import check_api_keys
 
         r = EnvCheck()
@@ -364,7 +364,25 @@ class TestCheckFunctions:
         )
 
         assert not r.failed
-        assert any("Codex CLI found" in p for p in r.passed)
+        assert any("Codex CLI found for Codex image generation" in p for p in r.passed)
+
+    @patch("check_env.shutil.which", return_value="/usr/bin/codex")
+    @patch.dict(os.environ, {}, clear=True)
+    def test_claude_codex_vqa_model_accepts_codex_exec_handoff(self, mock_which):
+        from check_env import check_api_keys
+
+        r = EnvCheck()
+        check_api_keys(
+            r,
+            {
+                "asset_image_model": "native",
+                "vqa_model": "codex",
+            },
+            agent="claude-code",
+        )
+
+        assert not r.failed
+        assert any("Codex CLI found for Codex image inspection" in p for p in r.passed)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_none_video_model_does_not_require_xai_key(self):

--- a/tools/check_env.py
+++ b/tools/check_env.py
@@ -328,7 +328,10 @@ def check_runtime_model_provider(
             r.ok(f"Codex {capability.replace('_', ' ')} uses the active Codex runtime")
             return
         if shutil.which("codex") or shutil.which("codex.cmd") or shutil.which("codex.exe"):
-            r.ok("Codex image provider selected and Codex CLI found")
+            if capability == "image_generation":
+                r.ok("Codex CLI found for Codex image generation")
+            else:
+                r.ok("Codex CLI found for Codex image inspection")
         else:
             r.fail("Codex image provider selected but Codex CLI was not found")
 


### PR DESCRIPTION
﻿## Summary

Improve GodotMaker agent pipeline prompts for Codex/Claude asset generation, playable tag planning, scoped GDD delegation, and faster finalize document checks.

## Motivation

Recent case-study runs exposed four workflow issues: Claude Code needed a clear Codex image handoff path, GDD planning over-applied "your call" delegation, v0.1.0 planning sliced work too mechanically without enough player-facing feedback, and `/gm-finalize` spent too long on open-ended document review.

## Changes

- [x] Add Codex image-generation handoff guidance for Claude Code asset generation.
- [x] Scope "your call" / "你定" to the current question or round during GDD.
- [x] Require GDD planning to treat each tag as a player-facing playable unit with visible feedback and payoff.
- [x] Replace finalize's broad document consistency pass with faster scoped gates.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
  - `python -m pytest tests/ -x -q` -> `792 passed`
- [x] Gitleaks passes or no secret-bearing files were touched
  - `gitleaks detect --source . --config .gitleaks.toml` -> no leaks found
- [x] Manual testing completed, if applicable
  - Prompt-only changes; reviewed staged diffs and ran repository checks.

## Benchmark Verification

Required only for performance-sensitive changes.

- [ ] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
No automated benchmark attached. The finalize change reduces open-ended document review scope in the skill prompt; runtime impact should be validated in the next full pipeline case study.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
