### PR TITLE
Preserve aspect ratio when resizing image assets; archive pre-resize originals

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -18,6 +18,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Added
 
 - (WIP) Diagnostic log at `.godotmaker/log_agent_tool_debug.log` that records every phase of `log_agent_tool.py` so the next failure mode is localizable from artifacts.
+- A resized image's untouched original is archived to `assets/origin/` for comparison and debugging.
 
 ## Changed
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -26,5 +26,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
+- Resized image assets are scaled proportionally and transparency-padded instead of stretched, so non-square art is no longer squashed.
 
 ## Removed

--- a/tests/tools/test_asset_image_finalize.py
+++ b/tests/tools/test_asset_image_finalize.py
@@ -86,3 +86,39 @@ def test_cli_outputs_json(tmp_path):
     assert data["width"] == 2
     assert data["height"] == 2
     assert output.exists()
+
+
+def test_finalize_pads_instead_of_stretching_on_aspect_mismatch(tmp_path):
+    # A square source forced into a wide target must NOT be stretched: it is
+    # scaled proportionally and centered on a transparent canvas.
+    source = tmp_path / "generated" / "hero.png"
+    output = tmp_path / "assets" / "img" / "hero.png"
+    make_png(source, size=(10, 10), color=(255, 0, 0, 255))
+
+    result = finalize_image_asset(source, output, resize="10x4")
+
+    assert (result["width"], result["height"]) == (10, 4)
+    with Image.open(output) as image:
+        assert image.size == (10, 4)
+        rgba = image.convert("RGBA")
+        # Centered art stays opaque...
+        assert rgba.getpixel((5, 2))[3] == 255
+        # ...while the horizontal padding is fully transparent.
+        assert rgba.getpixel((0, 2))[3] == 0
+        assert rgba.getpixel((9, 2))[3] == 0
+
+
+def test_finalize_keeps_matching_aspect_without_padding(tmp_path):
+    source = tmp_path / "generated" / "bar.png"
+    output = tmp_path / "assets" / "img" / "bar.png"
+    make_png(source, size=(8, 4), color=(0, 128, 255, 255))
+
+    result = finalize_image_asset(source, output, resize="4x2")
+
+    assert (result["width"], result["height"]) == (4, 2)
+    with Image.open(output) as image:
+        rgba = image.convert("RGBA")
+        # Same aspect ratio -> no transparent padding anywhere.
+        assert all(
+            rgba.getpixel((x, y))[3] == 255 for x in range(4) for y in range(2)
+        )

--- a/tests/tools/test_asset_image_finalize.py
+++ b/tests/tools/test_asset_image_finalize.py
@@ -122,3 +122,68 @@ def test_finalize_keeps_matching_aspect_without_padding(tmp_path):
         assert all(
             rgba.getpixel((x, y))[3] == 255 for x in range(4) for y in range(2)
         )
+
+
+def test_finalize_archives_original_by_default(tmp_path):
+    source = tmp_path / "generated" / "coin.png"
+    output = tmp_path / "assets" / "img" / "coin.png"
+    make_png(source, size=(16, 8))
+
+    result = finalize_image_asset(source, output, resize="4x4")
+
+    origin = tmp_path / "assets" / "origin" / "coin.png"
+    assert result["origin"] == str(origin)
+    assert origin.exists()
+    with Image.open(origin) as image:
+        # Original resolution preserved for comparison/debugging.
+        assert image.size == (16, 8)
+
+
+def test_finalize_skips_origin_when_disabled(tmp_path):
+    source = tmp_path / "generated" / "coin.png"
+    output = tmp_path / "assets" / "img" / "coin.png"
+    make_png(source, size=(16, 8))
+
+    result = finalize_image_asset(source, output, resize="4x4", archive_original=False)
+
+    assert "origin" not in result
+    assert not (tmp_path / "assets" / "origin" / "coin.png").exists()
+
+
+def test_finalize_skips_origin_without_resize(tmp_path):
+    source = tmp_path / "generated" / "coin.png"
+    output = tmp_path / "assets" / "img" / "coin.png"
+    make_png(source, size=(16, 8))
+
+    result = finalize_image_asset(source, output)
+
+    assert "origin" not in result
+    assert not (tmp_path / "assets" / "origin" / "coin.png").exists()
+
+
+def test_cli_no_origin_flag(tmp_path):
+    source = tmp_path / "generated" / "coin.png"
+    output = tmp_path / "assets" / "img" / "coin.png"
+    make_png(source)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_image_finalize.py"),
+            "--source",
+            str(source),
+            "--out",
+            str(output),
+            "--resize",
+            "2x2",
+            "--no-origin",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert "origin" not in data
+    assert not (tmp_path / "assets" / "origin" / "coin.png").exists()

--- a/tools/asset_gen.py
+++ b/tools/asset_gen.py
@@ -140,6 +140,7 @@ def finish_image_output(args, output: Path, cost: int, service: str):
             "original_height": final["original_height"],
             **({"asset_id": final["asset_id"]} if "asset_id" in final else {}),
             **({"resize": final["resize"]} if "resize" in final else {}),
+            **({"origin": final["origin"]} if "origin" in final else {}),
         },
     )
 

--- a/tools/asset_image_finalize.py
+++ b/tools/asset_image_finalize.py
@@ -91,6 +91,20 @@ def _fit_with_padding(image, size: tuple[int, int]):
     return canvas
 
 
+def _origin_path_for(output: Path) -> Path:
+    """Archive location for the untouched original of a finalized asset.
+
+    Mirrors the asset under an ``origin/`` sibling of the project
+    ``assets/`` root (e.g. ``assets/img/foo.png`` -> ``assets/origin/foo.png``).
+    Falls back to an ``origin/`` directory beside the output when there is no
+    ``assets`` ancestor (e.g. scene references under ``references/``).
+    """
+    for ancestor in output.parents:
+        if ancestor.name == "assets":
+            return ancestor / "origin" / (output.stem + ".png")
+    return output.parent / "origin" / (output.stem + ".png")
+
+
 def finalize_image_asset(
     source: Path,
     output: Path,
@@ -98,6 +112,7 @@ def finalize_image_asset(
     resize: str | None = None,
     image_format: str = "png",
     label: str | None = None,
+    archive_original: bool = True,
 ) -> dict[str, object]:
     """Copy or transform a generated source image into its final path."""
     source = Path(source)
@@ -109,6 +124,7 @@ def finalize_image_asset(
 
     requested_size = _parse_size(resize)
     image = _load_image(source)
+    origin_saved: str | None = None
     try:
         original_width, original_height = image.size
         source_format = (image.format or source.suffix.lstrip(".")).lower()
@@ -117,6 +133,18 @@ def finalize_image_asset(
             or output.suffix.lower() != source.suffix.lower()
             or source_format != image_format.lower()
         )
+        # Archive the untouched original before resizing, so the pre-resize
+        # art sits next to the finalized asset for comparison/debugging.
+        # Only meaningful when we resize (otherwise the final IS the original).
+        if archive_original and requested_size is not None:
+            origin_path = _origin_path_for(output)
+            origin_image = image
+            if origin_image.mode not in {"RGB", "RGBA"}:
+                origin_image = origin_image.convert(
+                    "RGBA" if "A" in image.getbands() else "RGB"
+                )
+            _atomic_save(origin_image, origin_path, "png")
+            origin_saved = str(origin_path)
         if requested_size is not None:
             image = _fit_with_padding(image, requested_size)
         if image_format.lower() == "png" and image.mode not in {"RGB", "RGBA"}:
@@ -153,6 +181,8 @@ def finalize_image_asset(
         "original_width": original_width,
         "original_height": original_height,
     }
+    if origin_saved is not None:
+        result["origin"] = origin_saved
     if requested_size is not None:
         result["resize"] = f"{requested_size[0]}x{requested_size[1]}"
     if label:
@@ -168,6 +198,12 @@ def _main() -> int:
     parser.add_argument("--resize", default=None, help="Optional WIDTHxHEIGHT resize")
     parser.add_argument("--format", default="png", choices=["png"], help="Output format")
     parser.add_argument("--label", default=None, help="Optional asset label for JSON output")
+    parser.add_argument(
+        "--no-origin",
+        dest="archive_original",
+        action="store_false",
+        help="Do not archive the untouched original under assets/origin/",
+    )
     args = parser.parse_args()
 
     try:
@@ -177,6 +213,7 @@ def _main() -> int:
             resize=args.resize,
             image_format=args.format,
             label=args.label,
+            archive_original=args.archive_original,
         )
     except ImageFinalizeError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}))

--- a/tools/asset_image_finalize.py
+++ b/tools/asset_image_finalize.py
@@ -66,6 +66,31 @@ def _atomic_save(image, output: Path, image_format: str) -> None:
             tmp_path.unlink()
 
 
+def _fit_with_padding(image, size: tuple[int, int]):
+    """Resize preserving aspect ratio, padding to exactly ``size``.
+
+    The image is scaled to fit within ``size`` (never cropped, never
+    stretched) and centered on a fully transparent canvas of exactly
+    ``size``. When the source aspect ratio already matches the target this
+    degrades to a plain proportional resize with no padding. Avoids the
+    aspect-ratio distortion a direct ``Image.resize(size)`` would cause when
+    the generated image's aspect ratio differs from the requested one.
+    """
+    from PIL import Image
+
+    target_w, target_h = size
+    src_w, src_h = image.size
+    scale = min(target_w / src_w, target_h / src_h)
+    fit_w = max(1, round(src_w * scale))
+    fit_h = max(1, round(src_h * scale))
+    fitted = image.resize((fit_w, fit_h), Image.Resampling.LANCZOS)
+    if fitted.mode != "RGBA":
+        fitted = fitted.convert("RGBA")
+    canvas = Image.new("RGBA", (target_w, target_h), (0, 0, 0, 0))
+    canvas.paste(fitted, ((target_w - fit_w) // 2, (target_h - fit_h) // 2))
+    return canvas
+
+
 def finalize_image_asset(
     source: Path,
     output: Path,
@@ -93,10 +118,7 @@ def finalize_image_asset(
             or source_format != image_format.lower()
         )
         if requested_size is not None:
-            from PIL import Image
-
-            resample = Image.Resampling.LANCZOS
-            image = image.resize(requested_size, resample)
+            image = _fit_with_padding(image, requested_size)
         if image_format.lower() == "png" and image.mode not in {"RGB", "RGBA"}:
             image = image.convert("RGBA" if "A" in image.getbands() else "RGB")
 


### PR DESCRIPTION
## Summary

Fix aspect-ratio distortion when finalizing generated image assets, and archive the untouched pre-resize original for debugging.

## Motivation

`asset_image_finalize` stretched generated images to the exact `--resize` target. Because the image-generation backends only emit a fixed set of output resolutions (e.g. OpenAI's 1:1 / 3:2 / 2:3), any asset whose target aspect ratio differed from the generated one got squashed — a square 1:1 generation forced into a wide sprite cell came out visibly distorted in-game. This makes the generated art look wrong even when the generation itself was fine.

It also adds a debugging aid: keep the original generated image beside the finalized asset so the source art can be compared against the processed result.

No linked issue.

## Changes

- [x] `finalize_image_asset` now scales proportionally and centers the art on a fully transparent canvas of the requested size instead of stretching (new `_fit_with_padding`). Output is still exactly the requested `WIDTHxHEIGHT`; a matching aspect ratio degrades to a plain proportional resize with no padding.
- [x] When an asset is resized, the untouched pre-resize original is archived to `assets/origin/<name>.png` (default on, `--no-origin` to skip). The path is surfaced in the JSON result and in `asset_gen`'s report.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — 2 new tests for the padding behavior, 4 for origin archiving; full `python -m pytest tests/` = 798 passed; `ruff` clean.
- [x] Gitleaks passes or no secret-bearing files were touched — only image-processing code, tests, and changelog.
- [x] Manual testing completed, if applicable — finalized a 1024x1024 source into a wide 256x96 target via the CLI: the circle's bounding box stayed 1:1 (round) vs the old stretch which produced a 2.58:1 ellipse; the original archived to `assets/origin/` at 1024x1024.

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed

> Note: resize output does change going forward (padded instead of stretched), and a new `assets/origin/` directory is produced at generation time. Existing on-disk game projects are not modified, so no migration script is required.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — N/A (Python tooling, no ECS)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated