### PR TITLE
fix: clarify visual QA and commit uid metadata

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -23,11 +23,13 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Changed
 
 - Clarified source-available licensing language and excluded internal planning notes from the documentation site.
+- Scaffold generates and commits Godot `.uid` import metadata in its initial commit so the project tree starts clean for `/gm-build`.
 
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
 - Resized image assets are scaled proportionally and transparency-padded instead of stretched, so non-square art is no longer squashed.
 - Clarified Visual QA handling of normal gameplay captures versus `--debug-collisions` collision-check captures.
+- `/gm-build` no longer falls back to slow sequential workers when the tree has uncommitted import artifacts.
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -28,5 +28,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
 - Resized image assets are scaled proportionally and transparency-padded instead of stretched, so non-square art is no longer squashed.
+- Clarified Visual QA handling of normal gameplay captures versus `--debug-collisions` collision-check captures.
 
 ## Removed

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -116,14 +116,16 @@ Workers with **no file ownership overlap** can run in parallel using git worktre
 
 Don't dispatch task-by-task — design batches. Before each round, inspect every pending task's **Affected files** list in `PLAN.md` and group tasks into the largest possible batch (up to 3) whose file sets are pairwise disjoint. Sequential dependencies (B reads a class B-task creates) belong in different batches; file-disjoint independent work belongs together.
 
-A typical `/gm-build` cycle runs as 3–6 batches: each batch is "dispatch parallel → wait → merge → build-check", repeated until `PLAN.md` is fully `verified`. Fix tasks discovered by the Reviewer use the same batching rule.
+A typical `/gm-build` cycle runs as 3–6 batches: each batch is "dispatch parallel → wait for all → merge → build-check → commit", repeated until `PLAN.md` is fully `verified`. Fix tasks discovered by the Reviewer use the same batching rule.
 
-### Before dispatch — snapshot the working tree
+### Precondition for parallel dispatch
 
-Before sending any isolated worker call, detect whether the current checkout is
-a normal branch, an existing worktree, detached HEAD, or a host-managed sandbox.
-If a clean snapshot is required but cannot be created safely, do not dispatch
-parallel workers; use sequential worker briefs or fail before the stage starts.
+Use `isolation: "worktree"` whenever the runtime supports it; fall back to
+sequential worker briefs only when it does not.
+
+Do NOT fall back to sequential because the tree has untracked or ignored files
+(`.uid`, `.godot/`). Keep the main tree clean by committing between batches (see
+Merge procedure).
 
 ### How to dispatch
 
@@ -174,6 +176,12 @@ If a worker's branch is missing or `git diff main..{branch}` is empty, treat the
    ```
 
 4. **If merge conflict occurs**: resolve manually, prioritizing the more recent/complete implementation. Then re-run both workers' unit tests to confirm.
+
+5. **Commit the merged batch** before dispatching the next one:
+   ```bash
+   git add -A
+   git commit -m "build: merge batch (<task ids>) + import metadata"
+   ```
 
 ### Rules
 

--- a/skills/core/gm-scaffold/SKILL.md
+++ b/skills/core/gm-scaffold/SKILL.md
@@ -42,7 +42,7 @@ Scaffold is **lifetime-once** — its event gets cleared after each tag's finali
 1. **Do NOT design the game here.** Game design is `/gm-gdd`'s job. Scaffold creates an empty, generic project. Non-gameplay project settings (resolution, rendering method, viewport defaults) are config choices scaffold may make — those are not game design.
 2. **Do NOT create Component/System stubs.** STRUCTURE.md doesn't exist yet, so there's nothing to derive from. Workers in `/gm-build` create code files on demand.
 3. **All addons MUST come from `.claude/config/addon_versions.json`** — do not guess versions.
-4. **Initial git commit is mandatory.** Worker worktree isolation in `/gm-build` requires `HEAD` to resolve.
+4. **Initial git commit is mandatory and must include import metadata.** Run `<godot_path> --headless --import` before the commit to generate and stage the `.uid` files. Worker worktree isolation in `/gm-build` requires `HEAD` to resolve.
 
 ## Scaffold Steps
 
@@ -146,7 +146,8 @@ def game(_game_process):
 ### 3. Initial commit
 
 ```bash
-git init   # if not already a git repo
+git init                              # if not already a git repo
+<godot_path> --headless --import      # generate .godot/ cache + *.uid sidecars
 git add -A
 git commit -m "Scaffold: initial Godot project with addons"
 ```

--- a/skills/core/visual-qa/SKILL.md
+++ b/skills/core/visual-qa/SKILL.md
@@ -162,8 +162,10 @@ state truth, or layout stability:
 
 - Untextured primitives contrasting with surrounding detail
 - Default Godot materials (grey StandardMaterial3D, magenta missing shader)
-- Debug artifacts (nav mesh, axis gizmos; collision shapes only in normal
-  gameplay captures, not `--debug-collisions` captures)
+- Debug artifacts in normal gameplay captures (nav mesh, axis gizmos, visible
+  collision shapes)
+- Collision overlay mismatch in `--debug-collisions` captures (shape offset,
+  wrong size, or wrong shape type relative to the sprite)
 
 ### Motion & Animation (dynamic mode only)
 

--- a/skills/core/visual-qa/scripts/dynamic_prompt.md
+++ b/skills/core/visual-qa/scripts/dynamic_prompt.md
@@ -59,8 +59,8 @@ The assets are usually fine — what breaks is placement, scaling, and compositi
 ### Placeholder Remnants
 - Primitive geometry (untextured cubes, spheres) contrasting with surrounding detail
 - Default Godot materials (grey StandardMaterial3D, magenta missing shader)
-- Debug artifacts (nav mesh, axis gizmos, path lines) — note: collision shapes visible via `--debug-collisions` are expected in collision-check screenshots; only flag them as artifacts in normal gameplay captures
-- **Collision-sprite mismatch** (in `--debug-collisions` captures only): collision shape significantly larger/smaller than the sprite, offset from the visual, or wrong shape type for the object
+- Debug artifacts in normal gameplay captures (nav mesh, axis gizmos, path lines, visible collision shapes)
+- **Collision-sprite mismatch** in `--debug-collisions` captures: collision shape significantly larger/smaller than the sprite, offset from the visual, or wrong shape type for the object
 - Orphaned UI elements at default positions
 
 ### Motion & Animation (compare consecutive frames)

--- a/skills/core/visual-qa/scripts/static_prompt.md
+++ b/skills/core/visual-qa/scripts/static_prompt.md
@@ -60,7 +60,8 @@ The assets themselves are usually fine — they come from a generation pipeline.
 - Primitive geometry (untextured cubes, spheres) contrasting with surrounding detail
 - Detail level mismatches: placeholder-quality next to finished materials
 - Default Godot materials (grey StandardMaterial3D, magenta missing shader)
-- Debug artifacts (nav mesh, axis gizmos, path lines; collision shapes only in normal gameplay captures, not `--debug-collisions` captures)
+- Debug artifacts in normal gameplay captures (nav mesh, axis gizmos, path lines, visible collision shapes)
+- Collision overlay mismatch in `--debug-collisions` captures (shape offset, wrong size, or wrong shape type relative to the sprite)
 - Orphaned UI elements at default positions
 
 ## Output Format


### PR DESCRIPTION
﻿## Summary

Clarifies Visual QA expectations for normal gameplay captures versus collision-debug captures, and ensures scaffold commits Godot `.uid` import metadata so build workers can keep using parallel worktree isolation.

## Motivation

Recent pipeline runs exposed two issues:

- Visual QA wording treated debug collision overlays too similarly to normal gameplay captures.
- Godot-generated `.uid` import metadata could remain uncommitted after scaffold, making `/gm-build` treat the tree as dirty and fall back to slower sequential worker dispatch.

## Changes

- [x] Clarified Visual QA prompt text for normal screenshots versus `--debug-collisions` captures.
- [x] Updated scaffold/build worker guidance so `.uid` metadata is generated and committed at scaffold time.
- [x] Added `docs/update/next.md` entries for both fixes.

## Testing

- [ ] New or updated tests pass (`pytest` / gdUnit4 where relevant)
  - Not run in this handoff; PR scope is prompt/scaffold workflow text plus release notes.
- [x] Gitleaks passes or no secret-bearing files were touched
  - No secret-bearing files touched.
- [x] Manual testing completed, if applicable
  - Ran `git diff --check origin/main..HEAD`.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
N/A
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
  - N/A: no ECS systems touched.
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
