### PR TITLE
fix: keep worker dispatch non-interactive

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -31,5 +31,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Resized image assets are scaled proportionally and transparency-padded instead of stretched, so non-square art is no longer squashed.
 - Clarified Visual QA handling of normal gameplay captures versus `--debug-collisions` collision-check captures.
 - `/gm-build` no longer falls back to slow sequential workers when the tree has uncommitted import artifacts.
+- Worker dispatch briefs now explicitly block approval prompts and confirmation pauses during non-interactive pipeline runs.
 
 ## Removed

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -57,6 +57,7 @@ Agent({
 - Copy relevant gotchas from reviewer skills (ui/gotchas.md, animation/gotchas.md, etc.)
 
 ### Prohibited Actions                                   [REQUIRED]
+- DO NOT ask for approval, wait for user input, or pause for confirmation. Execute the task directly. If required information or external state is missing, report `PARTIAL` or `FAILED` with the blocker.
 - DO NOT fabricate resource paths — only use paths listed in ASSETS.md or verified to exist in the project. If you need an asset that doesn't exist, report it in your summary; do NOT invent a path.
 - DO NOT modify files outside your Deliverables list — read-only access to all other files.
 - DO NOT write `test_system_has_query` tests — system.q is null outside World (see gecs gotcha G14).
@@ -89,6 +90,7 @@ Agent({
 13. **UI/scene tasks require SCENES.md reference.** When dispatching a worker for any UI screen, HUD, menu, or scene layout task, you MUST copy the relevant scene description from SCENES.md into the brief. Workers without layout specs will produce inconsistent UIs.
 14. **Worker model from config.** Read `worker_model` from `.godotmaker/config.yaml` (default: `opus`) and include it as `model:` in every Agent() call. See the Agent Call template at the top.
 15. **Cwd-relative paths in the brief.** Fill every `{path}` placeholder as cwd-relative (e.g. `src/systems/s_jump.gd`, not `D:/.../src/systems/s_jump.gd`).
+16. **Non-interactive execution.** Every worker brief MUST prohibit approval requests, user-input waits, and confirmation pauses.
 
 ## Worker Utility Convention
 


### PR DESCRIPTION
﻿## Summary

Makes worker dispatch briefs explicitly non-interactive so pipeline workers do not pause for approval or confirmation during automated runs.

## Motivation

A Codex build run paused inside a non-interactive worker flow while waiting for approval. Worker dispatch is generated by `/gm-build`, so the non-interactive rule belongs in the dispatch brief rather than the generic worker agent definition.

## Changes

- [x] Added a required prohibited action to worker briefs: do not ask for approval, wait for user input, or pause for confirmation.
- [x] Added a dispatch rule requiring every worker brief to carry that non-interactive constraint.
- [x] Added `docs/update/next.md` release-note entry.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
  - `python -m pytest` (`798 passed in 36.50s`)
- [x] Gitleaks passes or no secret-bearing files were touched
  - No secret-bearing files touched.
- [x] Manual testing completed, if applicable
  - `git diff --check`

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
N/A
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
  - N/A: prompt-only dispatch change.
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
