### PR TITLE
feat(gdd): scope audit to current tag and make pass 2 conditional

### DIFF
--- a/agents/gdd-auditor.md
+++ b/agents/gdd-auditor.md
@@ -1,6 +1,6 @@
 ---
 name: gdd-auditor
-description: Independent GDD reviewer. Reads a draft Game Design Document, applies a game-design checklist, and returns 5-8 high-value follow-up questions that the original interviewer is most likely to have missed. Read-only — MUST NOT modify the GDD or any other file.
+description: Independent GDD reviewer. Reads a draft Game Design Document scoped to the current tag, applies a game-design checklist, and returns up to 8 high-value follow-up questions (fewer — even zero — when the scoped content is already complete) that the original interviewer is most likely to have missed. Read-only — MUST NOT modify the GDD or any other file.
 model: inherit
 ---
 
@@ -10,19 +10,32 @@ You are an independent reviewer auditing a draft Game Design Document (GDD). You
 
 Your job is **not** to rewrite the GDD or answer questions yourself. Your job is to identify the highest-value gaps and produce a tight list of follow-up questions for the user.
 
+## Audit Scope — current tag only
+
+Audit **only the current tag's playable scope**, defined by the brief's
+`Current Tag` + `Current Tag Scope`. Flag gaps inside that slice.
+
+- A concern that belongs to a later tag (e.g. a deferred save system, settings
+  persistence outside this tag) is **N/A — deferred**, not a gap.
+- Subsequent mode: never flag or ask about anything in `Shipped Tags`.
+- Initial mode: the scope is the v0.1.0 first playable unit.
+
 ## Absolute Prohibitions
 
 You are STRICTLY PROHIBITED from:
 - Modifying the GDD or any other file
 - Inventing answers — when something is missing, ASK, do not GUESS
 - Asking the user to answer more than 8 questions in a single round
+- Flagging or asking about content outside the current tag's scope (future-tag
+  vision, or `Shipped Tags`)
+- Padding the question list to hit a count — there is no minimum
 - Repeating questions listed in the brief's `Previously Asked` field
 
 You are READ-ONLY.
 
 ## Audit Checklist
 
-Walk through these categories against the GDD. Flag a category only when the gap would meaningfully affect implementation or playtest.
+Walk through these categories against the **current tag's scope**. Flag a category only when the gap would meaningfully affect this tag's implementation or playtest. A category whose concern belongs to a later tag is **N/A — deferred**, not a gap.
 
 ### A. State & Lifecycle
 - Pause behavior: can the player pause? what gets paused (timers, audio, animations)?
@@ -80,6 +93,17 @@ Walk through these categories against the GDD. Flag a category only when the gap
 ### Iteration                                            [REQUIRED]
 {1 = first audit on v1 GDD, 2 = second audit on v2 GDD}
 
+### Current Tag                                          [REQUIRED]
+{e.g. v0.1.0 — the tag whose playable scope you are auditing}
+
+### Current Tag Scope                                    [REQUIRED]
+{The playable slice this tag delivers: the ROADMAP bullets for this tag in
+subsequent mode, or the v0.1.0 first-playable-unit definition in initial mode.
+Audit only gaps inside this slice.}
+
+### Shipped Tags (out of scope)                          [OPTIONAL]
+{subsequent mode only: list of prior shipped tags, out of audit scope}
+
 ### Previously Asked (do not repeat)                     [OPTIONAL]
 - {question text from prior audit round, if any}
 - ...
@@ -93,10 +117,14 @@ Walk through these categories against the GDD. Flag a category only when the gap
 ```
 ## GDD Audit Report — Iteration {N}
 
-### Overall Assessment
-{2-3 sentences: how complete the GDD is, where the biggest gaps cluster}
+### Completeness Verdict
+{One line: `complete` (no material gaps, no contradictions) OR `gaps: {count}`;
+plus `contradictions: yes/no`.}
 
-### Follow-up Questions (5-8, ordered by impact)
+### Overall Assessment
+{2-3 sentences: how complete the current tag's scope is, where the biggest gaps cluster}
+
+### Follow-up Questions (0-8, ordered by impact — omit entirely if none)
 1. **[Category {A-I}]** {one focused question — pick something whose answer changes implementation}
    - *Why this matters:* {one sentence}
 2. **[Category {A-I}]** {next question}
@@ -126,5 +154,5 @@ Walk through these categories against the GDD. Flag a category only when the gap
 2. **Ask for specifics, not feelings.** "What number of lives?" beats "How forgiving should it feel?"
 3. **Prefer multiple-choice with a default** when reasonable: "Pause: (a) full freeze incl. audio, (b) freeze gameplay only, (c) no pause. Default: (a). Pick one or override."
 4. **Skip the obvious.** If the GDD already says "single-player keyboard", do not ask about controller support unless the genre strongly implies one.
-5. **Cap at 8.** If you have more than 8 candidate questions, keep the highest-impact ones — those whose answers most change the implementation or scope.
+5. **Cap at 8, no floor.** Ask one question per real gap in this tag's scope; if the scope is complete, ask zero and report a `complete` verdict.
 6. **Never invent.** If something is unclear, ask; do not synthesize an answer for the user.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -24,6 +24,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - Clarified source-available licensing language and excluded internal planning notes from the documentation site.
 - Scaffold generates and commits Godot `.uid` import metadata in its initial commit so the project tree starts clean for `/gm-build`.
+- GDD design audit now focuses on the current release tag and only runs its second pass when the first turns up enough gaps, so simple or already-clear designs aren't over-questioned.
 
 ## Fixed
 

--- a/docs/wiki/03-skills/core-skills.md
+++ b/docs/wiki/03-skills/core-skills.md
@@ -30,7 +30,7 @@ Supporting skills are reference packs loaded silently by the role skills. You ne
 
 | Skill | What it provides | Loaded by |
 |-------|-----------------|-----------|
-| `game-planner` | Interview structure, GDD template guidance, and two fixed rounds of independent audit (via the `gdd-auditor` sub-agent) before the design is finalized | `/gm-gdd` |
+| `game-planner` | Interview structure, GDD template guidance, and current-tag-scoped independent audit (via the `gdd-auditor` sub-agent — one pass always, a second only when the first finds enough gaps) before the design is finalized | `/gm-gdd` |
 | `project-scaffold` | Project layout rules, addon setup steps, and the ECS folder conventions | `/gm-scaffold` |
 | `input-mapper` | Reference for managing Godot input actions in `project.godot` | `/gm-build`, `/gm-fixgap` |
 

--- a/docs/zh/wiki/03-skills/core-skills.md
+++ b/docs/zh/wiki/03-skills/core-skills.md
@@ -30,7 +30,7 @@ Core 技能分为两类：九个以 `/gm-*` 暴露的角色技能，以及十二
 
 | 技能 | 提供的内容 | 被谁加载 |
 |------|-----------|----------|
-| `game-planner` | 设计阶段的访谈结构与 GDD 模板指导，并在定稿前通过 `gdd-auditor` 子 Agent 进行两轮独立审计 | `/gm-gdd` |
+| `game-planner` | 设计阶段的访谈结构与 GDD 模板指导，并在定稿前通过 `gdd-auditor` 子 Agent 对当前发布 tag 范围进行独立审计（第一轮必跑，第二轮仅在第一轮发现足够缺口时触发） | `/gm-gdd` |
 | `project-scaffold` | 项目目录规则、插件安装步骤、ECS 目录约定 | `/gm-scaffold` |
 | `input-mapper` | 管理 `project.godot` 中 Godot 输入动作的参考资料 | `/gm-build`、`/gm-fixgap` |
 

--- a/skills/core/game-planner/SKILL.md
+++ b/skills/core/game-planner/SKILL.md
@@ -56,9 +56,9 @@ Do not re-ask anything the concept already answers. Start Round 1 by briefly sta
 The flow has two phases:
 
 1. **Interview phase (Rounds 1-4)** — Socratic questions organized around GDD sections. Progress in order, but adapt — some games need more depth in certain areas, less in others.
-2. **Audit phase (Rounds 5-7)** — synthesize a draft GDD, then run **two fixed rounds of independent audit** (`gdd-auditor` subagent) to catch the blind spots the interview missed. Each audit round produces 5-8 follow-up questions delivered to the user in a single batch.
+2. **Audit phase (Rounds 5-7)** — synthesize a draft GDD, then run **independent audit** (`gdd-auditor` subagent) scoped to the **current tag**. Pass 1 (Round 6) always runs. Pass 2 (Round 7) runs only when Pass 1 meets the trigger in that round. Each audit round produces up to 8 follow-up questions (fewer, or none, when the tag's scope is already complete), delivered to the user in one batch.
 
-Round 8 is the user's final review (Ask Maker mode). Do not skip the audit rounds — they exist precisely because interview-only flows leak details (pause behavior, failure recovery, balance numbers, mechanic interactions) that bite later.
+Round 8 is the user's final review (Ask Maker mode). Pass 1 is mandatory; do not skip it.
 
 ### Round 1 — Game Identity (GDD §1-2)
 
@@ -148,9 +148,9 @@ Rules for synthesis:
 - Add custom sections if the game needs them
 - Fill in smart defaults for anything the user said "your call" about in that question or round
 
-### Round 6 — Audit Pass 1 (GDD v1 → v2)
+### Round 6 — Audit Pass 1 (GDD v1 → v2, always runs)
 
-Spawn the **`gdd-auditor`** subagent with a fresh context. Pass it the full GDD v1 and the iteration number `1`.
+Spawn the **`gdd-auditor`** subagent with a fresh context. Pass it the full GDD v1, the iteration number `1`, and the current tag's scope.
 
 ```
 Agent({
@@ -172,13 +172,26 @@ Audit brief:
 ### Iteration
 1
 
+### Current Tag
+{current tag id — always v0.1.0 in initial mode; the current tag from /gm-gdd in subsequent mode}
+
+### Current Tag Scope
+{initial mode: the v0.1.0 first-playable-unit definition from Round 4.
+subsequent mode: the current tag's ROADMAP bullets passed in by /gm-gdd.}
+
+### Shipped Tags (out of scope)
+{subsequent mode only: list prior tags already shipped; omit in initial mode}
+
 ### Game Genre Hint
 {genre from Round 1}
 ```
 
-The auditor returns 5-8 follow-up questions. Present them to the user **in one batch** (do not ask them one-by-one):
+The auditor returns **up to 8** follow-up questions (possibly none). Two outcomes:
 
-> "I've drafted the GDD, but before showing it to you I had an independent reviewer audit it. They flagged {N} gaps worth filling in. Please answer these in one go — anything you don't have a strong opinion on, just say 'your call':
+- **Verdict `complete` / no questions** — tell the user the audit found nothing to fill in for {tag}, keep the GDD as v2 = v1, and **skip straight to Round 8** (do not run Pass 2).
+- **Questions returned** — present them to the user **in one batch** (do not ask them one-by-one):
+
+> "I've drafted the GDD, but before showing it to you I had an independent reviewer audit it for {tag}. They flagged {N} gaps worth filling in. Please answer these in one go — anything you don't have a strong opinion on, just say 'your call':
 >
 > 1. **[State & Lifecycle]** Can the player pause? If so, does pausing freeze audio too? *(default: yes to both)*
 > 2. **[Failure & Recovery]** When the player dies, do they restart the level or hit a checkpoint?
@@ -188,9 +201,11 @@ The auditor returns 5-8 follow-up questions. Present them to the user **in one b
 
 Wait for the user's batched answers, then update the GDD → **v2**.
 
-### Round 7 — Audit Pass 2 (GDD v2 → v3)
+### Round 7 — Audit Pass 2 (GDD v2 → v3, conditional)
 
-Spawn the auditor again with iteration `2`. **You MUST populate the `Previously Asked` field with the exact questions asked in Round 6** — otherwise the auditor will re-ask the same gaps.
+**Run Pass 2 only if Pass 1 met the trigger:** Pass 1 returned **≥3 follow-up questions** OR its verdict flagged **any contradiction**. Otherwise skip Pass 2 and go to Round 8.
+
+When the trigger is met, spawn the auditor again with iteration `2`. **You MUST populate the `Previously Asked` field with the exact questions asked in Round 6** — otherwise the auditor will re-ask the same gaps.
 
 ```
 Agent({
@@ -211,6 +226,15 @@ Audit brief:
 
 ### Iteration
 2
+
+### Current Tag
+{same current tag as Pass 1}
+
+### Current Tag Scope
+{same scope as Pass 1}
+
+### Shipped Tags (out of scope)
+{subsequent mode only: same list as Pass 1; omit in initial mode}
 
 ### Previously Asked (do not repeat)
 - {Round 6 question 1, verbatim}

--- a/tests/test_audit_workflow.py
+++ b/tests/test_audit_workflow.py
@@ -1,4 +1,5 @@
-"""Workflow-level checks for the two-pass GDD audit loop.
+"""Workflow-level checks for the GDD audit loop (current-tag-scoped;
+Pass 1 always runs, Pass 2 is conditional on Pass 1's findings).
 
 Validates that the contract between game-planner SKILL.md (the dispatcher) and
 agents/gdd-auditor.md (the sub-agent) stays intact across edits to either side.
@@ -22,8 +23,10 @@ def _auditor_text():
 
 
 def test_game_planner_dispatches_gdd_auditor():
-    """Both audit rounds must invoke the gdd-auditor sub-agent. If either
-    dispatch goes missing the two-pass loop silently degrades to one pass."""
+    """Both audit rounds must keep their gdd-auditor dispatch block in the
+    doc. Pass 1 runs unconditionally and Pass 2 is conditional, but both
+    blocks must stay present — this counts textual dispatch blocks, not
+    runtime invocations. A missing block means a round was deleted, not gated."""
     text = _planner_text()
     dispatch_count = len(re.findall(r'subagent_type:\s*"gdd-auditor"', text))
     assert dispatch_count >= 2, (
@@ -44,8 +47,8 @@ def test_game_planner_uses_auditor_model_from_config():
 
 
 def test_game_planner_has_two_audit_rounds():
-    """Round 6 and Round 7 must both exist as headings — they are the only
-    place the two-pass design is named in user-readable form."""
+    """Round 6 and Round 7 must both exist as headings — Pass 1 (always) and
+    Pass 2 (conditional) are the user-readable names of the audit phase."""
     text = _planner_text()
     assert re.search(r"###\s*Round\s*6\s*[—-]\s*Audit Pass 1", text), (
         "Round 6 audit heading missing from game-planner SKILL.md"
@@ -108,3 +111,65 @@ def test_gdd_auditor_brief_format_documents_previously_asked():
     )
     assert "Iteration" in brief, "Brief Format must list `Iteration` as a brief field"
     assert "GDD Path" in brief, "Brief Format must list `GDD Path` as a brief field"
+
+
+def test_pass_2_is_conditional():
+    """Round 7 (Pass 2) must be gated on a trigger derived from Pass 1's
+    findings — not an unconditional second pass. The trigger keeps simple /
+    already-clear tag scopes from being over-audited while preserving the
+    independent-review safety net for the rounds that actually need it."""
+    text = _planner_text()
+    round_7_match = re.search(
+        r"###\s*Round\s*7.*?(?=###\s*Round\s*8|\Z)", text, re.DOTALL
+    )
+    assert round_7_match, "Round 7 section not found"
+    round_7 = round_7_match.group(0)
+    assert "conditional" in round_7.lower(), (
+        "Round 7 must be marked conditional, not an unconditional second pass."
+    )
+    assert re.search(r"only if", round_7, re.IGNORECASE), (
+        "Round 7 must state the trigger condition (e.g. 'Run Pass 2 only if ...')."
+    )
+    assert "contradiction" in round_7.lower(), (
+        "Round 7 trigger must reference contradictions surfaced by Pass 1."
+    )
+
+
+def test_audit_briefs_carry_current_tag_scope():
+    """Both audit briefs must pass the current tag's scope so the auditor
+    constrains findings to the tag being planned, not the whole cross-tag GDD."""
+    text = _planner_text()
+    count = text.count("Current Tag Scope")
+    assert count >= 2, (
+        "Both Round 6 and Round 7 audit briefs must include a `Current Tag Scope` "
+        f"field; found {count}."
+    )
+
+
+def test_gdd_auditor_scopes_to_current_tag():
+    """The auditor must declare that it audits only the current tag's scope
+    and document the scope fields in its brief — otherwise it re-audits the
+    whole cross-tag GDD and re-litigates already-shipped tags."""
+    text = _auditor_text()
+    assert "Audit Scope" in text, (
+        "gdd-auditor.md must declare an `Audit Scope` section limiting it to the current tag."
+    )
+    assert "Current Tag Scope" in text, (
+        "gdd-auditor.md Brief Format must document the `Current Tag Scope` field."
+    )
+
+
+def test_gdd_auditor_has_no_question_floor():
+    """The auditor must have no lower bound on question count — a clear,
+    complete tag scope should yield zero questions instead of a manufactured
+    5-8. Only the upper cap of 8 remains."""
+    text = _auditor_text()
+    assert "5-8" not in text, (
+        "gdd-auditor.md still mandates a 5-8 question floor; the lower bound must be removed."
+    )
+    assert "0-8" in text, (
+        "gdd-auditor.md should express the question count as 0-8 (upper bound only)."
+    )
+    assert re.search(r"no floor|no minimum|return zero", text, re.IGNORECASE), (
+        "gdd-auditor.md must explicitly allow zero questions when the scope is complete."
+    )


### PR DESCRIPTION
## Summary

The GDD design audit (`game-planner` Rounds 6-7 via the `gdd-auditor` subagent) now scopes to the **current release tag** and runs its second pass only when the first finds enough gaps. Previously both passes ran unconditionally against the whole cross-tag GDD.

## Motivation

Two problems surfaced while reviewing the audit flow:

1. **Unconditional two passes** — even a simple or already-clear design got two full rounds of audit questions, because the auditor was forced to produce 5-8 questions every round regardless of how complete the GDD was.
2. **Whole-GDD scope** — the auditor read the entire cross-tag `GDD.md`, so in subsequent mode it re-litigated already-shipped tags (e.g. asking about v0.1.0 pause behavior while planning v0.5.0).

## Changes

- [x] `gdd-auditor`: audit only the current tag's scope; brief gains `Current Tag` / `Current Tag Scope` / `Shipped Tags (out of scope)`; emit a `Completeness Verdict`; drop the 5-8 question floor (cap 8, no floor; later-tag concerns are N/A).
- [x] `game-planner`: Pass 1 (Round 6) always runs and skips straight to Round 8 when the scope is complete; Pass 2 (Round 7) runs only when Pass 1 returns >=3 questions or flags a contradiction.
- [x] Sync the EN + ZH skill-reference wiki and add a `docs/update/next.md` entry.
- [x] Tests: add current-tag-scope / conditional-pass-2 / no-floor assertions; keep the existing structural checks.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — `python -m pytest tests/` -> 802 passed (incl. 4 new audit-workflow tests)
- [x] Gitleaks passes or no secret-bearing files were touched — gitleaks clean on this commit
- [x] Manual testing completed, if applicable — N/A (prompt/text + tests only)

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed

SKILL/agent prompt behavior change only; no files moved, no config keys renamed (`auditor_model` unchanged), no on-disk target-project state affected.

## Checklist

- [x] Code follows project conventions
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated