### PR TITLE
fix(asset): parallel Codex image gen via subagents, fixed source path

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -25,6 +25,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Clarified source-available licensing language and excluded internal planning notes from the documentation site.
 - Scaffold generates and commits Godot `.uid` import metadata in its initial commit so the project tree starts clean for `/gm-build`.
 - GDD design audit now focuses on the current release tag and only runs its second pass when the first turns up enough gaps, so simple or already-clear designs aren't over-questioned.
+- `/gm-asset` generates Codex images in one `codex exec` call with parallel subagents (one per asset) instead of one serial call per image.
 
 ## Fixed
 
@@ -33,5 +34,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Clarified Visual QA handling of normal gameplay captures versus `--debug-collisions` collision-check captures.
 - `/gm-build` no longer falls back to slow sequential workers when the tree has uncommitted import artifacts.
 - Worker dispatch briefs now explicitly block approval prompts and confirmation pauses during non-interactive pipeline runs.
+- Codex image generation copies each subagent's own generated file to a fixed per-asset path instead of the newest file in `generated_images`, which was unsafe once generation runs in parallel.
 
 ## Removed

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -127,12 +127,14 @@ Run up to 3 generation groups in parallel. Each group owns one or more target im
   python tools/asset_image_finalize.py --source <generated_image_path> \
     --out <target.png> --label <asset_id> [--resize WIDTHxHEIGHT]
   ```
-- For `codex` under Claude Code, call Codex through Bash. Put the prompt in a
-  temp file. The Codex prompt must explicitly require `$imagegen` / built-in
-  `image_gen`, copy the selected PNG from `$CODEX_HOME/generated_images/...` to
-  a requested source path under `.godotmaker/asset-generation/codex/`, and
-  report failure if the image-generation tool is unavailable. After `codex exec`
-  returns, verify that source path exists before finalizing it.
+- For `codex` under Claude Code, generate the whole batch in ONE `codex exec`
+  call (not one per image) and have Codex spawn one subagent per asset, run in
+  parallel, max 3 concurrent. The batch prompt lists each asset's id, prompt,
+  and exact target source path under `.godotmaker/asset-generation/codex/`, and
+  requires each subagent to copy the image it generated (the path `image_gen`
+  returned) to that asset's target path — never the newest file in
+  `generated_images`. See `references/asset-gen.md`. After `codex exec` returns,
+  verify each source path exists before finalizing.
 - Each group writes one JSON report under `.godotmaker/asset-generation/`: `{"ok": true, "provider": "<asset_image_model>", "assets": [<finalize result>, ...]}`.
 - Do not select images by scanning a global "latest generated image" list. Use the generated paths reported by the group.
 

--- a/skills/core/gm-asset/references/asset-gen.md
+++ b/skills/core/gm-asset/references/asset-gen.md
@@ -25,34 +25,45 @@ When `asset_image_model: codex` is selected in a Claude Code project, use
 non-interactive Codex as the image-generation provider. This is not an
 `asset_gen.py` backend.
 
-Write one prompt file per asset or generation group and run `codex exec` from
-the project root:
+Generate the whole batch in ONE `codex exec` call (not one per image) and have
+Codex spawn one subagent per asset, run in parallel, at most 3 at a time.
+
+Write one batch prompt file listing every asset (id, prompt, exact target
+path), then run `codex exec` from the project root:
 
 ```bash
 mkdir -p .godotmaker/asset-generation/codex
-cat > .godotmaker/asset-generation/codex_<asset_id>.prompt.txt <<'EOF'
-Use the $imagegen skill and built-in image_gen tool to generate this project
-asset.
+cat > .godotmaker/asset-generation/codex_batch.prompt.txt <<'EOF'
+Use the $imagegen skill and built-in image_gen tool to generate these assets.
+Spawn one subagent per asset and run them in parallel, at most 3 at a time.
+Wait for all subagents to finish.
 
-Generate a PNG for:
-<prompt>
+Each subagent must, for its asset:
+- generate the image from that asset's prompt with image_gen,
+- copy the image it just generated (the path image_gen returned) to that
+  asset's exact target path — do NOT scan generated_images for the newest file,
+- report the asset id and whether its target file now exists.
 
-After generation, copy the selected generated PNG from
-$CODEX_HOME/generated_images/... to:
-.godotmaker/asset-generation/codex/<asset_id>_source.png
+Assets:
+- id: <asset_id_1>
+  target: .godotmaker/asset-generation/codex/<asset_id_1>_source.png
+  prompt: <prompt 1>
+- id: <asset_id_2>
+  target: .godotmaker/asset-generation/codex/<asset_id_2>_source.png
+  prompt: <prompt 2>
 
-If built-in image generation is unavailable, do not create an image file.
+If built-in image generation is unavailable, do not create that image file.
 Report the failure clearly.
 EOF
 
 codex exec --json --dangerously-bypass-approvals-and-sandbox \
-  -C "$PWD" --output-last-message .godotmaker/asset-generation/codex_<asset_id>.summary.txt \
-  - < .godotmaker/asset-generation/codex_<asset_id>.prompt.txt
+  -C "$PWD" --output-last-message .godotmaker/asset-generation/codex_batch.summary.txt \
+  - < .godotmaker/asset-generation/codex_batch.prompt.txt
 ```
 
-Then check that `.godotmaker/asset-generation/codex/<asset_id>_source.png`
-exists and pass that file to `tools/asset_image_finalize.py`. Do not silently
-switch providers when the configured provider is `codex`.
+After `codex exec` returns, check that each `<asset_id>_source.png` exists, then
+pass each to `tools/asset_image_finalize.py`. Do not silently switch providers
+when the configured provider is `codex`.
 
 ### Gemini sizes and costs
 


### PR DESCRIPTION
## Summary

`/gm-asset` Codex image generation now runs as one batched `codex exec` with parallel subagents, and selects each source image deterministically by per-asset target path instead of "newest file in `generated_images`".

## Motivation

A pipeline AAR found `/gm-asset` generated images serially — multiple `codex exec` Bash calls in one message degrade to serial under Claude Code. The Codex prompt also copied "the selected generated PNG from `generated_images/...`", which resolved to the newest file, unsafe once generation runs in parallel.

## Changes

- [x] gm-asset / asset-gen: generate the whole batch in one `codex exec` and have Codex spawn one subagent per asset (max 3 concurrent), fanning out internally instead of relying on serial Bash calls.
- [x] Each subagent copies the image it generated (the `image_gen` result path) to that asset's fixed target path, never the newest file in `generated_images` — honoring the existing "do not scan for the latest image" rule.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — `python -m pytest` 798 passed; gdUnit4 N/A (no Godot project code changed).
- [x] Gitleaks passes or no secret-bearing files were touched — skill/doc prose only.
- [ ] Manual testing completed, if applicable — real multi-image parallelism and per-asset paths will be confirmed on the next live `/gm-asset` run.

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed

Skill behavior changes on the next `/gm-asset` run after publish; no config keys renamed, no files moved in target projects, no on-disk state format change.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable (N/A — no ECS code changed)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)
