### PR TITLE
feat(config): default worker_model to sonnet

### DIFF
--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -31,11 +31,9 @@ asset_image_model: native
 # Supported values: none, grok:<model>
 asset_video_model: none
 
-# Agent model configuration
-# Workers use opus for complex implementation tasks
-# Other roles (validation, document authoring) use sonnet - they receive
-# fully-resolved briefs from the lead agent and don't need opus-tier reasoning
-worker_model: opus
+# Agent model configuration. All roles default to sonnet; raise
+# worker_model to opus for games that need heavier implementation reasoning.
+worker_model: sonnet
 verifier_model: sonnet
 reviewer_model: sonnet
 analyst_model: sonnet

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -26,6 +26,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Scaffold generates and commits Godot `.uid` import metadata in its initial commit so the project tree starts clean for `/gm-build`.
 - GDD design audit now focuses on the current release tag and only runs its second pass when the first turns up enough gaps, so simple or already-clear designs aren't over-questioned.
 - `/gm-asset` generates Codex images in one `codex exec` call with parallel subagents (one per asset) instead of one serial call per image.
+- Worker subagents now default to `sonnet` instead of `opus` — measured worker context stays well within sonnet's window, so the lighter model is sufficient and cuts token cost.
 
 ## Fixed
 

--- a/docs/wiki/06-configuration/project-config.md
+++ b/docs/wiki/06-configuration/project-config.md
@@ -10,7 +10,7 @@ The first time you run `python tools/publish.py <project>`, the publish script c
 
 **`agent`** — selected coding-agent runtime, such as `claude-code` or `codex`.
 
-**`worker_model`** — which Claude model writes game code. Defaults to `opus` because complex implementation benefits from the stronger model.
+**`worker_model`** — which Claude model writes game code. Defaults to `sonnet`; set it to `opus` for games that need heavier implementation reasoning.
 
 **`verifier_model`**, **`reviewer_model`**, **`analyst_model`**, **`auditor_model`**, **`decomposer_model`** — role model defaults for validation, review, image analysis, audit, and GDD decomposition.
 
@@ -37,7 +37,7 @@ vqa_fallback_model: native
 asset_image_model: native
 asset_video_model: none
 
-worker_model: opus
+worker_model: sonnet
 verifier_model: sonnet
 reviewer_model: sonnet
 analyst_model: sonnet

--- a/docs/zh/wiki/06-configuration/project-config.md
+++ b/docs/zh/wiki/06-configuration/project-config.md
@@ -10,7 +10,7 @@
 
 **`agent`** — 当前项目选择的编码智能体运行时，例如 `claude-code` 或 `codex`。
 
-**`worker_model`** — 编写游戏代码的 Claude 模型。默认是 `opus`，因为复杂实现更适合强模型。
+**`worker_model`** — 编写游戏代码的 Claude 模型。默认是 `sonnet`；需要更强实现推理的游戏可改为 `opus`。
 
 **`verifier_model`**、**`reviewer_model`**、**`analyst_model`**、**`auditor_model`**、**`decomposer_model`** — 验证、审查、图片分析、审计和 GDD 拆分等角色的默认模型。
 
@@ -33,7 +33,7 @@ vqa_fallback_model: native
 asset_image_model: native
 asset_video_model: none
 
-worker_model: opus
+worker_model: sonnet
 verifier_model: sonnet
 reviewer_model: sonnet
 analyst_model: sonnet

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -10,7 +10,7 @@ When dispatching a worker, fill in this EXACT template. All REQUIRED fields must
 Agent({
   subagent_type: "worker",
   description: "Worker: implement {task_name}",
-  model: "{worker_model from .godotmaker/config.yaml, default: opus}",
+  model: "{worker_model from .godotmaker/config.yaml, default: sonnet}",
   prompt: "{worker brief below}"
 })
 ```
@@ -88,7 +88,7 @@ Agent({
 11. **Entity.name must be set explicitly**: When creating Entity instances programmatically, set `entity.name = "MyEntity"` before `add_entity()`. Without this, Godot assigns unpredictable auto-names (`@Node@2`), breaking E2E test node paths.
 12. **Worker self-check is mandatory**: Workers must run the self-check protocol before submitting their report. If self-check is not mentioned in the report, reject it.
 13. **UI/scene tasks require SCENES.md reference.** When dispatching a worker for any UI screen, HUD, menu, or scene layout task, you MUST copy the relevant scene description from SCENES.md into the brief. Workers without layout specs will produce inconsistent UIs.
-14. **Worker model from config.** Read `worker_model` from `.godotmaker/config.yaml` (default: `opus`) and include it as `model:` in every Agent() call. See the Agent Call template at the top.
+14. **Worker model from config.** Read `worker_model` from `.godotmaker/config.yaml` (default: `sonnet`) and include it as `model:` in every Agent() call. See the Agent Call template at the top.
 15. **Cwd-relative paths in the brief.** Fill every `{path}` placeholder as cwd-relative (e.g. `src/systems/s_jump.gd`, not `D:/.../src/systems/s_jump.gd`).
 16. **Non-interactive execution.** Every worker brief MUST prohibit approval requests, user-input waits, and confirmation pauses.
 


### PR DESCRIPTION
## Summary

Change the default `worker_model` from `opus` to `sonnet` for the build/fixgap worker subagents.

## Motivation

Measured worker peak context from a real Build run (18 workers, claude runtime) stays well within sonnet's 200k window: median ~76k, mean ~74k, max 121k (a single GameScene-assembly outlier); all 18 workers under 200k. Workers receive finely-decomposed tasks (one or two mechanics each), so the lighter model is sufficient and lowers token cost. The lead/orchestrator agent is unaffected — `worker_model` only controls the dispatched worker subagents.

## Changes

- [x] `config/config.yaml.default`: `worker_model: opus` -> `sonnet` + comment rewrite
- [x] `skills/core/_shared/worker-dispatch.md`: dispatch template + rule fallback `opus` -> `sonnet` (keeps `test_config_consistency` green)
- [x] `docs/wiki/06-configuration/project-config.md` and its zh mirror: documented default
- [x] `docs/update/next.md`: Changed entry

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — `pytest tests/` 802 passed; `test_config_consistency.py` green
- [x] Gitleaks passes or no secret-bearing files were touched — gitleaks: no leaks found
- [ ] Manual testing completed, if applicable

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed

> Existing target projects already pin an explicit `worker_model` in their `.godotmaker/config.yaml` (publish writes the full default set on first install and never overwrites it afterward except `agent`). The default change therefore only affects fresh installs; the skill fallback (`default: sonnet`) applies only when the key is absent, which does not happen for published projects.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable (N/A)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
