### PR TITLE
fix(evaluate): run visual-qa as a subagent so the headless gate works

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -37,5 +37,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Worker dispatch briefs now explicitly block approval prompts and confirmation pauses during non-interactive pipeline runs.
 - Codex image generation copies each subagent's own generated file to a fixed per-asset path instead of the newest file in `generated_images`, which was unsafe once generation runs in parallel.
 - Hook registration config is now runner-specific: Claude Code uses `agent-runtimes/claude-code/config/settings.json`, while Codex publishes `agent-runtimes/codex/config/hooks.json` to `.codex/hooks.json`.
+- `/gm-evaluate` runs visual-qa in a dispatched subagent instead of a forked skill context (which errored under `claude -p`), and rejects with a `critical_issue` when a per-scene call can't run instead of hand-writing `native` logs.
+- Visual QA rejects a stitched contact-sheet supplied in place of per-scene reference + screenshot paths.
 
 ## Removed

--- a/skills/core/gm-evaluate/SKILL.md
+++ b/skills/core/gm-evaluate/SKILL.md
@@ -104,7 +104,7 @@ All of these must pass for `result == "approve"`. Failure of any is a `critical_
 
 **Visual cross-check (per scene listed in SCENES.md):**
 7. Capture a screenshot via `game.screenshot("e2e/screenshots/scene_{name}.png")`. For scenes with motion/animation, capture a frame sequence per `.claude/skills/screenshot/SKILL.md` § "Frame Sequence for VQA Dynamic Mode". Screenshots overwrite per run (they're verification artifacts, not history; `e2e/screenshots/` is gitignored or sparingly committed at the user's choice).
-8. Compare against the reference image in `references/scene_{name}.png` by invoking the `visual-qa` skill.
+8. Compare against the reference image in `references/scene_{name}.png` by dispatching a subagent to run the `visual-qa` skill.
 
    **Precondition — reference must exist.** Before calling visual-qa, confirm `references/scene_{name}.png` exists. If missing → record `critical_issue: "missing reference for scene_{name}"` and skip the visual-qa call for this scene. Do NOT degrade to Question mode against the screenshot alone.
 
@@ -113,14 +113,16 @@ All of these must pass for `result == "approve"`. Failure of any is a `critical_
    **VQA log path.** Ask `visual-qa` to write its debug log to `e2e/screenshots/vqa.log`.
 
    ```
-   # Static scene
-   Skill(skill="visual-qa") "Check references/scene_{name}.png against e2e/screenshots/scene_{name}.png --log e2e/screenshots/vqa.log — Goal: {scene goal from SCENES.md}, Requirements: {key elements + layout}, Verify: {acceptance criteria block, or mechanic-id list fallback}."
+   # Static scene — dispatch a subagent to run visual-qa with:
+   "Check references/scene_{name}.png against e2e/screenshots/scene_{name}.png --log e2e/screenshots/vqa.log — Goal: {scene goal from SCENES.md}, Requirements: {key elements + layout}, Verify: {acceptance criteria block, or mechanic-id list fallback}."
 
-   # Dynamic scene (frame sequence in per-scene subdir)
-   Skill(skill="visual-qa") "Check references/scene_{name}.png against e2e/screenshots/scene_{name}/frame_*.png --log e2e/screenshots/vqa.log — Goal: ..., Requirements: ..., Verify: motion is fluid, no stuck entities, animation matches movement."
+   # Dynamic scene (frame sequence in per-scene subdir) — dispatch a subagent to run visual-qa with:
+   "Check references/scene_{name}.png against e2e/screenshots/scene_{name}/frame_*.png --log e2e/screenshots/vqa.log — Goal: ..., Requirements: ..., Verify: motion is fluid, no stuck entities, animation matches movement."
    ```
 
    **Audit trail.** Record every visual-qa call (verdict + context + mode + output digest) in `visual_checks.{scene_name}.vqa_calls[]` (schema below). If you override a recorded verdict for the final `result` — for instance you read the PNGs yourself and disagree — write the reason and what you saw into `visual_checks.{scene_name}.notes`. Either way, `result` reflects the chain transparently.
+
+   **Real invocation required.** Every `vqa_calls` entry and every `vqa.log` line must come from a visual-qa invocation — do not author them directly. If the invocation errors or its backend is unavailable, record a `critical_issue` and set `result: reject`.
 
    If a `fail` looks wrong, prefer re-calling visual-qa with refined `--context` or `--both` before overriding by hand. If the final visual-qa output marks an issue as style-only or non-blocking, do not promote it to `critical_issue`; record it in `visual_checks.{scene_name}.notes` or `minor_issues`.
 

--- a/skills/core/visual-qa/SKILL.md
+++ b/skills/core/visual-qa/SKILL.md
@@ -3,7 +3,6 @@ name: visual-qa
 description: |
   Visual quality assurance: analyze game screenshots for defects, compare against reference, check motion in frame sequences.
   Supports runtime-native inspection plus Gemini or OpenAI API-backed VQA.
-context: fork
 ---
 
 # Visual QA
@@ -52,6 +51,8 @@ Pick the mode from caller args by matching the first row whose precondition hold
 If a reference path appears in the args but the file does not exist on disk → STOP. Return `verdict: error` with `reason: "reference file missing: <path>"`.
 
 Reject any other argv shapes (`--screenshot <file> --requirements "..."` and similar).
+
+Each call takes one scene's reference plus that scene's screenshot or frame paths. Reject a single stitched / montage / contact-sheet image supplied in place of per-scene paths.
 
 ## Runtime-Native Execution
 


### PR DESCRIPTION
## Summary

The evaluate visual gate ran `visual-qa` as a forked skill (`context: fork`), which errors under the non-interactive `claude -p` pipeline. The evaluate lead then self-justified into reading PNGs itself and hand-writing `native` `vqa_calls` / `vqa.log` entries; the Codex runner reproduced the same fabrication via a stitched contact sheet plus an inline-Python log. Net effect: the automated visual QA gate effectively never ran as designed on headless pipelines.

This dispatches `visual-qa` as a subagent (works headless and keeps per-scene image reads out of the evaluate context, unlike a forked skill), forbids stitched/contact-sheet inputs, and makes the gate fail loud instead of fabricating an audit trail.

## Motivation

On every headless `evaluate`, visual verdicts were the agent eyeballing plus a hand-written log rather than a real `visual-qa` run, so the gate's verdicts could not be trusted. Subagent dispatch is the headless-compatible isolation mechanism the pipeline already uses for workers, unlike the skill `context: fork` that breaks under `claude -p`.

## Changes

- [x] `visual-qa`: drop `context: fork`; reject a stitched / montage / contact-sheet image supplied in place of per-scene reference + screenshot paths
- [x] `gm-evaluate`: compare each scene by dispatching a subagent to run `visual-qa`; require every `vqa_calls` / `vqa.log` entry to come from a real invocation, and record a `critical_issue` + reject when the call cannot run
- [x] `docs/update/next.md` entry

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — `python -m pytest tests/` → 807 passed. No new tests added: the changes are skill-prose + frontmatter with no unit-testable surface.
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable — **pending**: the headless subagent-dispatch path is not covered by unit tests and needs a real `evaluate` run to confirm visual-qa is invoked in a subagent and writes `vqa.log`.

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed

Skill prose / frontmatter change only — no file moves, no config-key renames, no on-disk state to migrate. Published projects pick up the new behavior on the next `publish.py`.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable — N/A, no ECS code touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
