### PR TITLE
[codex] docs: clarify agent runtime troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ Codex runner support and AI-generated art are preview features. The current art 
 
 If this direction is useful to you, star the repo, try the CLI, and open issues with the games you want it to build better.
 
+## Runtime Note
+
+GodotMaker is a workflow layer driven by external agent runtimes. Those agents are not maintained by this repository, and long-running automation can occasionally hit runtime-specific issues such as silent timeouts, completed work that does not exit cleanly, transient tool failures, rate limits, or child processes that need cleanup.
+
+Most one-off agent failures are recoverable by stopping the current run and starting `godotmaker-cli` again; the workflow is designed to resume from local project state. Feedback and issue reports are very welcome. If possible, include the key details for that run and the project's `.godotmaker/` directory, which often contains the state and reports needed to diagnose the issue.
+
 ## License
 
 Business Source License 1.1. See [LICENSE](LICENSE). Each released version converts to Apache License 2.0 four years after that version is first publicly distributed. **The games you build with GodotMaker are not GodotMaker and are entirely yours**, subject to any third-party engine, asset, model-provider, runtime, or dependency terms that may apply.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,6 +100,12 @@ Codex runner 支持和 AI 自动生成美术资源仍是预览功能。当前美
 
 如果你觉得这个方向有价值，欢迎 star、试用 CLI，并把你希望它做得更好的游戏类型和问题提到 issue。
 
+## 运行时说明
+
+GodotMaker 本身是一个工作流层，实际执行依赖外部 Agent runtime。这些 Agent 不是本仓库维护的组件，长时间自动化运行时偶尔会遇到运行时自身的小问题，例如静默超时、非输出式自动化任务已经完成但进程没有主动退出、临时工具失败、速率限制，或子进程需要额外清理。
+
+绝大多数一次性的 Agent 失败都可以通过停止当前运行、重新启动 `godotmaker-cli` 恢复；工作流会根据本地项目状态继续推进。我们非常欢迎提交 feedback 和 issue，如果能附上当次运行的必要信息和项目里的 `.godotmaker/` 目录就更好了。
+
 ## 许可证
 
 Business Source License 1.1。见 [LICENSE](LICENSE)。每个发布版本会在首次公开发布 4 年后自动转为 Apache License 2.0。**用 GodotMaker 做出来的游戏不是 GodotMaker，本身完全属于你**，但仍需遵守第三方引擎、素材、模型 provider、runtime 或依赖项可能适用的条款。

--- a/docs/wiki/04-troubleshooting/common-problems.md
+++ b/docs/wiki/04-troubleshooting/common-problems.md
@@ -114,6 +114,16 @@ These messages appear when you try to run a `/gm-*` command out of order. Each r
 
 ---
 
+### Agent runtime or CLI appears stuck
+
+**Symptom:** `godotmaker-cli` stops receiving output for a long time, reports an agent timeout, or a stage appears to have finished its non-interactive work but the underlying agent process does not exit cleanly.
+
+**Cause:** GodotMaker drives external agent runtimes. Those runtimes are not maintained by this repository, and long-running sessions can occasionally hit transient runtime-specific failures such as silent tool calls, rate limits, stream interruptions, or child-process cleanup issues.
+
+**Fix:** Stop the current run and start `godotmaker-cli` again from the same project directory. In most cases the pipeline resumes from local state and continues normally. Feedback and issue reports are very welcome. If possible, include the key details for that run and the project's `.godotmaker/` directory, which often contains the state and reports needed to diagnose the issue.
+
+---
+
 ### "Role 'gdd' has not completed yet — run /gm-gdd first"
 
 **Symptom:** You ran `/gm-build` and got a hook block saying the `gdd` role is missing.

--- a/docs/zh/wiki/04-troubleshooting/common-problems.md
+++ b/docs/zh/wiki/04-troubleshooting/common-problems.md
@@ -114,6 +114,16 @@ git config --global user.email "you@example.com"
 
 ---
 
+### Agent runtime 或 CLI 看起来卡住了
+
+**症状：** `godotmaker-cli` 很长时间收不到输出、报告 Agent 超时，或者某个阶段看起来已经完成了非交互式自动化工作，但底层 Agent 进程没有正常退出。
+
+**原因：** GodotMaker 驱动的是外部 Agent runtime。这些 runtime 不是本仓库维护的组件，长时间会话偶尔会遇到运行时自身的临时问题，例如静默工具调用、速率限制、输出流中断，或子进程清理异常。
+
+**解决办法：** 停止当前运行，然后在同一个项目目录重新启动 `godotmaker-cli`。绝大多数情况下，流水线会根据本地状态恢复并继续推进。我们非常欢迎提交 feedback 和 issue，如果能附上当次运行的必要信息和项目里的 `.godotmaker/` 目录就更好了。
+
+---
+
 ### "Role 'gdd' has not completed yet — run /gm-gdd first"
 
 **症状：** 你运行了 `/gm-build`，结果被 hook 拦下来，提示 `gdd` 角色未完成。


### PR DESCRIPTION
﻿## Summary

Clarifies how users should handle occasional external agent runtime stalls or timeout-like behavior.

## Motivation

GodotMaker drives long-running external agent runtimes, and some failures are transient or runtime-specific rather than framework bugs. Public docs should set expectations and tell users what diagnostic context helps when opening feedback or issues.

## Changes

- [x] Added a runtime note near the bottom of the English and Chinese READMEs.
- [x] Added matching troubleshooting entries in the English and Chinese wiki pages.
- [x] Asked users to include key run details and the project `.godotmaker/` directory when possible.

## Testing

- [ ] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

Validation performed:

```text
git diff --cached --check
```

Attempted `python -m pytest tests/test_docs.py -q`, but this repository does not contain `tests/test_docs.py`; no tests were run. This PR is documentation-only.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

Not applicable; no migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR

This is a documentation-only maintenance PR, so `docs/update/next.md` was intentionally not changed.
