### PR TITLE
Fix verify feedback build retry

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -24,5 +24,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
+- `gm-build` now consumes a newer failing verify report before treating an already-built, fully verified plan as complete.
+- `run_verify.py` now treats gdUnit warning exit code 101 as a non-blocking unit-test warning when the XML report shows every assertion passed.
 
 ## Removed

--- a/skills/core/gm-build/SKILL.md
+++ b/skills/core/gm-build/SKILL.md
@@ -25,6 +25,17 @@ Read `.godotmaker/stage.jsonl` (treat as empty if missing) — each line is `{"r
 - If `ROADMAP.md` does not exist → STOP. Tell user to run `/gm-gdd` first.
 - If **no event with `role == "gdd"`** exists anywhere in the file → STOP. Tell user to run `/gm-gdd` first.
 - If `PLAN.md` is missing the `**Tag:**` header → STOP. Tell user the file is stale and to re-run `/gm-gdd` to regenerate it for the current tag.
+
+Read `.godotmaker/verify_report.json` if it exists.
+
+Define **pending verify feedback** as:
+- `.godotmaker/verify_report.json` exists.
+- Its top-level `result` is `"fail"`.
+- Its `ts` is later than the latest `role == "build"` event in `stage.jsonl`, or there is no prior build event.
+
+Apply the resume gates in this order:
+
+- If pending verify feedback exists → proceed to Step 0, even if the last event is `build` and all PLAN.md tasks are already `verified`.
 - If the **last event** has `role == "build"` AND all PLAN.md tasks are `verified` → STOP. Tell the user:
   > "Build already completed for the current tag at {timestamp}. Recommended next: /gm-verify.
   > If you need to redo this step or have other plans, just tell me."
@@ -81,7 +92,7 @@ not on a worker-count cadence.
 
 ### Step 0 — Process Verify Feedback
 
-Run this step before Step 1 only if `.godotmaker/verify_report.json` exists, `result == "fail"`, and its `ts` is later than the most recent `role == "build"` event in `stage.jsonl` (or there is no prior build event). Otherwise → skip to Step 1.
+Run this step before Step 1 only if pending verify feedback exists. Otherwise → skip to Step 1.
 
 Translate failures into `pending` tasks at the bottom of `PLAN.md`.
 

--- a/skills/core/gm-verify/SKILL.md
+++ b/skills/core/gm-verify/SKILL.md
@@ -129,11 +129,14 @@ Schema:
       ]
     },
     "unit_tests": {
-      "result": "pass | fail | error",
+      "result": "pass | warn | fail | error",
       "passed": 624,
       "failed": 0,
       "failures": [
         {"test": "test_player_input::test_jump", "message": "expected 10, got 0"}
+      ],
+      "warnings": [
+        "Found 4 possible orphan nodes."
       ]
     },
     "lint": {
@@ -173,7 +176,7 @@ Field rules:
 - **Top-level `result`** — `"pass"` iff every `checks.*.result` ∈ {`pass`, `warn`}. Any `fail` / `error` makes overall `fail`. `tooling_notes` alone never makes overall `fail` — the `error` it pairs with does.
 - **`ts`** — UTC ISO 8601 at the moment you write the file. Consumers compare it against their own last-event timestamp for freshness.
 - **All array fields are required** (possibly empty `[]`). Do not omit them.
-- **Per-check `result`** — `pass` / `fail` are project-content. `warn` is lint-only style noise. `error` means the tool itself crashed and the project's actual state is unknown for this check; pair `error` with exactly one `tooling_notes` entry. Consumers fix `error` via config, NOT project code.
+- **Per-check `result`** — `pass` / `fail` are project-content. `warn` is non-blocking diagnostic noise (lint style drift or gdUnit warnings such as orphan nodes when every assertion passed). `error` means the tool itself crashed and the project's actual state is unknown for this check; pair `error` with exactly one `tooling_notes` entry. Consumers fix `error` via config, NOT project code.
 - **`format_drift`** — object when `gdformat --check` reports drift; `null` otherwise.
 - **`suggested_fallback`** + matching operand — the producer fills the operand so the consumer can act deterministically:
 

--- a/tests/test_gm_build_verify_feedback.py
+++ b/tests/test_gm_build_verify_feedback.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GM_BUILD = REPO_ROOT / "skills" / "core" / "gm-build" / "SKILL.md"
+
+
+def test_completed_build_resume_check_does_not_hide_newer_verify_failure():
+    text = GM_BUILD.read_text(encoding="utf-8")
+    assert "Define **pending verify feedback** as:" in text
+    assert "If pending verify feedback exists" in text
+    assert 'Its top-level `result` is `"fail"`.' in text
+    assert (
+        "Its `ts` is later than the latest `role == \"build\"` event in `stage.jsonl`, "
+        "or there is no prior build event."
+    ) in text
+    assert (
+        'If the **last event** has `role == "build"` AND all PLAN.md tasks are `verified`'
+    ) in text
+
+    pending_definition = text.index("Define **pending verify feedback** as:")
+    gate_order = text.index("Apply the resume gates in this order:")
+    pending_branch = text.index("If pending verify feedback exists")
+    completed_stop = text.index('Build already completed for the current tag')
+    step_zero = text.index("### Step 0")
+    step_zero_condition = text.index(
+        "Run this step before Step 1 only if pending verify feedback exists."
+    )
+
+    assert pending_definition < gate_order < pending_branch < completed_stop < step_zero
+    assert step_zero < step_zero_condition

--- a/tests/test_verify_report_fixtures.py
+++ b/tests/test_verify_report_fixtures.py
@@ -34,8 +34,9 @@ TOP_RESULT_VALUES = {"pass", "fail"}
 PER_CHECK_RESULT_VALUES = {"pass", "warn", "fail", "error"}
 REQUIRED_CHECKS = {"build", "unit_tests", "lint", "static_check"}
 
-# `warn` is lint-only (per gm-verify SKILL.md per-check result semantics).
-WARN_ALLOWED_CHECKS = {"lint"}
+# `warn` is reserved for non-blocking checks: lint style noise and gdUnit
+# warnings such as orphan-node reports when every assertion passed.
+WARN_ALLOWED_CHECKS = {"lint", "unit_tests"}
 
 # Producer rule: each non-escalate suggested_fallback REQUIRES the named
 # operand to be present and non-empty. Mirrors the table in
@@ -317,14 +318,19 @@ def test_escalate_does_not_require_any_operand():
     assert validate_report(r) == []
 
 
-def test_warn_outside_lint_is_invalid():
-    """`warn` is lint-only per SKILL.md per-check result semantics. A
-    build / unit_tests / static_check report with result == warn is a
-    documentation drift signal."""
+def test_warn_outside_allowed_checks_is_invalid():
+    """`warn` is allowed only for checks with non-blocking warning semantics."""
     r = report_pass()
     r["checks"]["build"]["result"] = "warn"
     issues = validate_report(r)
     assert any("warn" in i and "build" in i for i in issues), issues
+
+
+def test_unit_tests_warn_is_valid():
+    r = report_pass()
+    r["checks"]["unit_tests"]["result"] = "warn"
+    r["checks"]["unit_tests"]["warnings"] = ["Found 4 possible orphan nodes."]
+    assert validate_report(r) == []
 
 
 def test_missing_top_level_key_is_caught():

--- a/tests/tools/test_run_verify.py
+++ b/tests/tools/test_run_verify.py
@@ -216,6 +216,31 @@ def test_check_unit_tests_xml_pass_counts_all_cases():
     assert note is None
 
 
+def test_check_unit_tests_xml_pass_exit_101_is_warn():
+    xml = """<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="report_1" tests="76" failures="0" errors="0" skipped="0" />
+"""
+
+    def fake_run(cmd, *args, **kwargs):
+        _write_gdunit_xml_from_cmd(cmd, xml)
+        return _make_proc(
+            stdout="line 21: WARNING:: Found 4 possible orphan nodes.\n",
+            returncode=101,
+        )
+
+    with patch.object(run_verify.subprocess, "run", side_effect=fake_run):
+        result, note = run_verify.check_unit_tests("/usr/bin/godot", Path("/x"))
+
+    assert result == {
+        "result": "warn",
+        "passed": 76,
+        "failed": 0,
+        "failures": [],
+        "warnings": ["Found 4 possible orphan nodes."],
+    }
+    assert note is None
+
+
 def test_check_unit_tests_xml_suite_errors_count_as_failed():
     xml = """<?xml version="1.0" encoding="UTF-8"?>
 <testsuites name="report_1" tests="3" failures="0" skipped="0">

--- a/tools/run_verify.py
+++ b/tools/run_verify.py
@@ -173,6 +173,21 @@ _GDUNIT_FAILURE = re.compile(
     r"^\s*FAILED:\s*(.+?)\s+-\s+(.+)$",
     re.MULTILINE,
 )
+_GDUNIT_ORPHAN_WARNING = re.compile(
+    r"Found\s+\d+\s+possible\s+orphan\s+nodes?\.?",
+    re.IGNORECASE,
+)
+
+
+def _gdunit_warning_messages(combined: str, returncode: int) -> list[str]:
+    warnings: list[str] = []
+    for match in _GDUNIT_ORPHAN_WARNING.finditer(combined):
+        warning = match.group(0).strip()
+        if warning not in warnings:
+            warnings.append(warning)
+    if returncode == 101 and not warnings:
+        warnings.append("gdUnit exited with warning code 101")
+    return warnings
 
 
 def _int_attr(element: ET.Element, name: str) -> int:
@@ -275,6 +290,15 @@ def _parse_gdunit_stdout(combined: str, returncode: int) -> dict | None:
             "message": fm.group(2).strip(),
         })
 
+    if returncode == 101 and failed_count == 0:
+        return {
+            "result": "warn",
+            "passed": passed_count,
+            "failed": 0,
+            "failures": [],
+            "warnings": _gdunit_warning_messages(combined, returncode),
+        }
+
     if returncode != 0 and failed_count == 0:
         failed_count = 1
         failures.append({
@@ -325,6 +349,7 @@ def check_unit_tests(godot_path: str, project_dir: Path
                 ),
             )
 
+        combined = (proc.stdout or "") + (proc.stderr or "")
         results_xml = _find_gdunit_results_xml(report_path)
         if results_xml:
             try:
@@ -339,6 +364,13 @@ def check_unit_tests(godot_path: str, project_dir: Path
                     ),
                 )
             if proc.returncode != 0 and parsed_xml["result"] == "pass":
+                if proc.returncode == 101:
+                    parsed_xml["result"] = "warn"
+                    parsed_xml["warnings"] = _gdunit_warning_messages(
+                        combined,
+                        proc.returncode,
+                    )
+                    return (parsed_xml, None)
                 if proc.returncode == 100:
                     parsed_xml["result"] = "fail"
                     parsed_xml["failed"] = 1
@@ -363,7 +395,6 @@ def check_unit_tests(godot_path: str, project_dir: Path
                 )
             return (parsed_xml, None)
 
-        combined = (proc.stdout or "") + (proc.stderr or "")
         parsed = _parse_gdunit_stdout(combined, proc.returncode)
         if parsed:
             return (parsed, None)


### PR DESCRIPTION
## Summary

Fix verify-to-build retry handling so a newer failing verify report is consumed before `/gm-build` treats the current tag as already complete.

## Motivation

A verify failure after a completed build wrote `.godotmaker/verify_report.json` without a new stage event, but `/gm-build` could stop early because the last stage event was still `build` and all PLAN tasks were verified.

## Changes

- [x] Let `gm-build` treat pending verify feedback as higher priority than the completed-build resume stop.
- [x] Treat gdUnit exit code 101 as a warning when the XML report shows every assertion passed.
- [x] Extend verify report validation fixtures and tests for `unit_tests: warn`.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
  - `python -m pytest -q`
  - `818 passed in 37.45s`
- [x] Gitleaks passes or no secret-bearing files were touched
  - `gitleaks detect --source . --config .gitleaks.toml`
  - `no leaks found`
- [x] Manual testing completed, if applicable
  - Not applicable; behavior is covered by skill text regression tests and `run_verify.py` unit tests.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If Yes: run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: executed`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

No migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
  - Not applicable; no ECS files changed.
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR