### PR TITLE
feat: add visual asset contracts

### DIFF
--- a/agents/decomposer.md
+++ b/agents/decomposer.md
@@ -12,8 +12,8 @@ The lead does NOT want to see the file content come back. Your report is a short
 
 ## Absolute Prohibitions
 
-- Do NOT write game code (`.gd`, `.tscn`, `.tres`). That is `/gm-build`'s job.
-- Do NOT write to `assets/`. That is `/gm-asset`'s job.
+- Do NOT write game code (`.gd`, `.tscn`, `.tres`).
+- Do NOT write to `assets/`.
 - Do NOT spawn sub-agents.
 - Do NOT modify `GDD.md` — it is already confirmed by the user.
 - Do NOT modify `ROADMAP.md` — it is already confirmed by the user.
@@ -81,6 +81,7 @@ Required structure (matches the template):
 - **Main Build (M01, M02, ...):** convert game mechanics + entities + cross-tag refactor hints into mechanic-function build tasks per the template structure. Add normal M-series tasks for player-facing state, feedback, and presentation needed to play the current tag.
   - Subsequent mode with `Cross-Tag Refactor Hints`: turn each hint into one or more concrete tasks. E.g. `M03 — Refactor LevelUpCardPool into TalentTree (replaces v0.2.0 cardpool per superseded design)`.
 - **Playable Unit:** describe the game content the player can experience after this tag ships. For each mechanic, state the player operation or content, expected effect, required visible content, and evidence.
+- **Runtime Asset Assignments:** fill one row for every current-tag task or mechanic that produces player-visible content. Use `not required this tag` only with a deferral reason.
 - If the current ROADMAP entry cannot form a playable unit, report `failed` and state that ROADMAP.md needs a playable-unit tag.
 - All tasks in the Task Status table start as `pending`.
 
@@ -99,6 +100,8 @@ Run this step only when `ASSETS.md` is in `Owned Files`, or when no `Work Packag
 
 If this is `scene-asset-package`, read finalized PLAN.md first and use its
 `Assets Needed` / task-to-asset mapping as the source of truth.
+If PLAN.md lacks a needed Runtime Asset Assignment, report it under
+`Open TODOs / Deferred`; do not invent a new mapping in ASSETS.md.
 
 Follow the rules in `.claude/templates/ASSETS.md` (the file's own contract). Operationally:
 
@@ -113,6 +116,8 @@ If this is `scene-asset-package`, read finalized PLAN.md first. Use its Tag
 Mechanics, Inherited Mechanics, task IDs, affected scenes, and asset mappings as
 the only cross-reference source; do not guess task IDs or mechanic IDs from GDD
 alone.
+Copy the relevant PLAN Runtime Asset Assignments into each scene's `Asset
+bindings`. Use `not required this tag` only with a deferral reason.
 
 SCENES.md is an **end-of-tag snapshot** (same model as STRUCTURE.md) — overwrite root from `.claude/templates/SCENES.md` in both modes. After this step the file lists every scene that exists in the game as of this tag, so `/gm-evaluate`'s per-scene visual cross-check covers inherited scenes too.
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -21,6 +21,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Changed
 
+- Current-tag visual assets now carry runtime size, usage, and readability contracts through planning, asset generation, build, fixgap, and evaluation.
+
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.

--- a/migrations/20260528004107_visual_asset_contract.py
+++ b/migrations/20260528004107_visual_asset_contract.py
@@ -1,0 +1,133 @@
+"""Add visual asset contract sections to project docs."""
+import re
+from pathlib import Path
+
+
+ASSETS_SECTION = """## Visual Asset Contract
+
+<!-- Runtime contract for visible assets. Each gameplay-visible object, UI
+     element, and scene reference should map to an ASSETS.md row or to
+     `procedural`, `UI text`, or `not required this tag`.
+     Use `asset_name / assets/...` for concrete asset bindings.
+     `not required this tag` needs a deferral reason in Readability Requirement. -->
+
+| Tag | Scene / Mechanic | Visible Object | Asset Row / Path | Runtime Size | Visual Role | Readability Requirement | Source |
+|-----|------------------|----------------|------------------|--------------|-------------|-------------------------|--------|
+"""
+
+PLAN_SECTION = """### Runtime Asset Assignments
+
+<!-- Bind player-facing tasks to concrete assets or explicit procedural/UI
+     outputs. Use `asset_name / assets/...` for concrete assets, or
+     `procedural`, `UI text`, or `not required this tag`. `not required this tag`
+     needs a deferral reason in Verification. Asset names and paths should match
+     ASSETS.md and SCENES.md. -->
+
+| Task / Mechanic | Visible Content | Asset Row / Path | Runtime Size | Verification |
+|-----------------|-----------------|------------------|--------------|--------------|
+"""
+
+SCENE_SECTION = """### Asset bindings
+
+<!-- Bind each gameplay-visible object and non-text UI element to ASSETS.md.
+     Use `asset_name / assets/...` for concrete assets, or `procedural`,
+     `UI text`, or `not required this tag` when no runtime image/model asset is
+     required for this tag. `not required this tag` needs a deferral reason in
+     Visual Contract. -->
+
+| Element | Asset Row / Path | Runtime Size | Visual Contract |
+|---------|------------------|--------------|-----------------|
+"""
+
+
+def _insert_after_asset_table(text: str) -> str:
+    asset_table = re.search(r"(?m)^## Asset Table\s*$", text)
+    if asset_table:
+        next_h2 = re.search(r"(?m)^## (?!Asset Table\s*$).+", text[asset_table.end():])
+        if next_h2:
+            insert_at = asset_table.end() + next_h2.start()
+            return text[:insert_at].rstrip() + f"\n\n{ASSETS_SECTION}\n" + text[insert_at:].lstrip()
+    return text.rstrip() + f"\n\n{ASSETS_SECTION}"
+
+
+def _insert_runtime_asset_assignments(text: str) -> str:
+    if "### Runtime Asset Assignments" in text:
+        return text
+
+    main_build = re.search(r"(?m)^## Main Build\s*$", text)
+    if main_build:
+        next_h2 = re.search(r"(?m)^## (?!Main Build\s*$).+", text[main_build.end():])
+        end = main_build.end() + next_h2.start() if next_h2 else len(text)
+        section = text[main_build.start():end]
+        verify = re.search(r"(?m)^### Verify\s*$", section)
+        if verify:
+            insert_at = main_build.start() + verify.start()
+            return text[:insert_at].rstrip() + f"\n\n{PLAN_SECTION}\n" + text[insert_at:].lstrip()
+        return text[:end].rstrip() + f"\n\n{PLAN_SECTION}\n" + text[end:].lstrip()
+
+    return text.rstrip() + f"\n\n{PLAN_SECTION}"
+
+
+def _insert_scene_asset_bindings(text: str) -> str:
+    matches = list(re.finditer(r"(?m)^## Scene: .*$", text))
+    if not matches:
+        return text
+
+    pieces = [text[:matches[0].start()]]
+    for index, match in enumerate(matches):
+        start = match.start()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        chunk = text[start:end]
+        if "### Asset bindings" in chunk:
+            pieces.append(chunk)
+            continue
+        marker = "\n### Acceptance criteria"
+        if marker in chunk:
+            chunk = chunk.replace(marker, f"\n{SCENE_SECTION}\n{marker.lstrip()}", 1)
+        else:
+            chunk = chunk.rstrip() + f"\n\n{SCENE_SECTION}\n\n"
+        pieces.append(chunk)
+
+    return "".join(pieces)
+
+
+def migrate(target: Path) -> None:
+    """target is the absolute path to the game project root.
+
+    Scripts MUST be idempotent: re-runs after a partial failure must
+    not corrupt state. Raise an exception to abort the migration chain.
+    """
+    changed = False
+
+    assets_path = target / "ASSETS.md"
+    if not assets_path.exists():
+        print("ASSETS.md missing; skipping Visual Asset Contract migration")
+    else:
+        text = assets_path.read_text(encoding="utf-8")
+        if "## Visual Asset Contract" in text:
+            print("ASSETS.md already has Visual Asset Contract")
+        else:
+            assets_path.write_text(_insert_after_asset_table(text), encoding="utf-8")
+            print("Added Visual Asset Contract to ASSETS.md")
+            changed = True
+
+    plan_path = target / "PLAN.md"
+    if plan_path.exists():
+        text = plan_path.read_text(encoding="utf-8")
+        updated = _insert_runtime_asset_assignments(text)
+        if updated != text:
+            plan_path.write_text(updated, encoding="utf-8")
+            print("Added Runtime Asset Assignments to PLAN.md")
+            changed = True
+
+    scenes_path = target / "SCENES.md"
+    if scenes_path.exists():
+        text = scenes_path.read_text(encoding="utf-8")
+        updated = _insert_scene_asset_bindings(text)
+        if updated != text:
+            scenes_path.write_text(updated, encoding="utf-8")
+            print("Added Asset bindings to SCENES.md")
+            changed = True
+
+    if not changed:
+        print("Visual asset contract sections already present or not applicable")

--- a/skills/core/_shared/verifier-dispatch.md
+++ b/skills/core/_shared/verifier-dispatch.md
@@ -36,6 +36,13 @@ Agent({
 - [ ] Unit tests: all pass
 - [ ] {additional specific criteria}
 
+### Visual Verification                                  [REQUIRED for visual tasks]
+- Scene/reference/capture paths: {visual_checks scene, reference, captures[], and latest vqa_calls[].files from evaluation.json}
+- Visual-qa context: {latest vqa_calls[].context or scene Acceptance criteria}
+- Asset contract rows: {relevant SCENES.md Asset bindings and ASSETS.md Visual Asset Contract rows}
+- VQA log: {visual_checks.<scene>.vqa_log or latest vqa_calls[].log}
+- Required result: {pass, warning, or explicit non-blocking notes}
+
 ### Negative Tests                                       [OPTIONAL]
 - [ ] {input that should fail and how}
 

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -66,6 +66,12 @@ Agent({
 ### Assets Available                                     [OPTIONAL]
 {Asset paths and descriptions}
 
+### Visual Asset Contract                                [REQUIRED for visual tasks]
+{Copy the relevant PLAN.md Runtime Asset Assignments, SCENES.md Asset
+ bindings, and ASSETS.md Visual Asset Contract rows.
+ Include: asset row/path, runtime size, visual role, readability requirement,
+ and anchor/derivative source.}
+
 ### Scene Layout Reference                                [REQUIRED for UI/scene tasks]
 {Copy the relevant scene description from SCENES.md here.
  Include: element positions, sizes, layout type, mood.
@@ -91,6 +97,7 @@ Agent({
 14. **Worker model from config.** Read `worker_model` from `.godotmaker/config.yaml` (default: `sonnet`) and include it as `model:` in every Agent() call. See the Agent Call template at the top.
 15. **Cwd-relative paths in the brief.** Fill every `{path}` placeholder as cwd-relative (e.g. `src/systems/s_jump.gd`, not `D:/.../src/systems/s_jump.gd`).
 16. **Non-interactive execution.** Every worker brief MUST prohibit approval requests, user-input waits, and confirmation pauses.
+17. **Visual tasks require asset contract rows.** Fill the `Visual Asset Contract` section for visual tasks.
 
 ## Worker Utility Convention
 

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -34,7 +34,7 @@ Asset is re-runnable per tag, so the gate is the current state of `ASSETS.md` pl
 - If `PLAN.md` is missing the `**Tag:**` header → STOP. Tell user the file is stale and to re-run `/gm-gdd` to regenerate it for the current tag.
 - Build two work-pending checks for the current tag:
   1. **ASSETS.md gap:** any current-tag row in the Asset Table whose status is `MISSING` (i.e. not `provided` / `generated` / `N/A` / `deferred`).
-  2. **Scene-reference gap:** any scene listed in `SCENES.md` for the current tag whose `references/scene_{name}.png` is absent on disk.
+  2. **Scene-reference gap:** any scene listed in `SCENES.md` for the current tag whose `references/scene_{name}.png` is absent on disk, whose scene-reference report is missing, or whose report contract summary no longer matches the scene's Asset bindings / matching Visual Asset Contract rows.
 - If **both** checks come back empty → STOP. Tell the user:
   > "No MISSING assets and no missing scene references for the current tag. Recommended next: /gm-build.
   > If you've added new art files or scenes since last run, just tell me and I'll re-scan."
@@ -100,6 +100,7 @@ plan a fixed source path, final path, and report path:
   "group_id": "scene_refs_001",
   "kind": "scene_reference",
   "provider": "<asset_image_model>",
+  "contract_summary": "<SCENES.md Asset bindings + ASSETS.md Visual Asset Contract rows used>",
   "anchor_item": {
     "asset_id": "scene_main",
     "prompt": "<prompt>",
@@ -126,13 +127,13 @@ sequentially and write the fallback reason in the report and summary.
 For each missing scene:
 
 1. Read `references/visual-target.md`.
-2. Build the prompt for this scene using inputs from `SCENES.md` (Elements + Mood) + `STYLE.md` + `GDD.md` section 4. If the user provided art in `assets/`, also reference the analyst's style summary from `assets/manifest.json`.
+2. Build the prompt for this scene using inputs from `SCENES.md` (Elements + Mood + Asset bindings) + matching ASSETS.md Visual Asset Contract rows + `STYLE.md` + `GDD.md` section 4. If the user provided art in `assets/`, also reference the analyst's style summary from `assets/manifest.json`.
 3. Generate the scene image using the selected `asset_image_model` path:
    - API-backed selector: run `python tools/asset_gen.py image --model <asset_image_model> --prompt "..." --size 1K --aspect-ratio 16:9 -o references/scene_{name}.png`.
    - Active Codex runtime with `asset_image_model: native` or `asset_image_model: codex`: follow `references/asset-gen.md` Active Codex runtime batch for this scene.
    - Claude Code with `asset_image_model: codex`: follow `references/asset-gen.md` Codex handoff from Claude Code for this scene.
    - Other runtime-native provider: generate a source image path, then run `python tools/asset_image_finalize.py --source <generated_image_path> --out references/scene_{name}.png --label scene_{name}`.
-4. Write the scene's flat finalize JSON entry to the scene-reference generation report.
+4. Write the scene's flat finalize JSON entry and contract summary to the scene-reference generation report.
 5. Show the result to the user. If rejected, regenerate with a tightened prompt (per `references/visual-target.md`).
 
 ### Step 4 — Generate Remaining MISSING Art
@@ -188,6 +189,10 @@ After all generation calls return:
 - Re-dispatch one follow-up batch for missing or invalid generated images
 - Verify total MISSING count for the current tag is zero (or all remaining are deferred audio with user OK)
 - New rows added this tag must carry the current tag in their `Tag` column
+- Update `ASSETS.md` Visual Asset Contract for generated or provided visual
+  assets. Bind each gameplay-visible object to its scene/mechanic use,
+  runtime size, visual role, readability requirement, and anchor/derivative
+  source.
 
 ## Plan Discipline
 

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -154,6 +154,25 @@ table schema and include:
 
 Audio rows remain `deferred` unless the user provides files.
 
+Update `ASSETS.md` Visual Asset Contract for each current-tag visual asset:
+
+1. `Scene / Mechanic`: every scene and mechanic that must show the asset.
+2. `Visible Object`: the object or UI element name used in SCENES.md.
+3. `Asset Row / Path`: `asset_name / assets/...` for a concrete ASSETS.md
+   row and final path, or `procedural`, `UI text`, or
+   `not required this tag` with a deferral reason.
+4. `Runtime Size`: the intended display size in pixels, viewport percentage,
+   or world units.
+5. `Visual Role`: player, enemy, projectile, pickup, prop, background, HUD,
+   overlay, VFX, or other concrete role.
+6. `Readability Requirement`: the screenshot or frame-sequence condition that
+   makes the asset acceptable in play.
+7. `Source`: `anchor`, `derivative of <asset>`, `scene reference`,
+   `user-provided`, or `procedural/UI`.
+
+For small sprites, write the minimum readable display size and the contrast or
+silhouette requirement. For derivative assets, name the anchor asset.
+
 ## Asset Type Rules
 
 ### Background

--- a/skills/core/gm-asset/references/visual-target.md
+++ b/skills/core/gm-asset/references/visual-target.md
@@ -36,6 +36,8 @@ Visual style: {STYLE.md Style Anchor + Prompt Suffix}. Apply STYLE.md UI / Asset
 ## Inputs
 
 For each scene, gather from the planning docs:
+- **Asset bindings**: the scene's `Asset bindings` rows plus matching
+  `ASSETS.md` Visual Asset Contract rows
 - **Elements + Mood** → `SCENES.md` (the per-scene section)
 - **Visual style** → `STYLE.md` Style Anchor, Prompt Suffix, UI / Asset Rules, Avoid, and `GDD.md` §4
 - **Style anchors** → if the user supplied art in `assets/`, reference those files explicitly via the analyst's `assets/manifest.json` style summary

--- a/skills/core/gm-build/SKILL.md
+++ b/skills/core/gm-build/SKILL.md
@@ -116,6 +116,7 @@ Do NOT delete project code as a "fix" for a tool crash.
 - Read `references/worker-dispatch.md` for the brief template
 - Use `subagent_type: "worker"`. Each worker implements ONE game mechanic function + its tests.
 - Include the relevant Playable Unit fields in each worker brief.
+- For visual tasks, fill the `Visual Asset Contract` section from `references/worker-dispatch.md`.
 - Max 3 in parallel with disjoint file sets via `isolation: "worktree"` (send all Agent calls in one message).
 - After each worker reports DONE, mark its task in PLAN.md as `completed`.
 - **`main_scene` retarget is your job.** Scaffold leaves `run/main_scene="res://scenes/main.tscn"` (placeholder). After the worker that creates this tag's entry scene (per SCENES.md) completes and the `.tscn` is on disk, `Edit` `project.godot`'s `[application] run/main_scene` to `res://<path>`.

--- a/skills/core/gm-evaluate/SKILL.md
+++ b/skills/core/gm-evaluate/SKILL.md
@@ -108,19 +108,40 @@ All of these must pass for `result == "approve"`. Failure of any is a `critical_
 
    **Precondition — reference must exist.** Before calling visual-qa, confirm `references/scene_{name}.png` exists. If missing → record `critical_issue: "missing reference for scene_{name}"` and skip the visual-qa call for this scene. Do NOT degrade to Question mode against the screenshot alone.
 
-   **Context construction.** Pull the `Acceptance criteria` block from SCENES.md for this scene; paste it verbatim into the `Verify:` field. If the block is absent, fall back to the mechanic ids from PLAN.md Tag Mechanics + Inherited Mechanics that this scene exercises, each with its one-line description. Never leave `Requirements:` or `Verify:` as a placeholder. For deterministic setup screenshots, add `Visible state only; do not infer prior play history.` to `Verify:`.
+   **Visual binding preflight.** Before calling visual-qa, check the scene's
+   `Asset bindings` rows. Each non-`procedural` / non-`UI text` /
+   non-`not required this tag` binding must have:
+   - a concrete `asset_name / path` value;
+   - a matching ASSETS.md Asset Table row;
+   - a matching ASSETS.md Visual Asset Contract row;
+   - a non-empty Runtime Size;
+   - an existing file when the row status means the asset should be on disk.
+
+   If the scene has no `Asset bindings` section or ASSETS.md has no Visual
+   Asset Contract section, record `missing visual contract for <scene>` in
+   `major_issues`, then continue VQA with the scene Acceptance criteria and
+   mechanic fallback context. If the sections exist but a current-tag binding is
+   incomplete, record a `critical_issue`, set this scene's
+   `visual_checks.<scene>.result` to `"fail"`, note the exact missing binding in
+   `visual_checks.<scene>.notes`, and skip visual-qa for that scene.
+
+   For `not required this tag`, require a deferral reason in the Visual Contract
+   or Readability Requirement text. Missing deferral reasons are incomplete
+   bindings.
+
+   **Context construction.** Pull the `Acceptance criteria` block from SCENES.md for this scene; paste it verbatim into the `Verify:` field. Add the scene's `Asset bindings` rows and matching ASSETS.md Visual Asset Contract rows to `Requirements:`. If the block is absent, fall back to the mechanic ids from PLAN.md Tag Mechanics + Inherited Mechanics that this scene exercises, each with its one-line description. Never leave `Requirements:` or `Verify:` as a placeholder. For deterministic setup screenshots, add `Visible state only; do not infer prior play history.` to `Verify:`.
 
    **VQA log path.** Ask `visual-qa` to write its debug log to `e2e/screenshots/vqa.log`.
 
    ```
    # Static scene — dispatch a subagent to run visual-qa with:
-   "Check references/scene_{name}.png against e2e/screenshots/scene_{name}.png --log e2e/screenshots/vqa.log — Goal: {scene goal from SCENES.md}, Requirements: {key elements + layout}, Verify: {acceptance criteria block, or mechanic-id list fallback}."
+   "Check references/scene_{name}.png against e2e/screenshots/scene_{name}.png --log e2e/screenshots/vqa.log — Goal: {scene goal from SCENES.md}, Requirements: {SCENES.md Asset bindings + matching ASSETS.md Visual Asset Contract rows}, Verify: {acceptance criteria block, or mechanic-id list fallback}."
 
    # Dynamic scene (frame sequence in per-scene subdir) — dispatch a subagent to run visual-qa with:
-   "Check references/scene_{name}.png against e2e/screenshots/scene_{name}/frame_*.png --log e2e/screenshots/vqa.log — Goal: ..., Requirements: ..., Verify: motion is fluid, no stuck entities, animation matches movement."
+   "Check references/scene_{name}.png against e2e/screenshots/scene_{name}/frame_*.png --log e2e/screenshots/vqa.log — Goal: ..., Requirements: {SCENES.md Asset bindings + matching ASSETS.md Visual Asset Contract rows}, Verify: motion is fluid, no stuck entities, animation matches movement."
    ```
 
-   **Audit trail.** Record every visual-qa call (verdict + context + mode + output digest) in `visual_checks.{scene_name}.vqa_calls[]` (schema below). If you override a recorded verdict for the final `result` — for instance you read the PNGs yourself and disagree — write the reason and what you saw into `visual_checks.{scene_name}.notes`. Either way, `result` reflects the chain transparently.
+   **Audit trail.** Record every visual-qa call (verdict + context + mode + files + log path + output digest) in `visual_checks.{scene_name}.vqa_calls[]` (schema below). Also record the screenshot/frame paths used in `visual_checks.{scene_name}.captures[]`. If you override a recorded verdict for the final `result` — for instance you read the PNGs yourself and disagree — write the reason and what you saw into `visual_checks.{scene_name}.notes`. Either way, `result` reflects the chain transparently.
 
    **Real invocation required.** Every `vqa_calls` entry and every `vqa.log` line must come from a visual-qa invocation — do not author them directly. If the invocation errors or its backend is unavailable, record a `critical_issue` and set `result: reject`.
 
@@ -187,7 +208,9 @@ Write evaluation results to `.godotmaker/evaluation.json`:
   "visual_checks": {
     "<scene_name>": {
       "screenshot": "e2e/screenshots/scene_<name>.png",
+      "captures": ["e2e/screenshots/scene_<name>.png"],
       "reference": "references/scene_<name>.png",
+      "vqa_log": "e2e/screenshots/vqa.log",
       "result": "pass | fail | warning",
       "notes": "",
       "vqa_calls": [
@@ -196,6 +219,8 @@ Write evaluation results to `.godotmaker/evaluation.json`:
           "mode": "static | dynamic | question",
           "backend": "native | codex | gemini | openai",
           "model": "<vqa_model or fallback selector used>",
+          "files": ["references/scene_<name>.png", "e2e/screenshots/scene_<name>.png"],
+          "log": "e2e/screenshots/vqa.log",
           "context": "Goal: ... Requirements: ... Verify: ...",
           "verdict": "pass | fail | warning",
           "output_summary": "<first line or 1-sentence digest of the visual-qa response>"

--- a/skills/core/gm-fixgap/SKILL.md
+++ b/skills/core/gm-fixgap/SKILL.md
@@ -164,6 +164,8 @@ after **all** GAP.md tasks reach `completed`.
 **Verifier:**
 - Read `references/verifier-dispatch.md` for the brief template
 - Use `subagent_type: "verifier"`. Pass all completed workers' deliverables.
+- For evaluation-source visual tasks, fill the `Visual Verification` section
+  from `references/verifier-dispatch.md`.
 - A new FAIL task must cite an unresolved blocking finding or a blocking regression.
 - On FAIL for a task: add a NEW pending task in GAP.md (the failed task stays `completed`). Loop back to Step 3.
 - On PASS: update those tasks from `completed` → `verified`.

--- a/skills/core/gm-gdd/SKILL.md
+++ b/skills/core/gm-gdd/SKILL.md
@@ -141,6 +141,7 @@ directly if needed. PLAN.md must be stable before Phase B starts:
 - [ ] Playable Unit section is populated and references existing mechanic ids
 - [ ] Playable Unit describes player experience, unit outcome, scenes involved, and per-mechanic player operation / effect / visible evidence
 - [ ] PLAN covers the player-facing state, feedback, and presentation needed to play the current tag normally
+- [ ] PLAN Runtime Asset Assignments binds required visible content to ASSETS.md rows, procedural output, UI text, or `not required this tag` with a deferral reason
 - [ ] Risk/Main tasks have stable task IDs and all Task Status rows start as `pending`
 - [ ] Tasks list affected systems/scenes/assets clearly enough for downstream artifacts
 
@@ -240,10 +241,12 @@ The decomposer overwrites root `PLAN.md`, `STRUCTURE.md`, `SCENES.md` with the c
 - [ ] `SCENES.md` exists with `**Tag:**` header, scoped to this tag
 - [ ] `STYLE.md` exists
 - [ ] `ASSETS.md` exists and any new rows are tagged correctly (per `templates/ASSETS.md` and `gm-asset/SKILL.md`)
+- [ ] `ASSETS.md` Visual Asset Contract covers current-tag gameplay-visible objects with runtime size, scene/mechanic use, readability requirement, and source relationship
 - [ ] `TOC.md` updated (if decomposer touched it)
 - [ ] Parallel-only consistency check: PLAN task IDs referenced by STRUCTURE/SCENES/ASSETS exist in PLAN.md; every PLAN task's affected scene/system/asset appears in the corresponding artifact or is intentionally marked deferred.
 - [ ] Parallel-only mechanic ID check: every current-tag mechanic ID referenced by STRUCTURE/SCENES/ASSETS exists in final PLAN.md Tag Mechanics; no artifact references a guessed, renumbered, or stale current-tag mechanic ID.
 - [ ] Playable Unit scene check: every scene named in PLAN.md Playable Unit appears in SCENES.md, or PLAN.md marks it deferred.
+- [ ] Scene asset binding check: every SCENES.md gameplay object and non-text UI element binds to ASSETS.md, procedural output, UI text, or `not required this tag` with a deferral reason.
 
 **Fallback when subagent doesn't finish.** If any gate item is unmet (whether the decomposer reported failure or just produced incomplete artifacts), do NOT respawn the subagent — instead, take over directly. Read whichever artifacts exist, identify the missing pieces, and write them using the same templates the decomposer would have used. The templates document their structure conventions.
 

--- a/templates/ASSETS.md
+++ b/templates/ASSETS.md
@@ -27,6 +27,20 @@ Visual prompt language lives in `STYLE.md`.
 | 4 | v0.1.0 | background_sky | background | 1280x720 | {prompt or tool params} | assets/backgrounds/sky.png | pending |
 | ... | ... | ... | ... | ... | ... | ... | ... |
 
+## Visual Asset Contract
+
+<!-- Runtime contract for visible assets. Each gameplay-visible object, non-text
+     UI element, and scene reference should map to an ASSETS.md row or to
+     `procedural`, `UI text`, or `not required this tag`.
+     Use `asset_name / assets/...` for concrete asset bindings.
+     `not required this tag` needs a deferral reason in Readability Requirement. -->
+
+| Tag | Scene / Mechanic | Visible Object | Asset Row / Path | Runtime Size | Visual Role | Readability Requirement | Source |
+|-----|------------------|----------------|------------------|--------------|-------------|-------------------------|--------|
+| v0.1.0 | Gameplay / [v0.1.0-M1] | player character | player_idle / assets/sprites/player_idle.png | 32x32 px on screen | controllable player | readable silhouette against gameplay background | anchor |
+| v0.1.0 | Gameplay / [v0.1.0-M2] | enemy_basic | enemy_basic / assets/sprites/enemy_basic.png | 32x32 px on screen | enemy pressure | readable in normal gameplay captures | derivative of player/style anchor |
+| v0.1.0 | Main Menu | title text | UI text | viewport-relative | menu identity | readable at target resolution | procedural/UI |
+
 ## Animated Sprites
 
 <!-- Spritesheet breakdown for animated assets. -->

--- a/templates/PLAN.md
+++ b/templates/PLAN.md
@@ -101,6 +101,18 @@ the player-facing state, feedback, and presentation needed to play this tag.}
 - {asset description}
 - **Terrain approach:** Sprite placement (individual scene elements) | N/A
 
+### Runtime Asset Assignments
+
+<!-- Bind player-facing tasks to concrete assets or explicit procedural/UI
+     outputs. Use `asset_name / assets/...` for concrete assets, or
+     `procedural`, `UI text`, or `not required this tag`. `not required this tag`
+     needs a deferral reason in Verification. Asset names and paths should match
+     ASSETS.md and SCENES.md. -->
+
+| Task / Mechanic | Visible Content | Asset Row / Path | Runtime Size | Verification |
+|-----------------|-----------------|------------------|--------------|--------------|
+| M01 / [{Tag}-M1] | {player-facing object or UI} | {asset row/path, procedural, or UI text} | {px, %, or world units} | {screenshot, frame sequence, or E2E assertion} |
+
 ### Verify
 
 - Player input -> entity response feels correct

--- a/templates/SCENES.md
+++ b/templates/SCENES.md
@@ -26,6 +26,18 @@
 |---------|----------|------|-------------|
 | {element name} | {top-center, bottom-left, center, etc.} | {width% × height%} | {what it is and looks like} |
 
+### Asset bindings
+
+<!-- Bind each gameplay-visible object and non-text UI element to ASSETS.md.
+     Use `asset_name / assets/...` for concrete assets, or `procedural`,
+     `UI text`, or `not required this tag` when no runtime image/model asset is
+     required for this tag. `not required this tag` needs a deferral reason in
+     Visual Contract. -->
+
+| Element | Asset Row / Path | Runtime Size | Visual Contract |
+|---------|------------------|--------------|-----------------|
+| {element name} | {asset name / path, procedural, or UI text} | {px, %, or world units} | {readability, animation, or state requirement} |
+
 ### Acceptance criteria
 
 <!-- Observable facts to mark PASS/FAIL from the spawn-state screenshot

--- a/tests/test_playable_unit_contract_docs.py
+++ b/tests/test_playable_unit_contract_docs.py
@@ -84,6 +84,29 @@ def test_build_and_reviewer_check_playable_unit_authenticity():
     assert "Tests avoid gameplay-bypassing shortcuts" in reviewer
 
 
+def test_visual_asset_contract_flows_through_build_and_evaluate():
+    plan = _read("templates/PLAN.md")
+    scenes = _read("templates/SCENES.md")
+    assets = _read("templates/ASSETS.md")
+    decomposer = _read("agents/decomposer.md")
+    dispatch = _read("skills/core/_shared/worker-dispatch.md")
+    build = _read("skills/core/gm-build/SKILL.md")
+    evaluate = _read("skills/core/gm-evaluate/SKILL.md")
+    fixgap = _read("skills/core/gm-fixgap/SKILL.md")
+
+    assert "Runtime Asset Assignments" in plan
+    assert "Asset bindings" in scenes
+    assert "Visual Asset Contract" in assets
+    assert "Runtime Asset Assignments" in decomposer
+    assert "Visual Asset Contract` section" in build
+    assert "PLAN.md Runtime Asset Assignments" in dispatch
+    assert "SCENES.md Asset" in dispatch
+    assert "ASSETS.md Visual Asset Contract" in dispatch
+    assert "Visual binding preflight" in evaluate
+    assert "captures[]" in evaluate
+    assert "Visual Verification` section" in fixgap
+
+
 def test_evaluate_requires_runtime_playable_unit_proof():
     evaluate = _read("skills/core/gm-evaluate/SKILL.md")
     schema = _read("config/stage_schemas.json")

--- a/tests/tools/test_migration_visual_asset_contract.py
+++ b/tests/tools/test_migration_visual_asset_contract.py
@@ -1,0 +1,159 @@
+from importlib import import_module
+
+
+migration = import_module("migrations.20260528004107_visual_asset_contract")
+
+
+def test_adds_visual_asset_contract_after_asset_table(tmp_path):
+    assets = tmp_path / "ASSETS.md"
+    assets.write_text(
+        "# Assets\n\n"
+        "## Asset Table\n\n"
+        "| # | Tag | Name | Type | Size | Generation Params | File Path | Status |\n"
+        "|---|-----|------|------|------|-------------------|-----------|--------|\n"
+        "| 1 | v0.1.0 | player | sprite | 32x32 | prompt | assets/player.png | generated |\n\n"
+        "## Animated Sprites\n",
+        encoding="utf-8",
+    )
+
+    migration.migrate(tmp_path)
+
+    text = assets.read_text(encoding="utf-8")
+    assert "## Visual Asset Contract" in text
+    assert text.index("## Asset Table") < text.index("## Visual Asset Contract")
+    assert text.index("## Visual Asset Contract") < text.index("## Animated Sprites")
+
+
+def test_visual_asset_contract_migration_is_idempotent(tmp_path):
+    assets = tmp_path / "ASSETS.md"
+    plan = tmp_path / "PLAN.md"
+    scenes = tmp_path / "SCENES.md"
+    assets.write_text(
+        "# Assets\n\n"
+        "## Asset Table\n\n"
+        "| # | Tag | Name | Type | Size | Generation Params | File Path | Status |\n"
+        "|---|-----|------|------|------|-------------------|-----------|--------|\n\n"
+        "## Visual Asset Contract\n\n"
+        "| Tag | Scene / Mechanic | Visible Object | Asset Row / Path | Runtime Size | Visual Role | Readability Requirement | Source |\n"
+        "|-----|------------------|----------------|------------------|--------------|-------------|-------------------------|--------|\n",
+        encoding="utf-8",
+    )
+    plan.write_text(
+        "# Plan\n\n## Main Build\n\n### Runtime Asset Assignments\n\n"
+        "| Task / Mechanic | Visible Content | Asset Row / Path | Runtime Size | Verification |\n"
+        "|-----------------|-----------------|------------------|--------------|--------------|\n",
+        encoding="utf-8",
+    )
+    scenes.write_text(
+        "# Scenes\n\n## Scene: Gameplay\n\n### Asset bindings\n\n"
+        "| Element | Asset Row / Path | Runtime Size | Visual Contract |\n"
+        "|---------|------------------|--------------|-----------------|\n",
+        encoding="utf-8",
+    )
+
+    before = {
+        "assets": assets.read_text(encoding="utf-8"),
+        "plan": plan.read_text(encoding="utf-8"),
+        "scenes": scenes.read_text(encoding="utf-8"),
+    }
+    migration.migrate(tmp_path)
+
+    assert assets.read_text(encoding="utf-8") == before["assets"]
+    assert plan.read_text(encoding="utf-8") == before["plan"]
+    assert scenes.read_text(encoding="utf-8") == before["scenes"]
+
+
+def test_adds_runtime_asset_assignments_before_verify(tmp_path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    plan = tmp_path / "PLAN.md"
+    plan.write_text(
+        "# Plan\n\n"
+        "## Main Build\n\n"
+        "### Assets Needed\n\n"
+        "- player sprite\n\n"
+        "### Verify\n\n"
+        "- tests pass\n",
+        encoding="utf-8",
+    )
+
+    migration.migrate(tmp_path)
+
+    text = plan.read_text(encoding="utf-8")
+    assert "### Runtime Asset Assignments" in text
+    assert text.index("### Runtime Asset Assignments") < text.index("### Verify")
+    assert "asset_name / assets/..." in text
+
+
+def test_adds_runtime_asset_assignments_inside_main_build(tmp_path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    plan = tmp_path / "PLAN.md"
+    plan.write_text(
+        "# Plan\n\n"
+        "## Warmup\n\n"
+        "### Verify\n\n"
+        "- warmup check\n\n"
+        "## Main Build\n\n"
+        "### Build Tasks\n\n"
+        "| Task | Details |\n"
+        "|---|---|\n\n"
+        "### Verify\n\n"
+        "- build check\n\n"
+        "## Task Status\n\n",
+        encoding="utf-8",
+    )
+
+    migration.migrate(tmp_path)
+
+    text = plan.read_text(encoding="utf-8")
+    assert text.index("## Main Build") < text.index("### Runtime Asset Assignments")
+    assert text.index("### Runtime Asset Assignments") < text.index("## Task Status")
+
+
+def test_adds_asset_bindings_to_each_scene(tmp_path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    scenes = tmp_path / "SCENES.md"
+    scenes.write_text(
+        "# Scenes\n\n"
+        "## Scene: Gameplay\n\n"
+        "### Elements\n\n"
+        "| Element | Position | Size | Description |\n"
+        "|---|---|---|---|\n\n"
+        "### Acceptance criteria\n\n"
+        "- player visible\n\n"
+        "## Scene: Results\n\n"
+        "### Elements\n\n"
+        "- score text\n",
+        encoding="utf-8",
+    )
+
+    migration.migrate(tmp_path)
+
+    text = scenes.read_text(encoding="utf-8")
+    assert text.count("### Asset bindings") == 2
+    assert text.index("## Scene: Gameplay") < text.index("### Asset bindings") < text.index("### Acceptance criteria")
+    assert "`not required this tag`" in text
+
+
+def test_adds_asset_bindings_to_partially_migrated_scenes(tmp_path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    scenes = tmp_path / "SCENES.md"
+    scenes.write_text(
+        "# Scenes\n\n"
+        "## Scene: Gameplay\n\n"
+        "### Asset bindings\n\n"
+        "| Element | Asset Row / Path | Runtime Size | Visual Contract |\n"
+        "|---------|------------------|--------------|-----------------|\n\n"
+        "### Acceptance criteria\n\n"
+        "- player visible\n\n"
+        "## Scene: Results\n\n"
+        "### Elements\n\n"
+        "- score text\n",
+        encoding="utf-8",
+    )
+
+    migration.migrate(tmp_path)
+
+    text = scenes.read_text(encoding="utf-8")
+    assert text.count("### Asset bindings") == 2
+    gameplay = text.split("## Scene: Results", 1)[0]
+    assert gameplay.count("### Asset bindings") == 1


### PR DESCRIPTION
## Summary

Adds a Visual Asset Contract flow so current-tag visual assets carry runtime size, usage, readability, and scene binding information through planning, asset generation, build, evaluation, and fixgap.

## Motivation

Current asset/reference contracts can be too style-level: generated references may not bind concrete runtime objects, sizes, and readability requirements tightly enough for implementation and VQA to converge.

## Changes

- [x] Add Visual Asset Contract sections to ASSETS, PLAN, and SCENES templates.
- [x] Thread visual contract context through decomposer, asset, build, evaluate, fixgap, worker, and verifier prompts.
- [x] Add an idempotent migration for existing project docs.
- [x] Add tests for migration behavior and prompt contract coverage.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

```text
python -m pytest -q
825 passed in 38.82s

gitleaks detect --source . --config .gitleaks.toml
no leaks found

git diff --cached --check
pass
```

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [ ] **No** - no migration needed
- [x] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If Yes: run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: executed`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [x] Result attached or summarized below

Migration behavior was covered with pytest fixtures for insertion, idempotency, and partially migrated scene documents. I did not run a real previous-version project upgrade in this branch.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR