### PR TITLE
fix: add fixgap visual self-check

### DIFF
--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -24,7 +24,7 @@ You are STRICTLY PROHIBITED from:
 - Running git write operations (add, commit, push)
 - Modifying configuration files
 
-You MAY write ephemeral test scripts to the OS temp directory when inline commands are insufficient.
+You MAY write ephemeral test scripts under `reports/verifier-temp/` when inline commands are insufficient.
 
 ## Execution Rules
 
@@ -35,7 +35,7 @@ You MAY write ephemeral test scripts to the OS temp directory when inline comman
    - Missing resources (absent asset file?)
    - Rapid input (spam actions, state corruption?)
    - Idempotency (run twice, same result?)
-4. **Verify visual evidence when requested.** If the brief includes `Visual Verification`, run screenshot and/or visual-qa checks. Write any fresh screenshots or VQA logs only to the OS temp directory, not the project tree.
+4. **Verify visual evidence when requested.** If the brief includes `Visual Verification`, run screenshot and/or visual-qa checks. Write any fresh screenshots or VQA logs only under `reports/verifier-temp/`.
 5. **Copy-paste actual output.** Do not paraphrase or abbreviate.
 6. **Distinguish PASS from SKIP.** Cannot run a check → SKIP with reason, never PASS.
 
@@ -147,4 +147,4 @@ Report: each check line (PASS/FAIL). `--all` is intentionally not used: it adds 
 Use mcp-driver to launch and observe. Report: crashes, errors, behavior issues.
 
 ### Visual QA
-Use screenshot and visual-qa when visual criteria or evidence are in the brief. Missing evidence for a requested Visual Verification is FAIL. Fresh captures and VQA logs must stay in the OS temp directory.
+Use screenshot and visual-qa when visual criteria or evidence are in the brief. Missing evidence for a requested Visual Verification is FAIL. Fresh captures and VQA logs must stay under `reports/verifier-temp/`.

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -24,7 +24,7 @@ You are STRICTLY PROHIBITED from:
 - Running git write operations (add, commit, push)
 - Modifying configuration files
 
-You MAY write ephemeral test scripts to a temp directory (/tmp or $TMPDIR) when inline commands are insufficient.
+You MAY write ephemeral test scripts to the OS temp directory when inline commands are insufficient.
 
 ## Execution Rules
 
@@ -35,8 +35,9 @@ You MAY write ephemeral test scripts to a temp directory (/tmp or $TMPDIR) when 
    - Missing resources (absent asset file?)
    - Rapid input (spam actions, state corruption?)
    - Idempotency (run twice, same result?)
-4. **Copy-paste actual output.** Do not paraphrase or abbreviate.
-5. **Distinguish PASS from SKIP.** Cannot run a check → SKIP with reason, never PASS.
+4. **Verify visual evidence when requested.** If the brief includes `Visual Verification`, run screenshot and/or visual-qa checks. Write any fresh screenshots or VQA logs only to the OS temp directory, not the project tree.
+5. **Copy-paste actual output.** Do not paraphrase or abbreviate.
+6. **Distinguish PASS from SKIP.** Cannot run a check → SKIP with reason, never PASS.
 
 ## Brief Format (What You Receive)
 
@@ -61,6 +62,12 @@ You MAY write ephemeral test scripts to a temp directory (/tmp or $TMPDIR) when 
 
 ### Focus Areas                                          [OPTIONAL]
 {Specific files, systems, or interactions to stress-test}
+
+### Visual Verification                                  [OPTIONAL]
+- Reference: {references/scene_name.png}
+- Screenshot(s): {evaluator captures or temp capture path}
+- Verify: {observable visual criteria}
+- Worker self-check result: {pass | fail | warning | error | missing}
 ```
 
 ## Check Report Format (MANDATORY — use for EVERY check)
@@ -138,3 +145,6 @@ Report: each check line (PASS/FAIL). `--all` is intentionally not used: it adds 
 
 ### Runtime (MCP)
 Use mcp-driver to launch and observe. Report: crashes, errors, behavior issues.
+
+### Visual QA
+Use screenshot and visual-qa when visual criteria or evidence are in the brief. Missing evidence for a requested Visual Verification is FAIL. Fresh captures and VQA logs must stay in the OS temp directory.

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -15,11 +15,12 @@ You are a worker agent implementing a bounded unit of work for a Godot game proj
 3. **Write unit tests.** Minimum 2 unit tests per changed system using gdUnit4.
 4. **Expose e2e-testable interfaces.** Public methods, signals, and `simulate_*` helpers that an external e2e test could drive. Write UNIT tests that cover those interfaces (e.g., `test_simulate_jump_emits_signal`). Do NOT write files in `e2e/` — that directory is owned by the Evaluator.
 5. **Verify compilation.** Run headless-build before reporting. A broken build is automatic failure.
-6. **Report honestly.** If something failed, say so with error output. Never claim success without verification.
-7. **Write a MEMORY entry.** Every task produces learnings — document them.
-8. **No gold-plating.** No extra comments, docstrings, or type annotations on unchanged code.
-9. **Stay inside the project tree.** Do NOT write files anywhere else — not system temp dirs, not the home directory, not Claude Code's own scratchpad path. If you need a scratch file, create it under `.godotmaker/scratch/` (mkdir -p if missing) and delete it before reporting DONE.
-10. **Cwd-relative paths.** Your cwd is the project root (run `pwd` to confirm). Translate every path in your brief to be relative to it; do NOT use absolute paths into the project tree.
+6. **Use visual self-checks for visual gaps.** If the brief includes `Visual Self-Check`, capture screenshots and run `visual-qa` before reporting DONE.
+7. **Report honestly.** If something failed, say so with error output. Never claim success without verification.
+8. **Write a MEMORY entry.** Every task produces learnings — document them.
+9. **No gold-plating.** No extra comments, docstrings, or type annotations on unchanged code.
+10. **Stay inside the project tree.** Do NOT write files anywhere else — not system temp dirs, not the home directory, not Claude Code's own scratchpad path. If you need a scratch file, create it under `.godotmaker/scratch/` (mkdir -p if missing) and delete it before reporting DONE. Write visual self-check outputs to the path named in the brief.
+11. **Cwd-relative paths.** Your cwd is the project root (run `pwd` to confirm). Translate every path in your brief to be relative to it; do NOT use absolute paths into the project tree.
 
 ## Execution Order
 
@@ -31,11 +32,12 @@ You are a worker agent implementing a bounded unit of work for a Godot game proj
 6. Confirm your unit tests cover every e2e-testable interface (public methods, signals, simulate_* helpers)
 7. Run headless-build to confirm compilation. If you added new `class_name` declarations, run `godot --headless --import` once instead of `--quit` so the class cache reflects them.
 8. Run unit tests
-9. Commit your changes from the project root: `git add -A && git commit -m "<task name>"`
+9. If the brief includes `Visual Self-Check`, run screenshot + visual-qa self-checks
+10. Commit your changes from the project root: `git add -A && git commit -m "<task name>"`
    (skip if `git status --porcelain` is empty). In detached-head, sandbox, or
    host-managed workspaces, do not create commits; report the changed files for
    parent-session handoff.
-10. Write your report (using the EXACT format below)
+11. Write your report (using the EXACT format below)
 
 ## Brief Format (What You Receive)
 
@@ -79,6 +81,13 @@ The lead agent provides your brief with these fields. REQUIRED fields are always
 
 ### Assets Available                                     [OPTIONAL]
 {Asset paths and descriptions}
+
+### Visual Self-Check                                  [OPTIONAL]
+- Source: {evaluation.json.visual_checks scene and blocking finding}
+- Reference: {references/scene_name.png}
+- Target state: {scene or gameplay state to capture}
+- Verify: {observable visual criteria}
+- Output directory: `reports/fixgap-visual/{task_id}/`
 ```
 
 ## File Ownership
@@ -120,6 +129,14 @@ If you need to modify a file not in your deliverables, report this in your Notes
 - Status: PASS | FAIL
 - Command: {exact command}
 - Output: {build output — copy-paste if FAIL, "clean" if PASS}
+
+### Visual Self-Check
+Required only when the brief includes `Visual Self-Check`.
+- Status: PASS | FAIL | SKIP
+- Screenshot(s): {paths, or SKIP reason}
+- visual-qa command: {exact command, or SKIP reason}
+- visual-qa verdict: {pass | fail | warning | error | SKIP}
+- Output: {copy-paste if FAIL/WARNING/ERROR, "clean" if PASS}
 
 ### Memory Entry
 {What you learned during this task. Discoveries, gotchas, decisions,

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -26,5 +26,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
+- `/gm-fixgap` now preserves evaluator visual evidence through fix and verification.
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -27,5 +27,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
 - `/gm-fixgap` now preserves evaluator visual evidence through fix and verification.
+- `visual-qa` now limits visibility and readability findings to explicit `Verify:` criteria.
 
 ## Removed

--- a/skills/core/_shared/verifier-dispatch.md
+++ b/skills/core/_shared/verifier-dispatch.md
@@ -53,7 +53,8 @@ Agent({
 ```
 
 For visual gaps, include a command that runs visual-qa on evaluator captures.
-If a fresh capture or VQA log is needed, write it only to the OS temp directory.
+If a fresh capture, VQA log, or helper script is needed, write it only under
+`reports/verifier-temp/`.
 
 ## Spot-Check Protocol
 

--- a/skills/core/_shared/verifier-dispatch.md
+++ b/skills/core/_shared/verifier-dispatch.md
@@ -36,11 +36,12 @@ Agent({
 - [ ] Unit tests: all pass
 - [ ] {additional specific criteria}
 
-### Visual Verification                                  [REQUIRED for visual tasks]
+### Visual Verification                                  [REQUIRED when requested]
 - Scene/reference/capture paths: {visual_checks scene, reference, captures[], and latest vqa_calls[].files from evaluation.json}
 - Visual-qa context: {latest vqa_calls[].context or scene Acceptance criteria}
 - Asset contract rows: {relevant SCENES.md Asset bindings and ASSETS.md Visual Asset Contract rows}
 - VQA log: {visual_checks.<scene>.vqa_log or latest vqa_calls[].log}
+- Worker self-check result: {visual-qa verdict and output from the worker report, if present}
 - Required result: {pass, warning, or explicit non-blocking notes}
 
 ### Negative Tests                                       [OPTIONAL]
@@ -48,7 +49,11 @@ Agent({
 
 ### Focus Areas                                          [OPTIONAL]
 {Specific files, systems, or interactions to stress-test}
+
 ```
+
+For visual gaps, include a command that runs visual-qa on evaluator captures.
+If a fresh capture or VQA log is needed, write it only to the OS temp directory.
 
 ## Spot-Check Protocol
 

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -42,6 +42,7 @@ Agent({
 - [ ] e2e-testable interface: public methods / signals / simulate_* helpers for affected systems/scenes/UI, with unit tests covering each one
 - [ ] Run headless-build and confirm compilation
 - [ ] Run unit tests and include pass/fail output
+- [ ] If `Visual Self-Check` is present: capture screenshot(s), run visual-qa, include output
 - [ ] Summary of what was implemented (<200 words)
 - [ ] MEMORY entry: discoveries, gotchas, decisions (<100 words)
 
@@ -72,6 +73,13 @@ Agent({
  Include: asset row/path, runtime size, visual role, readability requirement,
  and anchor/derivative source.}
 
+### Visual Self-Check                                    [REQUIRED for fixgap visual tasks]
+- Source: {evaluation.json.visual_checks scene and blocking finding}
+- Reference: {references/scene_name.png}
+- Target state: {scene or gameplay state to capture}
+- Verify: {observable visual criteria from evaluation vqa_calls[].context or SCENES.md Acceptance criteria}
+- Output directory: `reports/fixgap-visual/{task_id}/`
+
 ### Scene Layout Reference                                [REQUIRED for UI/scene tasks]
 {Copy the relevant scene description from SCENES.md here.
  Include: element positions, sizes, layout type, mood.
@@ -98,6 +106,7 @@ Agent({
 15. **Cwd-relative paths in the brief.** Fill every `{path}` placeholder as cwd-relative (e.g. `src/systems/s_jump.gd`, not `D:/.../src/systems/s_jump.gd`).
 16. **Non-interactive execution.** Every worker brief MUST prohibit approval requests, user-input waits, and confirmation pauses.
 17. **Visual tasks require asset contract rows.** Fill the `Visual Asset Contract` section for visual tasks.
+18. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
 
 ## Worker Utility Convention
 

--- a/skills/core/gm-fixgap/SKILL.md
+++ b/skills/core/gm-fixgap/SKILL.md
@@ -102,6 +102,9 @@ entries. Fix the game code or runtime path. Do not reduce the `PLAN.md` or
 Evaluation-source visual tasks must cite the blocking finding reported by
 evaluation. Do not create a C/J task from a style-only or non-blocking visual
 finding.
+For blocking visual tasks, copy the relevant `evaluation.json.visual_checks`
+scene, reference, captures[], latest `vqa_calls[].context`, and latest
+`vqa_calls[].log` into the GAP task.
 
 #### 1b. Pull failures from `verify_report.json`
 
@@ -153,6 +156,7 @@ Worker-dispatch tasks only — Step 1b classified main-agent-direct and escalate
 - Dispatch verify-source before evaluation-source within `pending`.
 - Use `subagent_type: "worker"`. Max 3 in parallel with disjoint file sets via `isolation: "worktree"`.
 - In each brief, paste the specific finding from GAP.md, the file(s) to modify, and the correct behavior from GDD.md.
+- For blocking evaluation-source visual tasks, fill `Visual Asset Contract` and `Visual Self-Check` from `references/worker-dispatch.md`.
 - Update task status `pending` → `in_progress` when dispatched, `in_progress` → `completed` when worker reports DONE.
 
 ### Step 4 — Final Verify + Review (single pass after all fixes)
@@ -165,7 +169,8 @@ after **all** GAP.md tasks reach `completed`.
 - Read `references/verifier-dispatch.md` for the brief template
 - Use `subagent_type: "verifier"`. Pass all completed workers' deliverables.
 - For evaluation-source visual tasks, fill the `Visual Verification` section
-  from `references/verifier-dispatch.md`.
+  from `references/verifier-dispatch.md`, including the worker self-check
+  result when present.
 - A new FAIL task must cite an unresolved blocking finding or a blocking regression.
 - On FAIL for a task: add a NEW pending task in GAP.md (the failed task stays `completed`). Loop back to Step 3.
 - On PASS: update those tasks from `completed` → `verified`.
@@ -227,6 +232,7 @@ memory/
 | gdunit-driver | Unit test execution | .claude/skills/gdunit-driver/SKILL.md |
 | godot-api | Godot API reference | .claude/skills/godot-api/SKILL.md |
 | screenshot | Gameplay screenshot capture | .claude/skills/screenshot/SKILL.md |
+| visual-qa | Screenshot/reference visual checks | .claude/skills/visual-qa/SKILL.md |
 | mcp-driver | Runtime debugging via godot-mcp | .claude/skills/mcp-driver/SKILL.md |
 
 **Asset analysis:** Dispatch an Analyst subagent (`subagent_type: "analyst"`, see `references/analyst-dispatch.md`) when you need to analyze user-provided assets.

--- a/skills/core/screenshot/SKILL.md
+++ b/skills/core/screenshot/SKILL.md
@@ -105,6 +105,10 @@ Skill(skill="visual-qa") "Check references/scene_main.png against e2e/screenshot
 For static scenes (decoration, terrain, UI without motion), one screenshot
 is enough — use the Quick Capture pattern above and call `visual-qa` Static mode.
 
+For fixgap worker visual self-checks, save evidence under
+`reports/fixgap-visual/<task_id>/`. For verifier-only fresh captures, use
+the OS temp directory.
+
 ## Generate reference.png
 
 Use the quick capture method, save to `reference.png` in the project root:

--- a/skills/core/screenshot/SKILL.md
+++ b/skills/core/screenshot/SKILL.md
@@ -107,7 +107,7 @@ is enough — use the Quick Capture pattern above and call `visual-qa` Static mo
 
 For fixgap worker visual self-checks, save evidence under
 `reports/fixgap-visual/<task_id>/`. For verifier-only fresh captures, use
-the OS temp directory.
+`reports/verifier-temp/`.
 
 ## Generate reference.png
 

--- a/skills/core/visual-qa/SKILL.md
+++ b/skills/core/visual-qa/SKILL.md
@@ -35,12 +35,15 @@ holds. If no row matches, STOP and tell the caller their args are malformed.
 
 | Mode | Precondition | Required argv shape |
 |---|---|---|
-| Static | `references/<ref>.png` path AND exactly 1 `e2e/screenshots/<shot>.png` path | `Check references/<ref>.png against e2e/screenshots/<shot>.png - Goal: ... Requirements: ... Verify: ...` |
-| Dynamic | `references/<ref>.png` path AND 2 or more frame paths (`e2e/screenshots/<dir>/frame_*.png`) | `Check references/<ref>.png against <frame_glob> - Goal: ... Requirements: ... Verify: ...` |
+| Static | `references/<ref>.png` path AND exactly 1 screenshot path | `Check references/<ref>.png against <screenshot.png> - Goal: ... Requirements: ... Verify: ...` |
+| Dynamic | `references/<ref>.png` path AND 2 or more frame paths | `Check references/<ref>.png against <frame_glob> - Goal: ... Requirements: ... Verify: ...` |
 | Question | No `references/` path; caller asks a question about screenshots | `--question "..." <screenshot.png> [...]` |
 
 If a reference path appears in the args but the file does not exist on disk,
 STOP. Return `verdict: error` with `reason: "reference file missing: <path>"`.
+
+Screenshot paths for Static/Dynamic mode may come from `e2e/screenshots/`,
+`reports/fixgap-visual/`, or a verifier temp directory.
 
 Each call takes one scene's reference plus that scene's screenshot or frame
 paths. Reject a single stitched, montage, or contact-sheet image supplied in

--- a/skills/core/visual-qa/SKILL.md
+++ b/skills/core/visual-qa/SKILL.md
@@ -43,7 +43,7 @@ If a reference path appears in the args but the file does not exist on disk,
 STOP. Return `verdict: error` with `reason: "reference file missing: <path>"`.
 
 Screenshot paths for Static/Dynamic mode may come from `e2e/screenshots/`,
-`reports/fixgap-visual/`, or a verifier temp directory.
+`reports/fixgap-visual/`, or `reports/verifier-temp/`.
 
 Each call takes one scene's reference plus that scene's screenshot or frame
 paths. Reject a single stitched, montage, or contact-sheet image supplied in

--- a/skills/core/visual-qa/SKILL.md
+++ b/skills/core/visual-qa/SKILL.md
@@ -16,8 +16,8 @@ CRITICAL: When Task Context is provided, use its `Verify:` criteria as the
 gate. Treat the reference image as visual intent, not as a pixel-perfect or
 style-matching gate. Do not fail a check for pure reference/style mismatch
 (palette, capitalization, wording, roundedness, spacing, polish) unless it
-breaks the `Verify:` criteria or makes the scene unreadable, unusable, visually
-ambiguous, or logically false.
+breaks the `Verify:` criteria, blocks operation, destabilizes layout, or makes
+the visible state logically false.
 
 ## Execution Steps
 

--- a/skills/core/visual-qa/scripts/criteria.md
+++ b/skills/core/visual-qa/scripts/criteria.md
@@ -3,8 +3,7 @@
 Use these rules before choosing the final verdict:
 
 - `fail` means an acceptance criterion is not visibly satisfied, or a
-  visual/logical/motion bug blocks readability, operation, state truth, or
-  layout stability.
+  visual/logical/motion bug blocks operation, state truth, or layout stability.
 - `warning` means the acceptance criteria pass, and a material non-blocking
   issue was observed while checking the caller-provided context. Do not expand
   the review scope to search for warnings.
@@ -20,15 +19,21 @@ Use these rules before choosing the final verdict:
 
 ### Implementation Quality
 
-Flag these as `fail` only when they block acceptance, readability, operation,
-state truth, or layout stability:
+Flag these as `fail` only when they block acceptance, operation, state truth, or
+layout stability:
 
 - Grid/uniform placement when reference shows organic arrangement
 - Uniform/default scale when reference shows varied, purposeful sizing
 - Flat composition when reference has depth and layering
 - Stretched, tiled, or carelessly applied materials
 - Objects unrelated to environment
-- Camera framing misses required context or blocks readability/operation
+- Camera framing misses required context or blocks operation
+
+### Visibility Scope
+
+Only report visibility, contrast, or readability findings when the caller's
+`Verify:` criteria explicitly require the object, UI, or text to be visible or
+readable.
 
 ### Visual Bugs
 

--- a/tests/test_fixgap_visual_contract.py
+++ b/tests/test_fixgap_visual_contract.py
@@ -53,7 +53,7 @@ def test_verifier_rechecks_visual_evidence_when_requested():
     assert "Worker self-check result:" in dispatch
     assert "runs visual-qa on evaluator captures" in dispatch
     assert "Worker self-check evidence:" not in dispatch
-    assert "OS temp directory" in dispatch
+    assert "reports/verifier-temp/" in dispatch
     assert "/tmp" not in dispatch
     assert "$TMPDIR" not in dispatch
 
@@ -65,6 +65,7 @@ def test_fixgap_uses_screenshot_and_visual_qa_without_e2e_ownership():
     assert "| screenshot |" in fixgap
     assert "| visual-qa |" in fixgap
     assert "reports/fixgap-visual/<task_id>/" in screenshot
+    assert "reports/verifier-temp/" in screenshot
     assert ".godotmaker/scratch/fixgap-visual/<task_id>/" not in screenshot
 
 

--- a/tests/test_fixgap_visual_contract.py
+++ b/tests/test_fixgap_visual_contract.py
@@ -1,0 +1,77 @@
+"""Contract tests for fixgap visual self-check handoff."""
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXGAP = REPO_ROOT / "skills" / "core" / "gm-fixgap" / "SKILL.md"
+WORKER = REPO_ROOT / "agents" / "worker.md"
+VERIFIER = REPO_ROOT / "agents" / "verifier.md"
+WORKER_DISPATCH = REPO_ROOT / "skills" / "core" / "_shared" / "worker-dispatch.md"
+VERIFIER_DISPATCH = REPO_ROOT / "skills" / "core" / "_shared" / "verifier-dispatch.md"
+SCREENSHOT = REPO_ROOT / "skills" / "core" / "screenshot" / "SKILL.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_fixgap_dispatches_worker_visual_self_check():
+    fixgap = _read(FIXGAP)
+    dispatch = _read(WORKER_DISPATCH)
+
+    assert "Visual Self-Check" in fixgap
+    assert "Visual Self-Check" in dispatch
+    assert "evaluation.json.visual_checks" in dispatch
+    assert "Reference:" in dispatch
+    assert "Target state:" in dispatch
+    assert "Verify:" in dispatch
+    assert "reports/fixgap-visual/{task_id}/" in dispatch
+    assert "Output directory: `reports/fixgap-visual/{task_id}/`" in dispatch
+    assert ".godotmaker/scratch/fixgap-visual/{task_id}/" not in dispatch
+
+
+def test_worker_reports_visual_self_check_when_requested():
+    worker = _read(WORKER)
+
+    assert "Visual Self-Check" in worker
+    assert "Required only when the brief includes `Visual Self-Check`." in worker
+    assert "visual-qa" in worker
+    assert "### Visual Self-Check" in worker
+    assert "Screenshot(s):" in worker
+    assert "visual-qa verdict:" in worker
+    assert "reports/fixgap-visual/" in worker
+
+
+def test_verifier_rechecks_visual_evidence_when_requested():
+    verifier = _read(VERIFIER)
+    dispatch = _read(VERIFIER_DISPATCH)
+
+    assert "Visual Verification" in verifier
+    assert "Visual Verification" in dispatch
+    assert "visual-qa" in verifier
+    assert "Missing evidence for a requested Visual Verification is FAIL." in verifier
+    assert "Worker self-check result:" in dispatch
+    assert "runs visual-qa on evaluator captures" in dispatch
+    assert "Worker self-check evidence:" not in dispatch
+    assert "OS temp directory" in dispatch
+    assert "/tmp" not in dispatch
+    assert "$TMPDIR" not in dispatch
+
+
+def test_fixgap_uses_screenshot_and_visual_qa_without_e2e_ownership():
+    fixgap = _read(FIXGAP)
+    screenshot = _read(SCREENSHOT)
+
+    assert "| screenshot |" in fixgap
+    assert "| visual-qa |" in fixgap
+    assert "reports/fixgap-visual/<task_id>/" in screenshot
+    assert ".godotmaker/scratch/fixgap-visual/<task_id>/" not in screenshot
+
+
+def test_fixgap_preserves_visual_check_context_from_evaluation():
+    fixgap = _read(FIXGAP)
+
+    assert "evaluation.json.visual_checks" in fixgap
+    assert "captures[]" in fixgap
+    assert "vqa_calls[].context" in fixgap
+    assert "vqa_calls[].log" in fixgap

--- a/tests/test_visual_qa_script.py
+++ b/tests/test_visual_qa_script.py
@@ -7,6 +7,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = REPO_ROOT / "skills" / "core" / "visual-qa" / "scripts" / "visual_qa.py"
 VQA_SKILL = REPO_ROOT / "skills" / "core" / "visual-qa" / "SKILL.md"
 VQA_CRITERIA = REPO_ROOT / "skills" / "core" / "visual-qa" / "scripts" / "criteria.md"
+VQA_STATIC_PROMPT = REPO_ROOT / "skills" / "core" / "visual-qa" / "scripts" / "static_prompt.md"
+VQA_DYNAMIC_PROMPT = REPO_ROOT / "skills" / "core" / "visual-qa" / "scripts" / "dynamic_prompt.md"
+VQA_QUESTION_PROMPT = REPO_ROOT / "skills" / "core" / "visual-qa" / "scripts" / "question_prompt.md"
 EVALUATE_SKILL = REPO_ROOT / "skills" / "core" / "gm-evaluate" / "SKILL.md"
 
 
@@ -81,3 +84,20 @@ def test_visual_qa_accepts_fixgap_visual_evidence_path():
 
     assert "reports/fixgap-visual/" in vqa
     assert ".godotmaker/scratch/fixgap-visual/" not in vqa
+
+
+def test_visual_qa_limits_visibility_findings_to_verify_criteria():
+    criteria = VQA_CRITERIA.read_text(encoding="utf-8")
+    static_prompt = VQA_STATIC_PROMPT.read_text(encoding="utf-8")
+    dynamic_prompt = VQA_DYNAMIC_PROMPT.read_text(encoding="utf-8")
+    question_prompt = VQA_QUESTION_PROMPT.read_text(encoding="utf-8")
+    skill = VQA_SKILL.read_text(encoding="utf-8")
+
+    assert "Visibility Scope" in criteria
+    assert "explicitly require" in criteria
+    assert "visibility, contrast, or readability findings" in criteria
+    assert "blocks readability" not in criteria
+    assert "visually ambiguous" not in skill
+
+    for text in (static_prompt, dynamic_prompt, question_prompt, skill):
+        assert "**Objective reason:**" not in text

--- a/tests/test_visual_qa_script.py
+++ b/tests/test_visual_qa_script.py
@@ -83,6 +83,7 @@ def test_visual_qa_accepts_fixgap_visual_evidence_path():
     vqa = VQA_SKILL.read_text(encoding="utf-8")
 
     assert "reports/fixgap-visual/" in vqa
+    assert "reports/verifier-temp/" in vqa
     assert ".godotmaker/scratch/fixgap-visual/" not in vqa
 
 

--- a/tests/test_visual_qa_script.py
+++ b/tests/test_visual_qa_script.py
@@ -74,3 +74,10 @@ def test_evaluate_uses_e2e_vqa_log():
 
     assert "${VQA_LOG:-.vqa.log}" in vqa
     assert "e2e/screenshots/vqa.log" in evaluate
+
+
+def test_visual_qa_accepts_fixgap_visual_evidence_path():
+    vqa = VQA_SKILL.read_text(encoding="utf-8")
+
+    assert "reports/fixgap-visual/" in vqa
+    assert ".godotmaker/scratch/fixgap-visual/" not in vqa


### PR DESCRIPTION
## Summary

Adds a focused visual self-check handoff for `/gm-fixgap` workers and narrows `visual-qa` visibility/readability findings to explicit `Verify:` criteria.

## Motivation

Blocking visual evaluation gaps need enough preserved evidence for workers and verifiers to repair the actual observed issue without turning every visual task into a broad VQA gate.

## Changes

- [x] Pass evaluator visual evidence into fixgap worker briefs for blocking visual gaps.
- [x] Require worker visual self-check output only when the brief includes `Visual Self-Check`.
- [x] Add verifier visual verification context for requested visual rechecks.
- [x] Use the OS temp directory for verifier-only fresh captures and VQA logs.
- [x] Limit `visual-qa` visibility/readability findings to explicit `Verify:` criteria.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

```text
python -m pytest tests\test_visual_qa_script.py tests\test_fixgap_visual_contract.py -q
11 passed

git diff --check
pass
```

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: executed`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [x] Result attached or summarized below

No migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR