### PR TITLE
fix: run gecs and godot-api inline instead of forking skill context

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -24,6 +24,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
-- `gecs` and `godot-api` now run inline instead of forking a skill context (`context: fork`). When invoked from inside a worker subagent under a headless run, the forked context did real work that never surfaced on the parent process's stdout, so the runner's idle-timeout watchdog killed otherwise-healthy builds.
+- `gecs` and `godot-api` now run inline instead of forking a skill context (`context: fork`). When invoked from inside a worker subagent under a headless run, the forked context did real work that never surfaced on the parent process's stdout, so the runner's idle-timeout watchdog killed otherwise-healthy builds. (#31)
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -24,6 +24,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
-- `gecs` and `godot-api` now run inline instead of forking a skill context (`context: fork`). When invoked from inside a worker subagent under a headless run, the forked context did real work that never surfaced on the parent process's stdout, so the runner's idle-timeout watchdog killed otherwise-healthy builds. (#31)
+- `gecs` and `godot-api` run inline instead of forking a separate skill context, fixing headless builds that could stall when a worker looked up ECS or Godot APIs. (#31)
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -24,5 +24,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
+- `gecs` and `godot-api` now run inline instead of forking a skill context (`context: fork`). When invoked from inside a worker subagent under a headless run, the forked context did real work that never surfaced on the parent process's stdout, so the runner's idle-timeout watchdog killed otherwise-healthy builds.
 
 ## Removed

--- a/skills/core/gecs/SKILL.md
+++ b/skills/core/gecs/SKILL.md
@@ -15,7 +15,6 @@ description: |
   fabricated. NOT relevant for standard Godot subsystems (physics, animation,
   UI, tilemap, shader, particles, navigation, signals, audio) unless explicitly
   connected to ECS.
-context: fork
 ---
 
 # gecs — ECS Framework for Godot 4.x

--- a/skills/core/godot-api/SKILL.md
+++ b/skills/core/godot-api/SKILL.md
@@ -4,9 +4,6 @@ description: |
   Look up Godot engine class APIs — methods, properties, signals, enums.
   Use when you need to find which class to use or look up specific API details.
   Supports version-specific docs — reads the correct API for the project's Godot version.
-context: fork
-model: sonnet
-agent: Explore
 ---
 
 # Godot API Lookup

--- a/tests/test_skill_context_fork.py
+++ b/tests/test_skill_context_fork.py
@@ -1,0 +1,35 @@
+"""Guard core skills against `context: fork`.
+
+`context: fork` runs a skill in an isolated context whose internal tool
+activity does not surface on the parent process's stdout under a headless
+`claude -p` run. When such a skill is invoked from inside a worker subagent
+(routine during `/gm-build`), the forked context does real work the runner
+never sees, so the idle-timeout watchdog kills an otherwise-healthy build.
+The whole pipeline runs headless, so no core skill may declare it.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CORE_SKILLS = sorted((REPO_ROOT / "skills" / "core").glob("*/SKILL.md"))
+
+
+def _frontmatter(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---"):
+        return ""
+    end = text.find("\n---", 3)
+    return text[: end if end != -1 else len(text)]
+
+
+@pytest.mark.parametrize("skill", CORE_SKILLS, ids=lambda p: p.parent.name)
+def test_core_skill_does_not_fork_context(skill):
+    fm = _frontmatter(skill)
+    assert not re.search(r"^context:\s*fork\s*$", fm, re.MULTILINE), (
+        f"{skill.parent.name}/SKILL.md declares `context: fork`, which hangs "
+        f"headless runs when the skill is invoked from a worker subagent: the "
+        f"forked context's activity never reaches the parent stdout, so the "
+        f"runner's idle watchdog kills the build. Run the skill inline instead."
+    )


### PR DESCRIPTION
## Summary

`gecs` and `godot-api` carried `context: fork`. Strip it (plus the now-inert `model: sonnet` / `agent: Explore` on `godot-api`, which only take effect with `context: fork`) so both skills run inline in the caller's context — the pattern every other supporting skill already uses.

## Motivation

`context: fork` runs a skill in an isolated context whose internal tool activity does not surface on the parent process's stdout under a headless `claude -p` run. When either skill is invoked from inside a worker subagent (routine during `/gm-build`), the fork does real work the runner can't see, so the idle-timeout watchdog reads ~15 min of false silence and kills an otherwise-healthy build.

Subagents cannot spawn nested subagents, so dispatching these as subagents (the route used for `visual-qa`) would hit the depth limit when they are themselves invoked from a worker. Inline is the only reliable path; the trade-off is that the reference content loads into the caller's context, which is acceptable for lookup docs.

No related issue.

## Changes

- [x] Remove `context: fork` from `skills/core/gecs/SKILL.md`
- [x] Remove `context: fork` + `model: sonnet` + `agent: Explore` from `skills/core/godot-api/SKILL.md`
- [x] Add `tests/test_skill_context_fork.py` guarding all core skills against `context: fork`
- [x] Add a `docs/update/next.md` entry

## Testing

- [x] New or updated tests pass (`pytest`) — 854 passed
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable — pending a headless `/gm-build` where a worker invokes `gecs`/`godot-api`

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed

> Skill files are redeployed into target projects on the next `tools/publish.py`; no file moves, no config-key renames, no on-disk migration.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (n/a — no ECS code)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated