### PR TITLE
docs: update contribution workflow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @RandallLiuXin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,15 +28,17 @@ GodotMaker is licensed under the Business Source License 1.1 (see [LICENSE](LICE
 1. Fork the repo and create a branch from `main`.
 2. Follow the coding conventions below.
 3. Write or update tests for your changes.
-4. **Run benchmarks** — you must verify your changes do not regress performance before submitting. Include benchmark results in the PR description.
+4. For performance-sensitive changes, run benchmarks and include the results in the PR description.
 5. Run the full validation pipeline locally:
    ```bash
    # Run tests
-   pytest
+   python -m pytest
+
+   # Run gdUnit4 for Godot project changes
    godot --headless --path . -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd --add res://test/ --ignoreHeadlessMode
 
    # Gitleaks (runs automatically via pre-commit hook)
-   gitleaks detect --source .
+   gitleaks detect --source . --config .gitleaks.toml
    ```
 6. Add a changelog entry to [`docs/update/next.md`](docs/update/next.md) describing your change. Rules:
    - **One sentence per bullet.** If you can't fit it, your bullet is doing two things — split it.
@@ -62,8 +64,11 @@ cd GodotMaker
 # Install git hooks (gitleaks pre-commit)
 bash scripts/install-hooks.sh
 
-# Install Python dependencies
-pip install -r requirements.txt
+# Install development dependencies used by CI
+python -m pip install pytest ruff mkdocs mkdocs-material
+
+# Optional: install asset/API provider dependencies when working on tools/
+python -m pip install -r tools/requirements.txt
 ```
 
 ## Coding Conventions
@@ -97,7 +102,7 @@ pip install -r requirements.txt
 
 1. All PRs require at least one review.
 2. CI must pass before merge.
-3. Benchmark verification is mandatory — reviewers will check for performance data in the PR description.
+3. Performance-sensitive PRs must include benchmark data in the PR description.
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

Update contribution workflow docs and add a default CODEOWNERS file.

## Motivation

Keep contributor instructions aligned with the current local validation commands and ownership expectations.

## Changes

- [x] Relax mandatory benchmark wording to performance-sensitive changes.
- [x] Update local validation commands for pytest, gdUnit4, and gitleaks config usage.
- [x] Document current development dependency installation commands.
- [x] Add `.github/CODEOWNERS` with the repository owner.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

```text
git diff --check

pre-push hook:
ruff check .
pytest --tb=short
751 passed in 105.11s
gdlint .
```

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
N/A
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: executed`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

Not applicable: no migration script added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR