### PR TITLE
[codex] Allow ordinary agent sessions without role lock

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -18,7 +18,7 @@ Hook registration is runner-specific:
 | `check_file_permissions.py` | PreToolUse | Write\|Edit | Yes | Per-role write rules driven by `.godotmaker/current_role` |
 | `stage_reminder.py` | PreToolUse | Write\|Edit | Yes | Detect `stage.jsonl` appends, validate role outputs, inject next-role reminder |
 | `check_stage_prerequisites.py` | PreToolUse | Agent | Yes | Before worker dispatch, verify the prerequisite role completed and its outputs exist |
-| `check_asset_access.py` | PreToolUse | Read | Yes | Block the main agent (any role) from reading image files in `assets/` |
+| `check_asset_access.py` | PreToolUse | Read | Yes | During an active role, block the main agent from reading image files in `assets/` |
 | `log_subagent.py` | SubagentStart | — | No | Record subagent start metrics (role detection, agent_id) |
 | `on_subagent_stop.py` | SubagentStop | — | Yes | Dispatcher: serialise `log_subagent.handle_stop` + `check_worker_report` to avoid metrics-file race |
 | `check_completion.py` | Stop | — | Yes | Final gate: for `build` / `fixgap` only, blocks if workers were dispatched without verifier + reviewer |
@@ -55,16 +55,17 @@ skill) and applies that role's write rules. Per-role summary:
 | `gdd` | `.md` planning docs, `project.godot`, `.godotmaker/` (no `assets/`) |
 | `asset` | `ASSETS.md`, `.godotmaker/` (image files go through asset tools or analyst subagent) |
 | `build` / `fixgap` | nothing in `e2e/`; nothing in game code (`.gd` / `.tscn` / `.tres`) directly — must dispatch a Worker |
-| `verify` | `.godotmaker/stage.jsonl` and `.godotmaker/current_role` only (read-only otherwise) |
+| `verify` | `.godotmaker/stage.jsonl`, `.godotmaker/current_role`, and `.godotmaker/verify_report.json` only (read-only otherwise) |
 | `evaluate` | `e2e/`, `.godotmaker/evaluation.json`, `.godotmaker/stage.jsonl`, `.godotmaker/current_role` |
 | `accept` / `finalize` | anything except `e2e/` and game code (`.gd` / `.tscn` / `.tres`) |
 
-Subagents are always blocked from `e2e/` (Evaluator-owned) and from planning
-docs (`PLAN.md` / `STRUCTURE.md` / `ASSETS.md` / `GAP.md`); they report changes
-in their report instead.
+During an active pipeline role, subagents are blocked from `e2e/`
+(Evaluator-owned) and from planning docs (`PLAN.md` / `STRUCTURE.md` /
+`ASSETS.md` / `GAP.md`); they report changes in their report instead.
 
-When no role is set (legacy mode), falls back to: main agent blocked from game
-code, subagents blocked from planning docs.
+When no role is set, no `/gm-*` pipeline role is active. The hook records the
+file operation but does not block, so users can run ordinary coding-agent
+conversations in a GodotMaker project directory.
 
 Also records `FILE_WRITE` / `FILE_EDIT` metrics events for every file operation.
 
@@ -123,10 +124,12 @@ not sub-subagent dispatches.
 **Event:** PreToolUse (Read)
 **Blocks:** Yes
 
-Blocks the main agent (any role) from reading image files in `assets/`.
+Blocks the main agent from reading image files in `assets/` only while a
+pipeline role is active (`.godotmaker/current_role` exists).
 Image extensions: .png, .jpg, .jpeg, .svg, .webp, .gif, .bmp, .tga.
 
-Subagents (analyst) are allowed. Non-image files (.json, .ogg) are allowed.
+Regular conversations with no active role are allowed. Subagents (analyst) are
+allowed. Non-image files (.json, .ogg) are allowed.
 
 Purpose: force the main agent to delegate asset analysis to the analyst
 subagent instead of consuming context with raw image data.
@@ -179,7 +182,9 @@ removes the race.
 **Event:** SubagentStop (called via `on_subagent_stop.py`)
 **Blocks:** Yes
 
-Validates report format and content for all subagent roles.
+Validates report format and content for subagent roles while a `/gm-*`
+pipeline role is active. With no `.godotmaker/current_role`, ordinary
+subagent conversations are allowed and this hook does not block.
 
 **Format detection flow:**
 1. Detect `report_type` from message content (layered: exact marker → regex → fallback)

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -24,5 +24,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - (WIP) Rewire Agent prompt/output trace capture to `PreToolUse`/`PostToolUse` because the `SubagentStart` payload has no `prompt` field and silently wrote 0-byte traces.
+- Allow ordinary coding-agent conversations in GodotMaker project directories by making file-permission, asset-image-read, and subagent-report gates skip enforcement when no `.godotmaker/current_role` is active.
 
 ## Removed

--- a/docs/zh/hooks.md
+++ b/docs/zh/hooks.md
@@ -17,7 +17,7 @@ Hook 注册关系按 runner 分开维护：Claude Code 使用
 | `check_file_permissions.py` | PreToolUse | Write\|Edit | 是 | 由 `.godotmaker/current_role` 驱动的每角色写规则 |
 | `stage_reminder.py` | PreToolUse | Write\|Edit | 是 | 检测 `stage.jsonl` 追加操作，验证角色输出，注入下一角色提示 |
 | `check_stage_prerequisites.py` | PreToolUse | Agent | 是 | Worker 派发前，验证前置角色已完成且其产出存在 |
-| `check_asset_access.py` | PreToolUse | Read | 是 | 阻止主代理（任何角色）读取 `assets/` 中的图片文件 |
+| `check_asset_access.py` | PreToolUse | Read | 是 | 在活跃角色期间，阻止主代理读取 `assets/` 中的图片文件 |
 | `log_subagent.py` | SubagentStart | — | 否 | 记录子代理启动指标（角色检测、agent_id） |
 | `on_subagent_stop.py` | SubagentStop | — | 是 | 分发器：串行执行 `log_subagent.handle_stop` + `check_worker_report`，避免指标文件竞态 |
 | `check_completion.py` | Stop | — | 是 | 最终门控：仅针对 `build` / `fixgap`，若派发了 Worker 但未运行 Verifier + Reviewer 则阻止结束 |
@@ -50,13 +50,13 @@ Hook 注册关系按 runner 分开维护：Claude Code 使用
 | `gdd` | `.md` 规划文档、`project.godot`、`.godotmaker/`（不含 `assets/`） |
 | `asset` | `ASSETS.md`、`.godotmaker/`（图片文件通过 `asset_gen.py` Bash 或 Analyst 子代理处理） |
 | `build` / `fixgap` | `e2e/` 中不可写；游戏代码（`.gd` / `.tscn` / `.tres`）不可直接写——必须派发 Worker |
-| `verify` | 仅 `.godotmaker/stage.jsonl` 和 `.godotmaker/current_role`（其他地方只读） |
+| `verify` | 仅 `.godotmaker/stage.jsonl`、`.godotmaker/current_role` 和 `.godotmaker/verify_report.json`（其他地方只读） |
 | `evaluate` | `e2e/`、`.godotmaker/evaluation.json`、`.godotmaker/stage.jsonl`、`.godotmaker/current_role` |
 | `accept` / `finalize` | 除 `e2e/` 和游戏代码（`.gd` / `.tscn` / `.tres`）外的任何内容 |
 
-子代理始终被阻止写入 `e2e/`（评估器专属）和规划文档（`PLAN.md` / `STRUCTURE.md` / `ASSETS.md` / `GAP.md`）；它们通过报告来记录变更。
+在流水线角色活跃期间，子代理会被阻止写入 `e2e/`（评估器专属）和规划文档（`PLAN.md` / `STRUCTURE.md` / `ASSETS.md` / `GAP.md`）；它们通过报告来记录变更。
 
-未设置角色时（遗留模式），回退行为：主代理被阻止写游戏代码，子代理被阻止写规划文档。
+未设置角色时，表示当前没有活跃的 `/gm-*` 流水线角色。该 Hook 只记录文件操作，不阻止写入，因此用户可以在 GodotMaker 项目目录中正常开启普通 coding-agent 对话。
 
 同时为每次文件操作记录 `FILE_WRITE` / `FILE_EDIT` 指标事件。
 
@@ -105,10 +105,10 @@ Hook 还会重新验证前置角色在 `config/stage_schemas.json` 中的 `files
 **事件：** PreToolUse（Read）
 **是否阻止：** 是
 
-阻止主代理（任何角色）读取 `assets/` 中的图片文件。
+仅在流水线角色活跃时（存在 `.godotmaker/current_role`），阻止主代理读取 `assets/` 中的图片文件。
 图片扩展名：.png、.jpg、.jpeg、.svg、.webp、.gif、.bmp、.tga。
 
-子代理（Analyst）被允许。非图片文件（.json、.ogg）被允许。
+没有活跃角色的普通对话被允许。子代理（Analyst）被允许。非图片文件（.json、.ogg）被允许。
 
 目的：强制主代理将资源分析委托给 Analyst 子代理，而不是消耗上下文来读取原始图片数据。
 
@@ -146,7 +146,7 @@ Hook 还会重新验证前置角色在 `config/stage_schemas.json` 中的 `files
 **事件：** SubagentStop（通过 `on_subagent_stop.py` 调用）
 **是否阻止：** 是
 
-验证所有子代理角色的报告格式和内容。
+仅在 `/gm-*` 流水线角色活跃时验证子代理角色的报告格式和内容。没有 `.godotmaker/current_role` 时，普通子代理对话被允许，该 Hook 不阻止。
 
 **格式检测流程：**
 1. 从消息内容检测 `report_type`（分层：精确标记 → 正则 → 回退）
@@ -204,7 +204,7 @@ PreToolUse(Agent)
   └── check_stage_prerequisites.py (若前置角色未完成则阻止 build/fixgap)
 
 PreToolUse(Read)
-  └── check_asset_access.py (阻止主代理读取 assets/ 中的图片)
+  └── check_asset_access.py (活跃角色期间阻止主代理读取 assets/ 中的图片)
 
 SubagentStart
   └── log_subagent.py (记录启动 + 角色)

--- a/hooks/check_asset_access.py
+++ b/hooks/check_asset_access.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-"""PreToolUse hook: block the dispatching role from directly reading image
-files in assets/.
+"""PreToolUse hook: block active pipeline roles from reading asset images.
 
-The dispatching role (the active /gm-* skill in the main session) must delegate
-asset analysis to an analyst subagent. Subagents are allowed to read assets —
-only the main agent (empty agent_id) is blocked.
+The active /gm-* skill in the main session must delegate asset analysis to an
+analyst subagent. Regular coding-agent conversations with no current_role are
+not pipeline sessions and are allowed to read assets directly. Subagents are
+also allowed; only the main agent (empty agent_id) is blocked during a
+pipeline role.
 """
 import json
 import os
 import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from metrics import get_current_role
 
 
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".svg", ".webp", ".gif", ".bmp", ".tga"}
@@ -20,38 +24,34 @@ def main():
     except (json.JSONDecodeError, EOFError):
         sys.exit(0)
 
-    # Only check PreToolUse for Read tool
     if data.get("hook_event_name") != "PreToolUse":
         sys.exit(0)
     if data.get("tool_name") != "Read":
         sys.exit(0)
 
-    # Only block the main agent (the dispatching role), not subagents
     agent_id = data.get("agent_id", "")
     if agent_id:
-        sys.exit(0)  # Subagent — allow
+        sys.exit(0)
 
-    # Check if the file path is an image in assets/
+    if not get_current_role():
+        sys.exit(0)
+
     tool_input = data.get("tool_input", {})
     file_path = tool_input.get("file_path", "")
     if not file_path:
         sys.exit(0)
 
-    # Normalize path separators
     normalized = file_path.replace("\\", "/").lower()
 
-    # Check if path contains assets/ directory
     if "/assets/" not in normalized and not normalized.startswith("assets/"):
         sys.exit(0)
 
-    # Check file extension
     _, ext = os.path.splitext(normalized)
     if ext not in IMAGE_EXTENSIONS:
-        sys.exit(0)  # Non-image files (e.g., .json, .ogg) are OK
+        sys.exit(0)
 
-    # Block — dispatching role trying to read image in assets/
     reason = (
-        f"The dispatching role cannot read image files in assets/ directly. "
+        f"The active pipeline role cannot read image files in assets/ directly. "
         f"Dispatch an analyst subagent to analyze '{os.path.basename(file_path)}' instead. "
         f"See analyst-dispatch.md for the protocol."
     )

--- a/hooks/check_file_permissions.py
+++ b/hooks/check_file_permissions.py
@@ -3,8 +3,8 @@
 
 Reads .godotmaker/current_role and applies the role's write rules. See the
 gm-*/SKILL.md files for the canonical per-role rules; this hook enforces
-them. When no role is set, falls back to legacy rules (main agent blocked
-from game code, subagents blocked from planning docs).
+them. When no role is set, no /gm-* pipeline role is active, so regular
+coding-agent conversations are allowed to write normally.
 """
 import json
 import os
@@ -205,29 +205,6 @@ def _check_subagent(path_lower: str, file_name: str, agent_id: str,
                file_name, agent_id)
 
 
-def _check_legacy(is_subagent: bool, path_lower: str, file_name: str,
-                  ext: str, agent_id: str, agent_type: str) -> None:
-    """Fallback rules when no current_role is set."""
-    if is_subagent:
-        if _is_godotmaker_path(path_lower):
-            _block(f"Workers cannot write to .godotmaker/ ({file_name}).",
-                   file_name, agent_id)
-        if file_name in PLANNING_DOCS:
-            if agent_type in PLANNING_WRITER_AGENT_TYPES:
-                return
-            _block(f"Workers cannot modify planning documents ({file_name}).",
-                   file_name, agent_id)
-        if file_name == PROJECT_GODOT:
-            if agent_type in PLANNING_WRITER_AGENT_TYPES:
-                return
-            _block("Workers cannot modify project.godot.",
-                   file_name, agent_id)
-    else:
-        if ext in GAME_CODE_EXTENSIONS:
-            _block(f"Main agent cannot write game code directly ({file_name}). "
-                   "Dispatch a Worker subagent.", file_name)
-
-
 def main():
     try:
         data = json.load(sys.stdin)
@@ -261,7 +238,9 @@ def main():
     role = get_current_role()
 
     if not role:
-        _check_legacy(is_subagent, path_lower, file_name, ext, agent_id, agent_type)
+        record_event(EventType.HOOK_ALLOW, hook="check_file_permissions",
+                     file=file_name, agent_id=agent_id or "main", role=role)
+        sys.exit(0)
     elif is_subagent:
         _check_subagent(path_lower, file_name, agent_id, agent_type)
     else:

--- a/hooks/check_worker_report.py
+++ b/hooks/check_worker_report.py
@@ -6,7 +6,9 @@ results), Build, Memory Entry.
 
 Verifier reports MUST have: Overall, Results, Adversarial Probes.
 
-Blocks (JSON decision: "block") if required sections are missing.
+Blocks (JSON decision: "block") if required sections are missing. When no
+current_role is set, no /gm-* pipeline role is active and regular subagent
+conversations are allowed without report-format enforcement.
 
 Anti-deadloop: if a specific agent has been blocked BLOCK_LIMIT times,
 force-allow with a warning to prevent infinite retry loops.
@@ -22,7 +24,7 @@ from metrics import (
     record_event, read_current_events, EventType,
     detect_report_type, event_has_role,
     REPORT_REQUIRED_SECTIONS, REPORT_FORMAT_HINTS, REPORT_REQUIRED_LABELS,
-    state,
+    get_current_role, state,
 )
 
 BLOCK_LIMIT = 2  # Max blocks per subagent before force-allowing
@@ -213,6 +215,9 @@ def main_with_data(data: dict) -> None:
     if not message:
         sys.exit(0)
 
+    if not get_current_role():
+        sys.exit(0)
+
     # Anti-deadloop: per-agent block counter
     agent_id = data.get("agent_id") or ""
     state_key = f"worker_report_block:{agent_id}" if agent_id else "worker_report_block:main"
@@ -344,4 +349,3 @@ def build_progress_reminder() -> str | None:
 
 if __name__ == "__main__":
     main()
-

--- a/tests/hooks/test_check_asset_access.py
+++ b/tests/hooks/test_check_asset_access.py
@@ -1,0 +1,52 @@
+"""Tests for check_asset_access.py hook."""
+import pytest
+
+from .helpers import run_hook, is_blocked, cleanup_metrics, write_current_role
+
+HOOK = "check_asset_access.py"
+
+
+@pytest.fixture(autouse=True)
+def clean():
+    cleanup_metrics()
+    yield
+    cleanup_metrics()
+
+
+def _read_payload(path: str, agent_id: str = "") -> dict:
+    return {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": path},
+        "agent_id": agent_id,
+    }
+
+
+def test_no_role_allows_main_agent_asset_image_read():
+    _, _, parsed = run_hook(HOOK, _read_payload("assets/player.png"))
+
+    assert not is_blocked(parsed)
+
+
+def test_pipeline_role_blocks_main_agent_asset_image_read():
+    write_current_role("build")
+
+    _, _, parsed = run_hook(HOOK, _read_payload("assets/player.png"))
+
+    assert is_blocked(parsed)
+
+
+def test_pipeline_role_allows_subagent_asset_image_read():
+    write_current_role("build")
+
+    _, _, parsed = run_hook(HOOK, _read_payload("assets/player.png", agent_id="analyst-1"))
+
+    assert not is_blocked(parsed)
+
+
+def test_pipeline_role_allows_non_image_asset_read():
+    write_current_role("build")
+
+    _, _, parsed = run_hook(HOOK, _read_payload("assets/manifest.json"))
+
+    assert not is_blocked(parsed)

--- a/tests/hooks/test_check_file_permissions.py
+++ b/tests/hooks/test_check_file_permissions.py
@@ -9,6 +9,7 @@ HOOK = "check_file_permissions.py"
 
 @pytest.fixture(autouse=True)
 def clean():
+    cleanup_metrics()
     yield
     cleanup_metrics()
 
@@ -23,17 +24,17 @@ def project_dir():
         os.chdir(original)
 
 
-class TestMainAgentBlocked:
-    """Main agent (no agent_id) should be blocked from writing game code."""
+class TestNoRoleRegularConversation:
+    """Without current_role, hooks must not restrict ordinary conversations."""
 
     @pytest.mark.parametrize("ext", [".gd", ".tscn", ".tres"])
-    def test_block_game_code_extensions(self, ext):
+    def test_main_agent_can_write_game_code_extensions(self, ext):
         _, _, parsed = run_hook(HOOK, {
             "tool_name": "Write",
             "tool_input": {"file_path": f"scripts/player{ext}"},
             "agent_id": "",
         })
-        assert is_blocked(parsed), f"Should block main agent writing {ext}"
+        assert not is_blocked(parsed), f"No-role main agent should write {ext}"
 
     def test_allow_planning_docs(self):
         _, _, parsed = run_hook(HOOK, {
@@ -52,17 +53,17 @@ class TestMainAgentBlocked:
         assert not is_blocked(parsed), "Main agent should be allowed to edit MEMORY.md"
 
 
-class TestWorkerBlocked:
-    """Subagents (with agent_id) should be blocked from writing planning docs."""
+class TestNoRoleSubagentRegularConversation:
+    """Without current_role, subagents are not treated as pipeline workers."""
 
     @pytest.mark.parametrize("doc", ["PLAN.md", "STRUCTURE.md", "STYLE.md", "ASSETS.md"])
-    def test_block_planning_docs(self, doc):
+    def test_allow_planning_docs(self, doc):
         _, _, parsed = run_hook(HOOK, {
             "tool_name": "Edit",
             "tool_input": {"file_path": doc},
             "agent_id": "worker-123",
         })
-        assert is_blocked(parsed), f"Worker should be blocked from writing {doc}"
+        assert not is_blocked(parsed), f"No-role subagent should write {doc}"
 
     def test_allow_game_code(self):
         _, _, parsed = run_hook(HOOK, {
@@ -83,6 +84,10 @@ class TestWorkerBlocked:
 
 class TestDecomposerSubagent:
     """Decomposer subagent owns planning docs — must be exempt from the worker block."""
+
+    @pytest.fixture(autouse=True)
+    def active_gdd_role(self, project_dir):
+        write_current_role("gdd")
 
     # Full decomposer-owned set: PLANNING_DOCS minus gap.md (which belongs to
     # /gm-fixgap's lead, not decomposer) plus project.godot.
@@ -158,6 +163,10 @@ class TestIdentityResolution:
     Payload wins when present; metrics is consulted only when payload is empty.
     These tests document and freeze that priority — if the resolution rule
     changes (e.g., to require both to agree), update these tests deliberately."""
+
+    @pytest.fixture(autouse=True)
+    def active_gdd_role(self, project_dir):
+        write_current_role("gdd")
 
     def test_payload_decomposer_metrics_worker_allows(self, project_dir):
         """When payload says decomposer and metrics says worker, the payload
@@ -243,7 +252,7 @@ class TestEdgeCases:
             "tool_input": {"file_path": "scripts\\player_system.gd"},
             "agent_id": "",
         })
-        assert is_blocked(parsed), "Should handle Windows backslash paths"
+        assert not is_blocked(parsed), "No-role regular conversation should allow Windows paths"
 
 
 class TestRoleBased:

--- a/tests/hooks/test_check_worker_report.py
+++ b/tests/hooks/test_check_worker_report.py
@@ -1,6 +1,6 @@
 """Tests for check_worker_report.py hook."""
 import pytest
-from .helpers import run_hook, is_blocked, cleanup_metrics
+from .helpers import run_hook, is_blocked, cleanup_metrics, write_current_role
 
 HOOK = "check_worker_report.py"
 
@@ -34,6 +34,8 @@ COMPLETE_REVIEWER = (
 
 @pytest.fixture(autouse=True)
 def clean():
+    cleanup_metrics()
+    write_current_role("build")
     yield
     cleanup_metrics()
 
@@ -208,6 +210,16 @@ class TestFlexibleMarkerDetection:
 
 
 class TestEdgeCases:
+    def test_no_current_role_allows_regular_subagent_output(self):
+        cleanup_metrics()
+        _, code, parsed = run_hook(HOOK, {
+            "hook_event_name": "SubagentStop",
+            "agent_id": "x1",
+            "last_assistant_message": COMPLETE_WORKER.replace("### Tests", "### REMOVED"),
+        })
+        assert code == 0
+        assert not is_blocked(parsed)
+
     def test_unknown_report_type_allowed(self):
         _, code, parsed = run_hook(HOOK, {
             "hook_event_name": "SubagentStop",


### PR DESCRIPTION
## Summary

Allow ordinary coding-agent conversations in GodotMaker project directories when no `.godotmaker/current_role` pipeline lock is active.

## Motivation

Published GodotMaker hooks were applying pipeline restrictions to normal Claude Code conversations opened inside a generated project. A fresh session clears `current_role`, so no-role should mean ordinary conversation rather than legacy pipeline enforcement.

## Changes

- [x] Make file-permission enforcement allow Write/Edit when no `current_role` is active.
- [x] Make asset image read and subagent report gates skip enforcement when no `current_role` is active.
- [x] Keep role-based protections active when `/gm-*` skills write `current_role`.
- [x] Update English and Chinese hook docs plus release notes.
- [x] Add hook tests for no-role ordinary conversations and active-role enforcement.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
  - `python -m pytest tests/hooks/test_check_file_permissions.py tests/hooks/test_check_asset_access.py tests/hooks/test_check_worker_report.py`
- [x] Gitleaks passes or no secret-bearing files were touched
  - `gitleaks detect --source . --config .gitleaks.toml`
- [ ] Manual testing completed, if applicable

## Benchmark Verification

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: executed`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR