### PR TITLE
Detect user assets before generation

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -22,6 +22,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Changed
 
 - Clarified README preview-feature scope and roadmap priorities for art production, Codex runner fallback, 3D support, and audio generation.
+- `/gm-asset` now runs a lightweight user-asset preflight before generation so CLI-driven runs can notice files already placed under `assets/`.
 
 ## Fixed
 

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -77,18 +77,55 @@ Read `ASSETS.md` Asset Table. Filter to rows whose `Tag` matches the current tag
 
 Do NOT touch rows from prior tags — even if they look broken, that's a `/gm-fixgap` concern. New rows you add for newly-discovered assets must carry the current tag in their `Tag` column.
 
-### Step 2 — Collect User-Provided Files
+### Step 2 — Detect User-Provided Files
 
-Use `AskUserQuestion`:
-> "I'm about to fill in {N} missing assets. Do you want to provide any of them yourself before I generate? Audio MUST be user-provided. Place files in `assets/` and tell me when ready."
+Run the deterministic preflight before any AI generation:
 
-If user provides files:
+```bash
+python tools/asset_user_preflight.py --project-root .
+```
 
-1. Wait for user confirmation that files are placed.
-2. Dispatch an **analyst subagent** (`subagent_type: "analyst"`, see `references/analyst-dispatch.md`) to inspect image files and generate/update `assets/manifest.json`.
+The script scans supported file suffixes under `assets/`, excludes paths already
+consumed by completed ASSETS.md rows or `assets/manifest.json`, and prints JSON:
+
+```json
+{
+  "ok": true,
+  "candidate_count": 2,
+  "image_candidate_count": 1,
+  "audio_candidate_count": 1,
+  "needs_analyst": true,
+  "candidates": [
+    {"path": "assets/player.png", "kind_hint": "image", "reason": "..."},
+    {"path": "assets/audio/hit.ogg", "kind_hint": "audio", "reason": "..."}
+  ]
+}
+```
+
+Candidates can include `match_kind: "exact_path"` with `matched_asset_id`,
+`matched_asset_type`, and `matched_status` when the file path exactly matches an
+unfilled ASSETS.md row.
+
+If `candidate_count > 0`, treat the listed files as user-provided candidates
+already placed on disk:
+
+1. For image candidates, dispatch an **analyst subagent**
+   (`subagent_type: "analyst"`, see `references/analyst-dispatch.md`) to
+   inspect only the listed candidate paths and generate/update
+   `assets/manifest.json`.
    - **Do NOT read image files yourself.** All image analysis goes through the analyst.
    - Analyst extracts: type, role, dimensions, palette, style characteristics.
-3. After analyst reports, update ASSETS.md: change matching `MISSING` rows to `provided`.
+2. For audio candidates, do not dispatch analyst. Prefer preflight candidates
+   with `match_kind: "exact_path"`; otherwise match only by clear
+   filename/asset-id match.
+3. After analyst reports, update ASSETS.md: change high-confidence matching
+   `MISSING` / `deferred` rows to `provided`.
+4. Leave uncertain candidates in `assets/manifest.json` or on disk without
+   changing ASSETS.md. Do not guess.
+
+If no candidates are found, continue to generation. In an interactive session
+you may still ask the user whether they want to add files before generation,
+but CLI-driven runs must not depend on that question being answered.
 
 ### Step 3 — Generate Scene Reference Images (if MISSING)
 
@@ -218,6 +255,7 @@ Never revert a `provided`/`generated` row back to `MISSING`; if the user wants t
 | Tool | Purpose |
 |------|---------|
 | `tools/asset_gen.py` | API-backed image generation (Gemini / OpenAI / Grok) |
+| `tools/asset_user_preflight.py` | Find unconsumed user-provided asset candidates under `assets/` |
 | `tools/codex_image_claim.py` | Copy Codex saved_path into a project source path |
 | `tools/asset_image_finalize.py` | Copy, resize, and validate generated image assets |
 | `tools/asset_image_report_check.py` | Validate generation group reports and image files |

--- a/tests/tools/test_asset_user_preflight.py
+++ b/tests/tools/test_asset_user_preflight.py
@@ -1,0 +1,127 @@
+from pathlib import Path
+import sys
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_user_preflight import find_user_asset_candidates  # noqa: E402
+
+
+def write_assets_md(root: Path) -> None:
+    (root / "ASSETS.md").write_text(
+        "# Assets\n\n"
+        "## Asset Table\n\n"
+        "| ID | Tag | Name | Type | Size | Params | File Path | Status |\n"
+        "|---|---|---|---|---|---|---|---|\n"
+        "| 1 | v0.1.0 | player | sprite | 32x32 | user | assets/player.png | MISSING |\n"
+        "| 2 | v0.1.0 | enemy | sprite | 32x32 | gen | assets/enemy.png | generated |\n"
+        "| 3 | v0.1.0 | jump | audio | 1s | user | assets/audio/jump.wav | deferred |\n",
+        encoding="utf-8",
+    )
+
+
+def test_detects_unconsumed_image_and_audio_candidates(tmp_path: Path):
+    write_assets_md(tmp_path)
+    (tmp_path / "assets" / "audio").mkdir(parents=True)
+    (tmp_path / "assets" / "player.png").write_bytes(b"image")
+    (tmp_path / "assets" / "ui.webp").write_bytes(b"image")
+    (tmp_path / "assets" / "audio" / "hit.ogg").write_bytes(b"audio")
+    (tmp_path / "assets" / "audio" / "jump.wav").write_bytes(b"audio")
+    (tmp_path / "assets" / "enemy.png").write_bytes(b"generated")
+    (tmp_path / "assets" / "notes.txt").write_text("ignore", encoding="utf-8")
+
+    result = find_user_asset_candidates(tmp_path)
+
+    assert result["needs_analyst"] is True
+    assert result["image_candidate_count"] == 2
+    assert result["audio_candidate_count"] == 2
+    paths = {item["path"] for item in result["candidates"]}
+    assert paths == {
+        "assets/player.png",
+        "assets/ui.webp",
+        "assets/audio/hit.ogg",
+        "assets/audio/jump.wav",
+    }
+    player = next(item for item in result["candidates"] if item["path"] == "assets/player.png")
+    assert player["match_kind"] == "exact_path"
+    assert player["matched_asset_id"] == "player"
+    assert player["matched_status"] == "MISSING"
+
+
+def test_excludes_manifest_paths_and_origin_archives(tmp_path: Path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    (tmp_path / "assets" / "origin").mkdir(parents=True)
+    (tmp_path / "assets" / "hero.png").write_bytes(b"image")
+    (tmp_path / "assets" / "known.png").write_bytes(b"image")
+    (tmp_path / "assets" / "origin" / "old.png").write_bytes(b"image")
+    (tmp_path / "assets" / "manifest.json").write_text(
+        '{"assets": [{"path": "assets/known.png"}]}',
+        encoding="utf-8",
+    )
+
+    result = find_user_asset_candidates(tmp_path)
+
+    paths = [item["path"] for item in result["candidates"]]
+    assert paths == ["assets/hero.png"]
+    assert result["consumed_paths"] == ["assets/known.png"]
+
+
+def test_excludes_real_analyst_manifest_file_schema(tmp_path: Path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    (tmp_path / "assets" / "sprites").mkdir(parents=True)
+    (tmp_path / "assets" / "sprites" / "player.png").write_bytes(b"image")
+    (tmp_path / "assets" / "sprites" / "enemy.png").write_bytes(b"image")
+    (tmp_path / "assets" / "manifest.json").write_text(
+        '{"assets": [{"file": "sprites/player.png"}]}',
+        encoding="utf-8",
+    )
+
+    result = find_user_asset_candidates(tmp_path)
+
+    paths = [item["path"] for item in result["candidates"]]
+    assert paths == ["assets/sprites/enemy.png"]
+    assert result["consumed_paths"] == ["assets/sprites/player.png"]
+
+
+def test_excludes_utf8_bom_manifest_paths(tmp_path: Path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    (tmp_path / "assets" / "sprites").mkdir(parents=True)
+    (tmp_path / "assets" / "sprites" / "known.png").write_bytes(b"image")
+    (tmp_path / "assets" / "sprites" / "new.png").write_bytes(b"image")
+    (tmp_path / "assets" / "manifest.json").write_text(
+        '{"assets": [{"file": "sprites/known.png"}]}',
+        encoding="utf-8-sig",
+    )
+
+    result = find_user_asset_candidates(tmp_path)
+
+    paths = [item["path"] for item in result["candidates"]]
+    assert paths == ["assets/sprites/new.png"]
+    assert result["warnings"] == []
+    assert result["consumed_paths"] == ["assets/sprites/known.png"]
+
+
+def test_detects_svg_as_image_candidate(tmp_path: Path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    (tmp_path / "assets" / "ui").mkdir(parents=True)
+    (tmp_path / "assets" / "ui" / "button.svg").write_text("<svg />", encoding="utf-8")
+
+    result = find_user_asset_candidates(tmp_path)
+
+    assert result["needs_analyst"] is True
+    assert result["image_candidate_count"] == 1
+    assert result["candidates"][0]["path"] == "assets/ui/button.svg"
+    assert result["candidates"][0]["kind_hint"] == "image"
+
+
+def test_audio_only_candidates_do_not_require_analyst(tmp_path: Path):
+    (tmp_path / "ASSETS.md").write_text("# Assets\n", encoding="utf-8")
+    (tmp_path / "assets").mkdir()
+    (tmp_path / "assets" / "theme.mp3").write_bytes(b"audio")
+
+    result = find_user_asset_candidates(tmp_path)
+
+    assert result["candidate_count"] == 1
+    assert result["image_candidate_count"] == 0
+    assert result["audio_candidate_count"] == 1
+    assert result["needs_analyst"] is False

--- a/tools/asset_user_preflight.py
+++ b/tools/asset_user_preflight.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Find user-provided asset candidates before AI generation.
+
+The script is intentionally lightweight: it scans file suffixes under
+``assets/`` and filters out paths already consumed by ASSETS.md or
+assets/manifest.json. It does not inspect image/audio content.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".webp", ".svg"}
+AUDIO_SUFFIXES = {".wav", ".ogg", ".mp3"}
+SUPPORTED_SUFFIXES = IMAGE_SUFFIXES | AUDIO_SUFFIXES
+DONE_STATUSES = {"provided", "generated", "n/a"}
+UNFILLED_STATUSES = {"missing", "pending", "deferred"}
+ASSET_PATH_RE = re.compile(r"assets[/\\][^\s|,;)]+", re.IGNORECASE)
+
+
+def _normalize_project_path(path: str | Path) -> str:
+    value = str(path).replace("\\", "/").strip()
+    while value.startswith("./"):
+        value = value[2:]
+    return value
+
+
+def _normalize_manifest_path(path: str) -> str | None:
+    value = _normalize_project_path(path.strip().strip("`'\""))
+    if not value:
+        return None
+    if value.startswith("assets/"):
+        return value
+    if "/" in value or "\\" in path:
+        return f"assets/{value}"
+    return None
+
+
+def _kind_for_suffix(suffix: str) -> str:
+    lower = suffix.lower()
+    if lower in IMAGE_SUFFIXES:
+        return "image"
+    if lower in AUDIO_SUFFIXES:
+        return "audio"
+    return "unknown"
+
+
+def _extract_asset_paths(text: str) -> set[str]:
+    paths: set[str] = set()
+    for match in ASSET_PATH_RE.findall(text):
+        cleaned = match.strip().strip("`'\"")
+        paths.add(_normalize_project_path(cleaned))
+    return paths
+
+
+def _assets_paths_by_status(assets_md: Path) -> tuple[set[str], dict[str, dict[str, str]]]:
+    if not assets_md.exists():
+        return set(), {}
+
+    done_paths: set[str] = set()
+    unfilled_paths: dict[str, dict[str, str]] = {}
+    text = assets_md.read_text(encoding="utf-8-sig")
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|") or "---" in stripped:
+            continue
+
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) < 2:
+            continue
+
+        status = cells[-1].strip().lower()
+        row_paths = _extract_asset_paths(stripped)
+        row_info = {
+            "asset_id": cells[2] if len(cells) > 2 else "",
+            "asset_type": cells[3] if len(cells) > 3 else "",
+            "status": cells[-1],
+        }
+        if status in DONE_STATUSES:
+            done_paths.update(row_paths)
+        elif status in UNFILLED_STATUSES:
+            for row_path in row_paths:
+                unfilled_paths[row_path] = row_info
+
+    return done_paths, unfilled_paths
+
+
+def _collect_manifest_paths(value: Any) -> set[str]:
+    paths: set[str] = set()
+    if isinstance(value, str):
+        paths.update(_extract_asset_paths(value))
+    elif isinstance(value, list):
+        for item in value:
+            paths.update(_collect_manifest_paths(item))
+    elif isinstance(value, dict):
+        file_value = value.get("file")
+        if isinstance(file_value, str):
+            normalized = _normalize_manifest_path(file_value)
+            if normalized is not None:
+                paths.add(normalized)
+        for key, item in value.items():
+            if key == "file":
+                continue
+            paths.update(_collect_manifest_paths(item))
+    return paths
+
+
+def _manifest_paths(manifest_path: Path) -> tuple[set[str], list[str]]:
+    if not manifest_path.exists():
+        return set(), []
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8-sig"))
+    except Exception as exc:
+        return set(), [f"Could not parse {manifest_path}: {exc}"]
+    return _collect_manifest_paths(data), []
+
+
+def find_user_asset_candidates(project_root: Path) -> dict[str, object]:
+    project_root = project_root.resolve()
+    assets_dir = project_root / "assets"
+    assets_md = project_root / "ASSETS.md"
+    manifest_path = assets_dir / "manifest.json"
+
+    done_paths, unfilled_paths = _assets_paths_by_status(assets_md)
+    manifest_paths, warnings = _manifest_paths(manifest_path)
+    consumed_paths = done_paths | manifest_paths
+
+    candidates: list[dict[str, object]] = []
+    if assets_dir.exists():
+        for path in sorted(assets_dir.rglob("*")):
+            if not path.is_file():
+                continue
+            suffix = path.suffix.lower()
+            if suffix not in SUPPORTED_SUFFIXES:
+                continue
+
+            rel_path = _normalize_project_path(path.relative_to(project_root))
+            if rel_path == "assets/manifest.json":
+                continue
+            if rel_path.startswith("assets/origin/"):
+                continue
+            if rel_path in consumed_paths:
+                continue
+
+            reason = "not in completed ASSETS.md rows or assets/manifest.json"
+            candidate: dict[str, object] = {
+                "path": rel_path,
+                "kind_hint": _kind_for_suffix(suffix),
+                "reason": reason,
+                "match_kind": "unmatched",
+            }
+            if rel_path in unfilled_paths:
+                reason = "matches an unfilled ASSETS.md path"
+                row_info = unfilled_paths[rel_path]
+                candidate.update({
+                    "reason": reason,
+                    "match_kind": "exact_path",
+                    "matched_asset_id": row_info["asset_id"],
+                    "matched_asset_type": row_info["asset_type"],
+                    "matched_status": row_info["status"],
+                })
+            candidates.append(candidate)
+
+    image_count = sum(1 for item in candidates if item["kind_hint"] == "image")
+    audio_count = sum(1 for item in candidates if item["kind_hint"] == "audio")
+    return {
+        "ok": True,
+        "assets_dir": "assets",
+        "candidate_count": len(candidates),
+        "image_candidate_count": image_count,
+        "audio_candidate_count": audio_count,
+        "needs_analyst": image_count > 0,
+        "candidates": candidates,
+        "consumed_paths": sorted(consumed_paths),
+        "warnings": warnings,
+    }
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Find unconsumed user-provided asset candidates under assets/"
+    )
+    parser.add_argument(
+        "--project-root",
+        default=".",
+        help="Project root containing ASSETS.md and assets/",
+    )
+    args = parser.parse_args()
+
+    result = find_user_asset_candidates(Path(args.project_root))
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
﻿## Summary

Add a deterministic `/gm-asset` preflight that detects user-provided files already placed under `assets/` before AI generation starts.

## Motivation

CLI-driven asset runs cannot rely on an interactive user question to discover files added outside the agent flow. A cheap suffix scan lets the asset stage notice obvious user-provided images and audio without expensive content inspection.

## Changes

- [x] Add `tools/asset_user_preflight.py` to report unconsumed image/audio candidates under `assets/`.
- [x] Update `/gm-asset` to run the preflight before generation and dispatch analyst only for image candidates.
- [x] Add pytest coverage for ASSETS.md status filtering, analyst manifest paths, UTF-8 BOM manifests, SVG detection, and audio-only candidates.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

```text
python -m pytest tests\tools\test_asset_user_preflight.py -q
6 passed in 0.09s

python -m pytest --tb=short -q
866 passed in 35.86s

gitleaks detect --source . --config .gitleaks.toml
no leaks found
```

Manual smoke:

```text
Published current branch into a temporary target project, created ASSETS.md plus files under assets/, and ran the published tools\asset_user_preflight.py in that target.
Result: PASS; 3 candidates detected, completed/manifest/origin paths excluded, warnings empty.
```

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
N/A
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
