### PR TITLE
fix: split GPU deps so macOS can install tool requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,8 @@ python -m pip install pytest ruff mkdocs mkdocs-material
 
 # Optional: install asset/API provider dependencies when working on tools/
 python -m pip install -r tools/requirements.txt
+# Optional: NVIDIA GPU acceleration for rembg (Linux/Windows only)
+# python -m pip install -r tools/requirements-gpu.txt
 ```
 
 ## Coding Conventions

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ For framework development:
 git clone https://github.com/RandallLiuXin/GodotMaker.git
 cd GodotMaker
 pip install -r tools/requirements.txt
+# Optional: NVIDIA GPU acceleration for rembg (Linux/Windows only)
+# pip install -r tools/requirements-gpu.txt
 python tools/check_env.py
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -69,6 +69,8 @@ CLI 会从 idea 梳理和 GDD 规划开始驱动工作流，直到生成一个�
 git clone https://github.com/RandallLiuXin/GodotMaker.git
 cd GodotMaker
 pip install -r tools/requirements.txt
+# 可选：rembg NVIDIA GPU 加速（仅 Linux/Windows）
+# pip install -r tools/requirements-gpu.txt
 python tools/check_env.py
 ```
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -21,6 +21,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Changed
 
+- Split Python tool dependencies: `tools/requirements.txt` now installs CPU `onnxruntime` for all platforms; optional `tools/requirements-gpu.txt` adds NVIDIA CUDA acceleration on Linux/Windows.
 - Clarified README preview-feature scope and roadmap priorities for art production, Codex runner fallback, 3D support, and audio generation.
 - `/gm-asset` now runs a lightweight user-asset preflight before generation so CLI-driven runs can notice files already placed under `assets/`.
 

--- a/docs/wiki/01-getting-started/installation.md
+++ b/docs/wiki/01-getting-started/installation.md
@@ -61,6 +61,8 @@ For framework development or manual publishing, clone the repository:
 git clone https://github.com/RandallLiuXin/GodotMaker.git
 cd GodotMaker
 pip install -r tools/requirements.txt
+# Optional: NVIDIA GPU acceleration for rembg (Linux/Windows only)
+# pip install -r tools/requirements-gpu.txt
 python tools/check_env.py
 ```
 

--- a/docs/wiki/07-contributing/development-setup.md
+++ b/docs/wiki/07-contributing/development-setup.md
@@ -8,6 +8,8 @@ This page gets you from a fresh clone to a running test suite, and walks through
 git clone https://github.com/RandallLiuXin/GodotMaker.git
 cd GodotMaker
 pip install -r tools/requirements.txt
+# Optional: NVIDIA GPU acceleration for rembg (Linux/Windows only)
+# pip install -r tools/requirements-gpu.txt
 ```
 
 You also need **Godot 4.5 or later** on your `PATH`. Run this to confirm everything is in place before you start:

--- a/docs/zh/wiki/01-getting-started/installation.md
+++ b/docs/zh/wiki/01-getting-started/installation.md
@@ -61,6 +61,8 @@ npm install -g godotmaker-cli
 git clone https://github.com/RandallLiuXin/GodotMaker.git
 cd GodotMaker
 pip install -r tools/requirements.txt
+# 可选：rembg NVIDIA GPU 加速（仅 Linux/Windows）
+# pip install -r tools/requirements-gpu.txt
 python tools/check_env.py
 ```
 

--- a/docs/zh/wiki/07-contributing/development-setup.md
+++ b/docs/zh/wiki/07-contributing/development-setup.md
@@ -8,6 +8,8 @@
 git clone https://github.com/RandallLiuXin/GodotMaker.git
 cd GodotMaker
 pip install -r tools/requirements.txt
+# 可选：rembg NVIDIA GPU 加速（仅 Linux/Windows）
+# pip install -r tools/requirements-gpu.txt
 ```
 
 你还需要将 **Godot 4.5 或更高版本**加入 `PATH`。开始之前先运行以下命令确认环境就绪：

--- a/skills/core/gm-asset/references/rembg.md
+++ b/skills/core/gm-asset/references/rembg.md
@@ -24,9 +24,9 @@ The prompt must include a solid flat background color. Without it, the generator
 
 The script auto-detects NVIDIA GPUs and uses CUDA when available. If a GPU is present but CUDA deps are missing, it prints a clear warning and falls back to CPU.
 
-Required for GPU:
+Required for GPU (Linux/Windows with NVIDIA CUDA only):
 ```bash
-pip install onnxruntime-gpu nvidia-cudnn-cu12==9.*
+pip install -r tools/requirements-gpu.txt
 ```
 
 Verify CUDA is working:
@@ -39,9 +39,10 @@ If the script warns about GPU detected but CUDA unavailable — install the deps
 
 ## CLI
 
-Dependencies in `tools/requirements.txt`. If rembg is not installed:
+Dependencies in `tools/requirements.txt` (CPU). For NVIDIA GPU acceleration on Linux/Windows, also install `tools/requirements-gpu.txt`. If rembg is not installed:
 ```bash
-pip install rembg[gpu,cli]   # use rembg[cpu,cli] if no GPU
+pip install -r tools/requirements.txt
+pip install -r tools/requirements-gpu.txt   # optional, Linux/Windows + NVIDIA only
 ```
 
 ### Single image

--- a/tools/rembg_matting.py
+++ b/tools/rembg_matting.py
@@ -75,7 +75,7 @@ def create_session(model: str = "birefnet-general"):
             "WARNING: NVIDIA GPU detected but CUDA is not available for rembg/onnxruntime.\n"
             "  Background removal will run on CPU (much slower).\n"
             "  To fix, install GPU dependencies:\n"
-            "    pip install onnxruntime-gpu nvidia-cudnn-cu12==9.*\n"
+            "    pip install -r tools/requirements-gpu.txt\n"
             "  Then verify:\n"
             "    python -c \"import onnxruntime; print(onnxruntime.get_available_providers())\"\n"
             "  Expected output should include 'CUDAExecutionProvider'.\n",

--- a/tools/requirements-gpu.txt
+++ b/tools/requirements-gpu.txt
@@ -1,0 +1,10 @@
+# Optional NVIDIA CUDA acceleration for rembg background removal.
+# Linux/Windows with an NVIDIA GPU only — not available on macOS.
+#
+# Install after the base requirements:
+#   pip install -r tools/requirements.txt
+#   pip install -r tools/requirements-gpu.txt
+#
+# Replaces the CPU onnxruntime wheel with onnxruntime-gpu.
+onnxruntime-gpu
+nvidia-cudnn-cu12==9.*

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -6,5 +6,4 @@ numpy
 pillow
 rembg
 pymatting
-onnxruntime-gpu
-nvidia-cudnn-cu12==9.*
+onnxruntime


### PR DESCRIPTION
Move onnxruntime-gpu and nvidia-cudnn into optional requirements-gpu.txt and use CPU onnxruntime in the base requirements for all platforms.

