### PR TITLE
Add community links to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ During a run, GodotMaker agents keep moving the design forward:
 
 A small game usually takes about **3-5 hours of agent runtime**. You do not need to manually drive each stage or keep an eye on it the whole time; the workflow is designed to keep going on its own.
 
+## Community
+
+- [Discord](https://discord.gg/rjhP9Z9PHP)
+
 ## Quick Start
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,6 +49,10 @@ Claude Code、Codex、Gemini、OpenAI、xAI、Tripo 等外部 runtime 或模型 
 
 一个小型游戏通常需要 **3-5 小时的 Agent 运行时间**。不过你不需要手动驱动每个阶段，也不需要一直守在电脑前，工作流会自己持续推进。
 
+## 社区
+
+- 【GodotMaker】：https://qm.qq.com/q/z6huEnumru
+
 ## 快速开始
 
 ```bash


### PR DESCRIPTION
## Summary

Add visible community links to the README files.

## Motivation

The project now has dedicated community channels, and the README should make them easy to find before users start setup. The English README points users to Discord, while the Chinese README points users to the QQ group invite.

## Changes

- [x] Add the Discord invite link to `README.md` before Quick Start.
- [x] Add the GodotMaker QQ group invite link to `README.zh-CN.md` before 快速开始.

## Testing

- [ ] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

Documentation-only change. I reviewed the final README diff; no local tests were run.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

Not applicable; no migration was added or modified.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR

ECS metadata is not applicable to this README-only change. `docs/update/next.md` was not updated because this is a documentation-only community-link update.