### PR TITLE
Add OpenCode runtime support

### DIFF
--- a/agent-runtimes/opencode/plugins/godotmaker-hooks.js
+++ b/agent-runtimes/opencode/plugins/godotmaker-hooks.js
@@ -50,6 +50,7 @@ function runHook(projectRoot, script, payload, options = {}) {
   const parsed = parseJson(result.stdout)
   const reason = blockReason(parsed)
   if (reason) {
+    if (options.blockDecision === "return") return parsed
     throw new Error(reason)
   }
   if (result.error) {
@@ -60,6 +61,54 @@ function runHook(projectRoot, script, payload, options = {}) {
     throw new Error(`GodotMaker hook ${script} exited ${result.status}${stderr ? `: ${stderr}` : ""}`)
   }
   return parsed
+}
+
+function runStopHook(projectRoot, script, payload) {
+  const parsed = runHook(projectRoot, script, payload, {
+    blockDecision: "return",
+    failOnNonZero: false,
+  })
+  const reason = blockReason(parsed)
+  return reason ? { script, reason } : null
+}
+
+function stopNoticeText(blocks) {
+  const details = blocks.map((block) => `- ${block.script}: ${block.reason}`).join("\n\n")
+  return [
+    "GodotMaker Stop hooks blocked this stage from finishing.",
+    "",
+    details,
+    "",
+    "Address the hook feedback, then finish the active GodotMaker stage again.",
+  ].join("\n")
+}
+
+async function sendStopNotice(client, sessionID, blocks) {
+  if (!blocks.length || !sessionID) return
+  const text = stopNoticeText(blocks)
+  try {
+    await client?.session?.prompt?.({
+      path: { id: sessionID },
+      body: {
+        parts: [{ type: "text", text }],
+      },
+    })
+    return
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.warn(`[GodotMaker] failed to send Stop hook prompt: ${message}`)
+  }
+  try {
+    await client?.tui?.showToast?.({
+      body: {
+        title: "GodotMaker Stop hook blocked",
+        message: text.slice(0, 1800),
+        variant: "warning",
+      },
+    })
+  } catch {
+    // Toast is best-effort. The log line above is the final fallback.
+  }
 }
 
 function claudeToolName(tool) {
@@ -154,7 +203,7 @@ function runPostToolHooks(projectRoot, input, output) {
   })
 }
 
-function runSessionEventHooks(projectRoot, event, rootSessions) {
+async function runSessionEventHooks(projectRoot, client, event, rootSessions) {
   const type = event?.type || ""
   if (type === "session.created") {
     const info = asObject(event?.properties?.info)
@@ -177,17 +226,21 @@ function runSessionEventHooks(projectRoot, event, rootSessions) {
       session_id: sessionID,
       agent_id: "",
     }
-    runHook(projectRoot, "check_completion.py", payload)
-    runHook(projectRoot, "check_clean_workspace.py", payload, { failOnNonZero: false })
+    const blocks = [
+      runStopHook(projectRoot, "check_completion.py", payload),
+      runStopHook(projectRoot, "check_clean_workspace.py", payload),
+    ].filter(Boolean)
+    await sendStopNotice(client, sessionID, blocks)
   }
 }
 
 export const GodotMakerHooks = async (ctx) => {
   const projectRoot = ctx.directory
+  const client = ctx.client
   const rootSessions = new Set()
   return {
     event: async (input) => {
-      runSessionEventHooks(projectRoot, input.event, rootSessions)
+      await runSessionEventHooks(projectRoot, client, input.event, rootSessions)
     },
     "tool.execute.before": async (input, output) => {
       runPreToolHooks(projectRoot, input, output)

--- a/agent-runtimes/opencode/plugins/godotmaker-hooks.js
+++ b/agent-runtimes/opencode/plugins/godotmaker-hooks.js
@@ -149,18 +149,29 @@ function taskPayload(input, args) {
   return payload
 }
 
-function runPreToolHooks(projectRoot, input, output) {
+function runPreToolHooks(projectRoot, input, output, childSessions) {
   const tool = String(input.tool || "").toLowerCase()
   const args = asObject(output.args)
+  const isChildSession = childSessions.has(input.sessionID || "")
 
   if (tool === "write" || tool === "edit") {
+    // OpenCode tool hooks do not expose a reliable subagent identity.
     const payload = basePayload("PreToolUse", input, args)
-    runHook(projectRoot, "check_file_permissions.py", payload)
+    // Child sessions are governed by native `.opencode/agents/*.md` edit
+    // permissions. Running the Python role gate without an agent_id would
+    // misclassify the child as the root stage agent and block valid worker
+    // edits, but stage completion writes still need schema validation below.
+    if (!isChildSession) {
+      runHook(projectRoot, "check_file_permissions.py", payload)
+    }
     runHook(projectRoot, "stage_reminder.py", payload)
     return
   }
 
   if (tool === "read") {
+    // OpenCode child sessions do not expose the agent_id required by the
+    // Python asset-read gate. Keep the gate on the root stage session only.
+    if (isChildSession) return
     runHook(projectRoot, "check_asset_access.py", basePayload("PreToolUse", input, args))
     return
   }
@@ -169,12 +180,6 @@ function runPreToolHooks(projectRoot, input, output) {
     const payload = taskPayload(input, args)
     runHook(projectRoot, "check_stage_prerequisites.py", payload)
     runHook(projectRoot, "log_agent_tool.py", payload, { failOnNonZero: false })
-    runHook(projectRoot, "log_subagent.py", {
-      ...payload,
-      hook_event_name: "SubagentStart",
-      agent_id: input.callID || "",
-      agent_type: payload.agent_type || "",
-    }, { failOnNonZero: false })
   }
 }
 
@@ -194,13 +199,6 @@ function runPostToolHooks(projectRoot, input, output) {
     tool_response: response,
   }
   runHook(projectRoot, "log_agent_tool.py", payload, { failOnNonZero: false })
-  runHook(projectRoot, "on_subagent_stop.py", {
-    ...payload,
-    hook_event_name: "SubagentStop",
-    agent_id: input.callID || "",
-    agent_type: args.subagent_type || "",
-    last_assistant_message: response.output || "",
-  })
 }
 
 async function runSessionEventHooks(projectRoot, client, event, rootSessions) {
@@ -238,12 +236,19 @@ export const GodotMakerHooks = async (ctx) => {
   const projectRoot = ctx.directory
   const client = ctx.client
   const rootSessions = new Set()
+  const childSessions = new Set()
   return {
     event: async (input) => {
-      await runSessionEventHooks(projectRoot, client, input.event, rootSessions)
+      const event = input.event
+      if (event?.type === "session.created") {
+        const info = asObject(event?.properties?.info)
+        const sessionID = info.id || event?.properties?.sessionID || ""
+        if (info.parentID && sessionID) childSessions.add(sessionID)
+      }
+      await runSessionEventHooks(projectRoot, client, event, rootSessions)
     },
     "tool.execute.before": async (input, output) => {
-      runPreToolHooks(projectRoot, input, output)
+      runPreToolHooks(projectRoot, input, output, childSessions)
     },
     "tool.execute.after": async (input, output) => {
       runPostToolHooks(projectRoot, input, output)

--- a/agent-runtimes/opencode/plugins/godotmaker-hooks.js
+++ b/agent-runtimes/opencode/plugins/godotmaker-hooks.js
@@ -1,0 +1,205 @@
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import path from "node:path"
+
+const PYTHON = process.env.GODOTMAKER_HOOK_PYTHON || "python"
+
+function asObject(value) {
+  return value && typeof value === "object" && !Array.isArray(value) ? value : {}
+}
+
+function hookPath(projectRoot, script) {
+  return path.join(projectRoot, ".godotmaker", "hooks", script)
+}
+
+function parseJson(text) {
+  const trimmed = (text || "").trim()
+  if (!trimmed) return null
+  try {
+    return JSON.parse(trimmed)
+  } catch {
+    return null
+  }
+}
+
+function blockReason(parsed) {
+  if (!parsed) return null
+  if (parsed.decision === "block") return parsed.reason || "GodotMaker hook blocked this action."
+  const specific = asObject(parsed.hookSpecificOutput)
+  if (specific.permissionDecision === "deny") {
+    return specific.permissionDecisionReason || "GodotMaker hook denied this action."
+  }
+  return null
+}
+
+function runHook(projectRoot, script, payload, options = {}) {
+  const scriptPath = hookPath(projectRoot, script)
+  if (!existsSync(scriptPath)) return null
+
+  const result = spawnSync(PYTHON, [scriptPath], {
+    cwd: projectRoot,
+    input: JSON.stringify(payload),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PYTHONDONTWRITEBYTECODE: "1",
+    },
+    maxBuffer: 1024 * 1024 * 4,
+  })
+
+  const parsed = parseJson(result.stdout)
+  const reason = blockReason(parsed)
+  if (reason) {
+    throw new Error(reason)
+  }
+  if (result.error) {
+    throw new Error(`GodotMaker hook ${script} failed: ${result.error.message}`)
+  }
+  if (result.status !== 0 && options.failOnNonZero !== false) {
+    const stderr = (result.stderr || "").trim()
+    throw new Error(`GodotMaker hook ${script} exited ${result.status}${stderr ? `: ${stderr}` : ""}`)
+  }
+  return parsed
+}
+
+function claudeToolName(tool) {
+  const normalized = String(tool || "").toLowerCase()
+  if (normalized === "read") return "Read"
+  if (normalized === "write") return "Write"
+  if (normalized === "edit") return "Edit"
+  if (normalized === "task") return "Agent"
+  return tool || ""
+}
+
+function claudeToolInput(args) {
+  const input = { ...asObject(args) }
+  if (input.filePath && !input.file_path) input.file_path = input.filePath
+  if (input.oldString && !input.old_string) input.old_string = input.oldString
+  if (input.newString && !input.new_string) input.new_string = input.newString
+  if (input.replaceAll !== undefined && input.replace_all === undefined) {
+    input.replace_all = input.replaceAll
+  }
+  return input
+}
+
+function basePayload(eventName, input, args) {
+  return {
+    hook_event_name: eventName,
+    tool_name: claudeToolName(input.tool),
+    tool_input: claudeToolInput(args),
+    tool_use_id: input.callID || "",
+    session_id: input.sessionID || "",
+    agent_id: "",
+  }
+}
+
+function taskPayload(input, args) {
+  const payload = basePayload("PreToolUse", input, args)
+  const toolInput = asObject(payload.tool_input)
+  payload.agent_type = toolInput.subagent_type || ""
+  return payload
+}
+
+function runPreToolHooks(projectRoot, input, output) {
+  const tool = String(input.tool || "").toLowerCase()
+  const args = asObject(output.args)
+
+  if (tool === "write" || tool === "edit") {
+    const payload = basePayload("PreToolUse", input, args)
+    runHook(projectRoot, "check_file_permissions.py", payload)
+    runHook(projectRoot, "stage_reminder.py", payload)
+    return
+  }
+
+  if (tool === "read") {
+    runHook(projectRoot, "check_asset_access.py", basePayload("PreToolUse", input, args))
+    return
+  }
+
+  if (tool === "task") {
+    const payload = taskPayload(input, args)
+    runHook(projectRoot, "check_stage_prerequisites.py", payload)
+    runHook(projectRoot, "log_agent_tool.py", payload, { failOnNonZero: false })
+    runHook(projectRoot, "log_subagent.py", {
+      ...payload,
+      hook_event_name: "SubagentStart",
+      agent_id: input.callID || "",
+      agent_type: payload.agent_type || "",
+    }, { failOnNonZero: false })
+  }
+}
+
+function runPostToolHooks(projectRoot, input, output) {
+  const tool = String(input.tool || "").toLowerCase()
+  if (tool !== "task") return
+
+  const args = asObject(input.args)
+  const response = {
+    title: output?.title || "",
+    output: output?.output || "",
+    metadata: output?.metadata || {},
+  }
+  const payload = {
+    ...taskPayload(input, args),
+    hook_event_name: "PostToolUse",
+    tool_response: response,
+  }
+  runHook(projectRoot, "log_agent_tool.py", payload, { failOnNonZero: false })
+  runHook(projectRoot, "on_subagent_stop.py", {
+    ...payload,
+    hook_event_name: "SubagentStop",
+    agent_id: input.callID || "",
+    agent_type: args.subagent_type || "",
+    last_assistant_message: response.output || "",
+  })
+}
+
+function runSessionEventHooks(projectRoot, event, rootSessions) {
+  const type = event?.type || ""
+  if (type === "session.created") {
+    const info = asObject(event?.properties?.info)
+    const sessionID = info.id || event?.properties?.sessionID || ""
+    if (info.parentID) return
+    if (sessionID) rootSessions.add(sessionID)
+    runHook(projectRoot, "session_start.py", {
+      hook_event_name: "SessionStart",
+      session_id: sessionID,
+    }, { failOnNonZero: false })
+    return
+  }
+
+  const status = event?.properties?.status?.type
+  if (type === "session.idle" || (type === "session.status" && status === "idle")) {
+    const sessionID = event?.properties?.sessionID || ""
+    if (!rootSessions.has(sessionID)) return
+    const payload = {
+      hook_event_name: "Stop",
+      session_id: sessionID,
+      agent_id: "",
+    }
+    runHook(projectRoot, "check_completion.py", payload)
+    runHook(projectRoot, "check_clean_workspace.py", payload, { failOnNonZero: false })
+  }
+}
+
+export const GodotMakerHooks = async (ctx) => {
+  const projectRoot = ctx.directory
+  const rootSessions = new Set()
+  return {
+    event: async (input) => {
+      runSessionEventHooks(projectRoot, input.event, rootSessions)
+    },
+    "tool.execute.before": async (input, output) => {
+      runPreToolHooks(projectRoot, input, output)
+    },
+    "tool.execute.after": async (input, output) => {
+      runPostToolHooks(projectRoot, input, output)
+    },
+    "experimental.session.compacting": async (input) => {
+      runHook(projectRoot, "log_compaction.py", {
+        hook_event_name: "PreCompact",
+        session_id: input.sessionID || "",
+      }, { failOnNonZero: false })
+    },
+  }
+}

--- a/agent-runtimes/opencode/references/runtime-mapping.md
+++ b/agent-runtimes/opencode/references/runtime-mapping.md
@@ -73,29 +73,23 @@ If OpenCode subagent execution is unavailable, use a sequential fallback only
 when the current stage explicitly allows the lead session to perform that role's
 work. Otherwise stop and report the missing capability before editing files.
 
-## MCP, Permissions, And Hooks
+## Runtime Boundaries
 
-- MCP: OpenCode must have a configured `godot` MCP server before stages that
-  depend on Godot MCP tools. If it is missing, stop with a setup handoff.
-- Permissions: unattended GodotMaker runs require OpenCode permissions that do
-  not deadlock on expected file edits, shell commands, git operations, and
-  Godot invocations. For OpenCode CLI runs, this normally means
-  `--dangerously-skip-permissions`.
-- Hooks: OpenCode uses `.opencode/plugins/godotmaker-hooks.js`, which publish
-  deploys from the OpenCode runtime package. The plugin adapts OpenCode
-  `tool.execute.before`, `tool.execute.after`, session, and compaction events
-  to GodotMaker's Python hook scripts under `.godotmaker/hooks`.
-- Lifecycle hooks are best-effort where OpenCode event semantics differ from
-  Claude Code. File gates, asset read gates, task dispatch gates, subagent
-  report gates, completion gates, and compaction metrics must still go through
-  the deployed plugin adapter.
+- Use the configured OpenCode `godot` MCP server for Godot operations. If it is
+  missing, stop with a setup handoff.
+- Root-stage hooks remain active through `.opencode/plugins/godotmaker-hooks.js`.
+- Child-session edit boundaries are governed by `.opencode/agents/*.md`
+  `permission` frontmatter, not by Claude-style `agent_id` hook payloads.
+- OpenCode child sessions do not provide the `agent_id` payload required by
+  GodotMaker's Python subagent read/write gates. Treat unsupported child-session
+  gates as degraded instead of claiming Claude Code hook parity.
 
 ## Image And VQA Capability
 
 OpenCode as a coding-agent runtime does not provide native image generation or
-native image inspection in the GodotMaker contract. If a project config selects
-`native` for `asset_image_model` or `vqa_model`, stop and ask the user to switch
-that field to `codex` or an API-backed selector before the dependent stage runs.
+native image inspection in the GodotMaker contract. If a dependent stage sees
+`native` for `asset_image_model` or `vqa_model`, stop and ask for `codex` or an
+API-backed selector.
 
 ## Unsupported Capability Rule
 

--- a/agent-runtimes/opencode/references/runtime-mapping.md
+++ b/agent-runtimes/opencode/references/runtime-mapping.md
@@ -44,6 +44,14 @@ Project artifact paths are different: if a skill asks the stage to create or
 consume project assets such as `references/scene_<name>.png`, resolve those as
 project-root files.
 
+## Dot-Directory File Checks
+
+Do not use Glob to prove that a known dot-directory state file is missing.
+For exact paths such as `.godotmaker/evaluation.json`,
+`.godotmaker/verify_report.json`, `.godotmaker/stage.jsonl`, or
+`.opencode/godotmaker.yaml`, use direct Read when the file content is needed,
+or a shell existence check when only existence matters.
+
 ## Delegated Roles
 
 OpenCode project agents are published under `.opencode/agents/*.md`.

--- a/agent-runtimes/opencode/references/runtime-mapping.md
+++ b/agent-runtimes/opencode/references/runtime-mapping.md
@@ -47,6 +47,13 @@ project-root files.
 ## Delegated Roles
 
 OpenCode project agents are published under `.opencode/agents/*.md`.
+Published OpenCode subagents omit the `model` field so OpenCode inherits the
+active parent session model.
+
+For OpenCode, ignore `model:` fields shown in shared `Agent(...)` examples.
+Do not pass per-call model fields to the OpenCode task/subagent tool. Treat
+`worker_model`, `asset_producer_model`, and other role model fields as
+unsupported for OpenCode subagents.
 
 Use the OpenCode task/subagent mechanism for delegated GodotMaker roles when
 available. The delegate must receive the current brief and follow the matching

--- a/agent-runtimes/opencode/references/runtime-mapping.md
+++ b/agent-runtimes/opencode/references/runtime-mapping.md
@@ -1,0 +1,95 @@
+# OpenCode Runtime Mapping
+
+Use this mapping whenever GodotMaker is published for OpenCode. It maps the
+shared GodotMaker surface vocabulary to OpenCode-native execution behavior.
+
+GodotMaker shared documentation may keep surface vocabulary such as `/gm-build`,
+worker, reviewer, verifier, analyst, and worktree. In OpenCode, interpret those
+terms through this mapping and execute the OpenCode-native equivalent.
+
+## Invocation Vocabulary
+
+- `/gm-*` in shared GodotMaker prose is framework surface vocabulary. In
+  OpenCode, load and run the matching project-local skill from
+  `.opencode/skills/<name>/SKILL.md`.
+- Do not ask the user to literally type a slash command unless the active
+  OpenCode session explicitly supports that alias.
+- Keep reports and user-facing stage names as GodotMaker role names; only the
+  execution surface changes.
+
+## Path Vocabulary
+
+When a shared GodotMaker reference mentions Claude-shaped paths, apply this
+mapping before filesystem access:
+
+| Shared surface path | OpenCode runtime path |
+|---|---|
+| `.claude/skills` | `.opencode/skills` |
+| `.claude/agents` | `.opencode/agents` |
+| `.claude/templates` | `.opencode/templates` |
+| `.claude/config` | `.opencode/config` |
+| `.claude/godotmaker.yaml` | `.opencode/godotmaker.yaml` |
+
+When a shared skill says to read `.claude/godotmaker.yaml` for `godot_path`,
+read `.opencode/godotmaker.yaml`.
+
+## Skill-Local References
+
+When a loaded skill says to read `references/*.md`, treat that path as relative
+to the current skill directory, not the project root. For example, inside
+`gm-asset`, `references/asset-runtime-pipeline.md` resolves to
+`.opencode/skills/gm-asset/references/asset-runtime-pipeline.md`.
+
+Project artifact paths are different: if a skill asks the stage to create or
+consume project assets such as `references/scene_<name>.png`, resolve those as
+project-root files.
+
+## Delegated Roles
+
+OpenCode project agents are published under `.opencode/agents/*.md`.
+
+Use the OpenCode task/subagent mechanism for delegated GodotMaker roles when
+available. The delegate must receive the current brief and follow the matching
+role definition:
+
+| GodotMaker role | OpenCode role file |
+|---|---|
+| `worker` | `.opencode/agents/worker.md` |
+| `reviewer` | `.opencode/agents/reviewer.md` |
+| `verifier` | `.opencode/agents/verifier.md` |
+| `analyst` | `.opencode/agents/analyst.md` |
+| `asset-producer` | `.opencode/agents/asset-producer.md` |
+| `decomposer` | `.opencode/agents/decomposer.md` |
+| `gdd-auditor` | `.opencode/agents/gdd-auditor.md` |
+
+If OpenCode subagent execution is unavailable, use a sequential fallback only
+when the current stage explicitly allows the lead session to perform that role's
+work. Otherwise stop and report the missing capability before editing files.
+
+## MCP, Permissions, And Hooks
+
+- MCP: OpenCode must have a configured `godot` MCP server before stages that
+  depend on Godot MCP tools. If it is missing, stop with a setup handoff.
+- Permissions: unattended GodotMaker runs require OpenCode permissions that do
+  not deadlock on expected file edits, shell commands, git operations, and
+  Godot invocations. For OpenCode CLI runs, this normally means
+  `--dangerously-skip-permissions`.
+- Hooks: OpenCode does not use Claude Code's `.claude/settings.json` hook
+  format. GodotMaker's deterministic hook scripts remain under
+  `.godotmaker/hooks`, but OpenCode hook/plugin parity is not assumed by this
+  mapping. When no runtime hook exists, stages must rely on explicit validators
+  or stop at the relevant gate.
+
+## Image And VQA Capability
+
+OpenCode as a coding-agent runtime does not automatically provide native image
+generation or native image inspection. If a project config selects `native` for
+`asset_image_model` or `vqa_model`, continue only when the active OpenCode
+environment has that capability and the stage contract documents how to use it.
+Otherwise require an API-backed image or VQA provider.
+
+## Unsupported Capability Rule
+
+If a capability is unavailable and no fallback above applies, stop before making
+dependent edits. Report the missing capability, the stage being blocked, and the
+smallest setup or handoff needed to continue.

--- a/agent-runtimes/opencode/references/runtime-mapping.md
+++ b/agent-runtimes/opencode/references/runtime-mapping.md
@@ -74,19 +74,21 @@ work. Otherwise stop and report the missing capability before editing files.
   not deadlock on expected file edits, shell commands, git operations, and
   Godot invocations. For OpenCode CLI runs, this normally means
   `--dangerously-skip-permissions`.
-- Hooks: OpenCode does not use Claude Code's `.claude/settings.json` hook
-  format. GodotMaker's deterministic hook scripts remain under
-  `.godotmaker/hooks`, but OpenCode hook/plugin parity is not assumed by this
-  mapping. When no runtime hook exists, stages must rely on explicit validators
-  or stop at the relevant gate.
+- Hooks: OpenCode uses `.opencode/plugins/godotmaker-hooks.js`, which publish
+  deploys from the OpenCode runtime package. The plugin adapts OpenCode
+  `tool.execute.before`, `tool.execute.after`, session, and compaction events
+  to GodotMaker's Python hook scripts under `.godotmaker/hooks`.
+- Lifecycle hooks are best-effort where OpenCode event semantics differ from
+  Claude Code. File gates, asset read gates, task dispatch gates, subagent
+  report gates, completion gates, and compaction metrics must still go through
+  the deployed plugin adapter.
 
 ## Image And VQA Capability
 
-OpenCode as a coding-agent runtime does not automatically provide native image
-generation or native image inspection. If a project config selects `native` for
-`asset_image_model` or `vqa_model`, continue only when the active OpenCode
-environment has that capability and the stage contract documents how to use it.
-Otherwise require an API-backed image or VQA provider.
+OpenCode as a coding-agent runtime does not provide native image generation or
+native image inspection in the GodotMaker contract. If a project config selects
+`native` for `asset_image_model` or `vqa_model`, stop and ask the user to switch
+that field to `codex` or an API-backed selector before the dependent stage runs.
 
 ## Unsupported Capability Rule
 

--- a/agent-runtimes/opencode/templates/agents-bootstrap.md
+++ b/agent-runtimes/opencode/templates/agents-bootstrap.md
@@ -1,0 +1,5 @@
+Before executing any GodotMaker stage skill in OpenCode, apply the OpenCode
+runtime mapping at `.opencode/references/runtime-mapping.md`. Shared
+GodotMaker docs may use `/gm-*` and Claude-shaped paths as surface vocabulary;
+resolve them through that mapping before acting.
+

--- a/agent-runtimes/opencode/templates/agents-bootstrap.md
+++ b/agent-runtimes/opencode/templates/agents-bootstrap.md
@@ -3,3 +3,6 @@ runtime mapping at `.opencode/references/runtime-mapping.md`. Shared
 GodotMaker docs may use `/gm-*` and Claude-shaped paths as surface vocabulary;
 resolve them through that mapping before acting.
 
+For `.godotmaker/*` and `.opencode/*` state files, follow the OpenCode
+dot-directory file-check rule in the runtime mapping before treating a missing
+Glob result as authoritative.

--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -3,6 +3,7 @@
 # Deployed to .godotmaker/config.yaml by publish script
 
 # Selected coding-agent runtime for this project.
+# Supported values: claude-code, codex, opencode
 # publish.py updates this value on each publish.
 agent: claude-code
 

--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -5,6 +5,9 @@
 # Selected coding-agent runtime for this project.
 # Supported values: claude-code, codex, opencode
 # publish.py updates this value on each publish.
+#
+# OpenCode projects must use codex or API-backed selectors for image and VQA
+# fields.
 agent: claude-code
 
 # Visual quality assessment model.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -9,6 +9,12 @@ Hook registration is runner-specific:
 `agent-runtimes/opencode/plugins/godotmaker-hooks.js` as an adapter plugin.
 The scripts are deployed to `.godotmaker/hooks/` via publish.
 
+OpenCode uses a degraded adapter for runner-level hooks; see the OpenCode
+runtime provider docs for its subagent permission boundary.
+In the inventory below, `SubagentStart` and `SubagentStop` entries apply to
+Claude Code / Codex hook payloads; the OpenCode adapter does not emit those
+Claude-style lifecycle events.
+
 ---
 
 ## Hook Inventory
@@ -19,9 +25,9 @@ The scripts are deployed to `.godotmaker/hooks/` via publish.
 | `check_file_permissions.py` | PreToolUse | Write\|Edit | Yes | Per-role write rules driven by `.godotmaker/current_role` |
 | `stage_reminder.py` | PreToolUse | Write\|Edit | Yes | Detect `stage.jsonl` appends, validate role outputs, inject next-role reminder |
 | `check_stage_prerequisites.py` | PreToolUse | Agent | Yes | Before worker dispatch, verify the prerequisite role completed and its outputs exist |
-| `check_asset_access.py` | PreToolUse | Read | Yes | During an active role, block the main agent from reading image files in `assets/` |
-| `log_subagent.py` | SubagentStart | — | No | Record subagent start metrics (role detection, agent_id) |
-| `on_subagent_stop.py` | SubagentStop | — | Yes | Dispatcher: serialise `log_subagent.handle_stop` + `check_worker_report` to avoid metrics-file race |
+| `check_asset_access.py` | PreToolUse | Read | Yes | During an active role, block the main/root agent from reading image files in `assets/` |
+| `log_subagent.py` | SubagentStart | — | No | Claude Code / Codex: record subagent start metrics (role detection, agent_id). OpenCode does not emit this lifecycle hook. |
+| `on_subagent_stop.py` | SubagentStop | — | Yes | Claude Code / Codex: serialise `log_subagent.handle_stop` + `check_worker_report` to avoid metrics-file race. OpenCode does not emit this lifecycle hook. |
 | `check_completion.py` | Stop | — | Yes | Final gate: for `build` / `fixgap` only, blocks if workers were dispatched without verifier + reviewer |
 
 ---
@@ -64,6 +70,11 @@ During an active pipeline role, general subagents are blocked from `e2e/`
 and from planning docs (`PLAN.md` / `STRUCTURE.md` / `ASSETS.md` /
 `GAP.md`). `asset-producer` may write `assets/`, `references/`, and
 `.godotmaker/asset-generation/`.
+
+Runner note: this subagent write gate requires a runtime-provided `agent_id`.
+OpenCode child sessions do not expose that payload, so the OpenCode adapter
+does not run this Python subagent write gate for child sessions; it relies on
+OpenCode-native agent edit permissions for that boundary.
 
 When no role is set, no `/gm-*` pipeline role is active. The hook records the
 file operation but does not block, so users can run ordinary coding-agent
@@ -131,8 +142,10 @@ Blocks the main agent from reading image files in `assets/` only while a
 pipeline role is active (`.godotmaker/current_role` exists).
 Image extensions: .png, .jpg, .jpeg, .svg, .webp, .gif, .bmp, .tga.
 
-Regular conversations with no active role are allowed. Subagents (analyst) are
-allowed. Non-image files (.json, .ogg) are allowed.
+Regular conversations with no active role are allowed. Subagents are allowed
+when the runtime provides a subagent identity. OpenCode child sessions do not
+expose the same `agent_id` payload, so its adapter keeps this gate on the root
+stage session only. Non-image files (.json, .ogg) are allowed.
 
 Purpose: force the main agent to delegate asset analysis to the analyst
 subagent instead of consuming context with raw image data.
@@ -141,6 +154,9 @@ subagent instead of consuming context with raw image data.
 
 **Event:** SubagentStart (and called by `on_subagent_stop.py` for SubagentStop)
 **Blocks:** Never
+
+Runner support: Claude Code / Codex only. The OpenCode adapter does not emit
+Claude-style subagent lifecycle hooks.
 
 **SubagentStart:** Detects role and records `SUBAGENT_START` metric with
 `agent_id`, `agent_type`, `role`, `description`.
@@ -169,6 +185,9 @@ events: `WORKER_DONE`, `VERIFIER_PASS`, etc.
 
 **Event:** SubagentStop
 **Blocks:** Yes (delegates to `check_worker_report`)
+
+Runner support: Claude Code / Codex only. The OpenCode adapter does not emit
+Claude-style subagent lifecycle hooks.
 
 Single dispatcher for the `SubagentStop` event. Reads stdin once and runs
 serially:
@@ -262,10 +281,10 @@ PreToolUse(Read)
   └── check_asset_access.py (block main agent from reading assets/ images)
 
 SubagentStart
-  └── log_subagent.py (record start + role)
+  └── log_subagent.py (Claude Code / Codex: record start + role)
 
 SubagentStop
-  └── on_subagent_stop.py (serial: log_subagent.handle_stop → check_worker_report)
+  └── on_subagent_stop.py (Claude Code / Codex: serial report gate)
 
 Stop
   └── check_completion.py (build/fixgap diligence check only; no-op for other roles)

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,12 +1,13 @@
 # Hooks Reference
 
 Complete reference for all GodotMaker hooks. Hooks are Python scripts that run
-on Claude Code events to enforce pipeline rules.
+on coding-agent runtime events to enforce pipeline rules.
 
 Hook registration is runner-specific:
 `agent-runtimes/claude-code/config/settings.json` for Claude Code and
-`agent-runtimes/codex/config/hooks.json` for Codex. The scripts are deployed to
-`.godotmaker/hooks/` via publish.
+`agent-runtimes/codex/config/hooks.json` for Codex. OpenCode uses
+`agent-runtimes/opencode/plugins/godotmaker-hooks.js` as an adapter plugin.
+The scripts are deployed to `.godotmaker/hooks/` via publish.
 
 ---
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -19,6 +19,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - Added the initial OpenCode publish target with `.opencode` skills, agents, runtime references, and project instructions.
 - Added OpenCode `godot` MCP registration during publish and environment checks for the published `.opencode` runtime tree.
+- Added provider setup docs for agent runtimes and image/VQA selectors, including OpenCode image/VQA capability gates.
 
 ## Changed
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,6 +17,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
+- Added the initial OpenCode publish target with `.opencode` skills, agents, runtime references, and project instructions.
+
 ## Changed
 
 - Updated README and wiki first-run docs to use the current `godotmaker-cli` command, runner selection flags, Node.js requirement, and project config flow.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -39,6 +39,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Fixed OpenCode subagents so delegated roles inherit the active session model correctly.
 - Fixed OpenCode worker deadlocks by publishing explicit external-directory
   permissions for subagents.
+- Fixed headless-build and gdUnit guidance so workers read `godot_path` through
+  the selected project-local agent config instead of Claude-specific paths.
 - Fixed the API-backed OpenAI image provider so supported reference images are
   all passed to the generation call instead of silently using only the first one.
 - Fixed OpenCode session-idle Stop hook handling so Stop hook block decisions

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -21,6 +21,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Added OpenCode `godot` MCP registration during publish and environment checks for the published `.opencode` runtime tree.
 - Added provider setup docs for agent runtimes and image/VQA selectors, including OpenCode image/VQA capability gates.
 - Added an OpenCode hook adapter plugin that runs the shared GodotMaker hook contract through OpenCode runtime events.
+- Added `/gm-asset` provider routing for OpenAI image generation selectors.
 
 ## Changed
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -18,6 +18,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Added
 
 - Added the initial OpenCode publish target with `.opencode` skills, agents, runtime references, and project instructions.
+- Added OpenCode `godot` MCP registration during publish and environment checks for the published `.opencode` runtime tree.
 
 ## Changed
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -25,6 +25,9 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Changed
 
+- Downgraded OpenCode hook support to root-stage lifecycle gates plus
+  OpenCode-native subagent permissions, instead of claiming full Claude
+  Code-style subagent hook parity.
 - Updated README and wiki first-run docs to use the current `godotmaker-cli` command, runner selection flags, Node.js requirement, and project config flow.
 
 ## Fixed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -20,6 +20,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Added the initial OpenCode publish target with `.opencode` skills, agents, runtime references, and project instructions.
 - Added OpenCode `godot` MCP registration during publish and environment checks for the published `.opencode` runtime tree.
 - Added provider setup docs for agent runtimes and image/VQA selectors, including OpenCode image/VQA capability gates.
+- Added an OpenCode hook adapter plugin that runs the shared GodotMaker hook contract through OpenCode runtime events.
 
 ## Changed
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -32,6 +32,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Fixed scaffold addon validation so full repository checkouts inside
+  `addons/*` are rejected before they can break Godot class scanning.
 - Fixed OpenCode subagents so delegated roles inherit the active session model correctly.
 - Fixed OpenCode worker deadlocks by publishing explicit external-directory
   permissions for subagents.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -32,6 +32,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Fixed verify/build gates so Godot headless shutdown notes no longer block
+  the pipeline, while other Godot diagnostics fail closed.
 - Fixed scaffold addon validation so full repository checkouts inside
   `addons/*` are rejected before they can break Godot class scanning.
 - Fixed OpenCode subagents so delegated roles inherit the active session model correctly.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -28,4 +28,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Fixed OpenCode subagents so delegated roles inherit the active session model correctly.
+
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -32,5 +32,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Fixed OpenCode subagents so delegated roles inherit the active session model correctly.
 - Fixed the API-backed OpenAI image provider so supported reference images are
   all passed to the generation call instead of silently using only the first one.
+- Fixed OpenCode session-idle Stop hook handling so Stop hook block decisions
+  are sent back to the active session instead of terminating the worker process.
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -41,6 +41,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
   permissions for subagents.
 - Fixed headless-build and gdUnit guidance so workers read `godot_path` through
   the selected project-local agent config instead of Claude-specific paths.
+- Fixed verify static checks so `check_project.py` tool failures are reported as
+  tooling errors instead of static-check passes.
 - Fixed the API-backed OpenAI image provider so supported reference images are
   all passed to the generation call instead of silently using only the first one.
 - Fixed OpenCode session-idle Stop hook handling so Stop hook block decisions

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -45,5 +45,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
   all passed to the generation call instead of silently using only the first one.
 - Fixed OpenCode session-idle Stop hook handling so Stop hook block decisions
   are sent back to the active session instead of terminating the worker process.
+- Fixed OpenCode runtime guidance for dot-directory state files so agents do
+  not treat missing Glob results as authoritative for known project metadata.
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -33,6 +33,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - Fixed OpenCode subagents so delegated roles inherit the active session model correctly.
+- Fixed OpenCode worker deadlocks by publishing explicit external-directory
+  permissions for subagents.
 - Fixed the API-backed OpenAI image provider so supported reference images are
   all passed to the generation call instead of silently using only the first one.
 - Fixed OpenCode session-idle Stop hook handling so Stop hook block decisions

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -30,5 +30,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - Fixed OpenCode subagents so delegated roles inherit the active session model correctly.
+- Fixed the API-backed OpenAI image provider so supported reference images are
+  all passed to the generation call instead of silently using only the first one.
 
 ## Removed

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -134,15 +134,16 @@ by incremental migration. `publish.py` refuses to upgrade across MAJOR
 boundaries without `--force`, which performs a clean re-initialization.
 
 Full rebuild cleans all framework-managed content:
-- `.claude/skills/`, `.claude/agents/`, `.claude/config/`, `.claude/templates/`
+- The selected runner's `skills/`, `agents/`, `config/`, and `templates/`
 - `.godotmaker/hooks/`, `.godotmaker/stage_schemas.json`
 - `.godotmaker/state.json`, `.godotmaker/metrics*.jsonl`
 - `.godotmaker/applied_migrations.json` (re-baselined after re-deploy)
 - `tools/`
-- `.claude/settings.json` (force-overwritten)
+- The selected runner's hook config or plugin adapter (force-overwritten)
 
 Preserved (user configuration):
-- `CLAUDE.md`, `.claude/godotmaker.yaml`, `.godotmaker/config.yaml`
+- `CLAUDE.md` / `AGENTS.md`, the selected runner's `godotmaker.yaml`,
+  `.godotmaker/config.yaml`
 
 After re-deploy, `publish.py` calls `baseline_applied()` to mark every
 current migration as applied without running it — same as a fresh install.
@@ -173,10 +174,11 @@ picking up local changes during development.
 
 ## Session Version Display
 
-When a Claude Code session starts in a published project, the
+When a supported coding-agent session starts in a published project, the
 `session_start.py` hook reads `.godotmaker/version` and injects
-`[GodotMaker vX.Y.Z]` into the session context. This helps the
-active role skill (and the user) know which framework version is deployed.
+`[GodotMaker vX.Y.Z]` into the session context where the runtime supports that
+hook context. This helps the active role skill know which framework version is
+deployed.
 
 ## Workflow for Releasing a New Version
 
@@ -204,20 +206,20 @@ Every publish overwrites:
 
 | Directory | Content |
 |-----------|---------|
-| `.claude/skills/` | All skills (flattened from core + reviewer) |
-| `.claude/agents/` | Agent definitions (worker, verifier, reviewer, analyst, asset-producer) |
+| Selected runner `skills/` | All skills (flattened from core + reviewer) |
+| Selected runner `agents/` | Agent definitions (worker, verifier, reviewer, analyst, asset-producer) |
 | `.godotmaker/hooks/` | All hook scripts |
-| `.claude/config/` | Config files (settings.json only with `--force`) |
-| `.claude/templates/` | Document templates |
+| Selected runner `config/` | Config files |
+| Selected runner `templates/` | Document templates |
 | `tools/` | Python tools (check_project, check_env, etc.) |
 
 These are **not** overwritten (created only on fresh install):
 
 | File | Reason |
 |------|--------|
-| `CLAUDE.md` | User may have customized it |
-| `.claude/settings.json` | User hook configuration (overwritten only with `--force`) |
-| `.claude/godotmaker.yaml` | Host-specific paths |
+| `CLAUDE.md` / `AGENTS.md` | User may have customized it |
+| Selected runner hook config or plugin adapter | User hook behavior (overwritten only with `--force`) |
+| Selected runner `godotmaker.yaml` | Host-specific paths |
 | `.godotmaker/config.yaml` | Project-specific settings |
 
 ## Note on addon_versions.json

--- a/docs/wiki/01-getting-started/installation.md
+++ b/docs/wiki/01-getting-started/installation.md
@@ -10,9 +10,10 @@ GodotMaker turns a game idea into a playable Godot 4 project. The normal path is
 | Git | 2.30+ | Tracks changes and enables isolated agent worktrees | https://git-scm.com/downloads |
 | Node.js | 22+ | Runs `godotmaker-cli` and Godot MCP tooling | https://nodejs.org |
 | Python | 3.10+ | Runs GodotMaker helper scripts and verification tools | https://python.org/downloads |
-| Claude Code or Codex | Latest | Agent runtime used to implement and evaluate the game | https://claude.ai/code or https://openai.com/codex/ |
+| Claude Code, Codex, or OpenCode | Latest | Agent runtime used to implement and evaluate the game | https://claude.ai/code, https://openai.com/codex/, or https://opencode.ai/ |
 
-Install each one, then continue. You only need one authenticated agent runtime for the first run: Claude Code or Codex.
+Install each one, then continue. You only need one authenticated agent runtime
+for the first run: Claude Code, Codex, or OpenCode.
 
 ## Choose an agent runner
 
@@ -21,6 +22,7 @@ GodotMaker is normally launched through `godotmaker-cli`. Pick the runner at lau
 ```bash
 godotmaker-cli --agent claude-code
 godotmaker-cli --agent codex
+godotmaker-cli --agent opencode
 ```
 
 `--agent` is the safest way to switch runners for one run. If it is omitted, the CLI resolves the runner from the project config, then the CLI-global config, then the default runner.
@@ -29,7 +31,13 @@ godotmaker-cli --agent codex
 
 GodotMaker can use runtime-native image and vision capabilities or API-backed providers depending on `.godotmaker/config.yaml`.
 
-API keys are required only when the project selects an API-backed provider. GodotMaker itself does not provide the external model service. If you want Codex to provide image generation in a Claude Code project, set `asset_image_model: codex`; this requires Codex CLI on PATH and does not require an image API key.
+API keys are required only when the project selects an API-backed provider.
+GodotMaker itself does not provide the external model service. If you want
+Codex to provide image generation in a Claude Code or OpenCode project, set
+`asset_image_model: codex`; this requires Codex CLI on PATH and does not
+require an image API key. OpenCode does not currently default to native image
+generation or native VQA; configure `codex` or an API-backed provider for those
+fields before running the full pipeline.
 
 | Key | Required when | What it unlocks |
 |-----|---------------|-----------------|

--- a/docs/wiki/05-tools/check-env.md
+++ b/docs/wiki/05-tools/check-env.md
@@ -44,7 +44,8 @@ If Godot is not on your PATH, this check shows a warning rather than a hard fail
 - Codex projects check that `codex` is installed, the `.agents` runtime tree is
   present, and the `godot` MCP server is configured.
 - OpenCode projects check that `opencode` is installed, the `.opencode`
-  runtime tree is present, and the `godot` MCP server is configured.
+  runtime tree and hook adapter are present, and the `godot` MCP server is
+  configured.
 
 ### API keys
 

--- a/docs/wiki/05-tools/check-env.md
+++ b/docs/wiki/05-tools/check-env.md
@@ -38,9 +38,13 @@ If anything is missing, you'll see a list of failed checks and what to do about 
 
 If Godot is not on your PATH, this check shows a warning rather than a hard failure — you can still provide the full path to the executable when you run `publish.py`, and it will be saved in `.claude/godotmaker.yaml` for future use.
 
-### Claude Code
+### Selected coding agent
 
-- The `claude` command-line tool is installed and on your PATH.
+- Claude Code projects check that `claude` is installed.
+- Codex projects check that `codex` is installed, the `.agents` runtime tree is
+  present, and the `godot` MCP server is configured.
+- OpenCode projects check that `opencode` is installed, the `.opencode`
+  runtime tree is present, and the `godot` MCP server is configured.
 
 ### API keys
 
@@ -50,7 +54,12 @@ If Godot is not on your PATH, this check shows a warning rather than a hard fail
 | `OPENAI_API_KEY` | Required when selected | OpenAI image generation or VQA |
 | `XAI_API_KEY` | Required when selected | xAI Grok image generation |
 
-API-backed selectors fail when the matching key is absent. `asset_image_model: native` passes for Codex and warns for Claude Code because the checker cannot prove a Claude-side native generation tool is available. `asset_image_model: codex` in a Claude Code project passes when the Codex CLI is on PATH.
+API-backed selectors fail when the matching key is absent. `asset_image_model:
+native` passes for Codex and warns for Claude Code because the checker cannot
+prove a Claude-side native generation tool is available. OpenCode projects fail
+on `native` image generation or `native` VQA until you switch those fields to
+`codex` or an API-backed selector. `asset_image_model: codex` in a Claude Code
+or OpenCode project passes when the Codex CLI is on PATH.
 
 The checker also verifies that the selected provider package can be imported, catching installation issues that version checks alone would miss.
 

--- a/docs/wiki/05-tools/check-project.md
+++ b/docs/wiki/05-tools/check-project.md
@@ -17,7 +17,7 @@ python tools/check_project.py /path/to/my-game --all
 
 | Flag | What it checks |
 |------|---------------|
-| `--build` | `project.godot` exists and has a valid `[application]` section |
+| `--build` | `project.godot` exists, required addons are installed, git `HEAD` resolves, and Godot headless parse has no blocking diagnostics |
 | `--ecs` | The gecs addon is present; game code has Component and System files |
 | `--tests` | The gdUnit4 addon is present; every System has a matching unit test file |
 | `--e2e` | The godot-e2e plugin is enabled; `e2e/` has real test functions, not placeholders |
@@ -27,7 +27,11 @@ python tools/check_project.py /path/to/my-game --all
 
 ## What it catches
 
-**Build readiness** — confirms `project.godot` is present and structurally valid. A missing project file means Godot cannot open the project at all.
+**Build readiness** — confirms `project.godot` is present and structurally
+valid, required addons have the expected addon-only shape, git `HEAD`
+resolves, and `<godot_path> --headless --quit` has no blocking diagnostics.
+Godot shutdown notes are reported separately; other Godot diagnostics fail the
+check.
 
 **ECS setup** — confirms that `addons/gecs/` is installed and that your game actually has GDScript files that `extend Component` and `extend System`. A project with neither has not been built yet (or the build was interrupted).
 

--- a/docs/wiki/05-tools/publish.md
+++ b/docs/wiki/05-tools/publish.md
@@ -16,6 +16,11 @@ claude
 python tools/publish.py --agent codex /path/to/my-game
 cd /path/to/my-game
 codex
+
+# OpenCode
+python tools/publish.py --agent opencode /path/to/my-game
+cd /path/to/my-game
+opencode
 ```
 
 On Windows:
@@ -43,10 +48,10 @@ The first time you run this, the script will ask you for the full path to your G
 | `assets/sprites`, `assets/audio`, `assets/fonts`, `assets/ui`, `references/` | Standard asset folders |
 
 The script also registers the `godot-mcp` server for the selected agent (Claude
-Code via `claude mcp`, Codex via `codex mcp`), initializes a git repository if
-one doesn't exist, and creates a `.gitignore` with the right entries. For Codex,
-MCP registration is required because the GodotMaker runtime depends on the
-Godot MCP tools.
+Code via `claude mcp`, Codex via `codex mcp`, OpenCode via `opencode mcp`),
+initializes a git repository if one doesn't exist, and creates a `.gitignore`
+with the right entries. MCP registration is required because the GodotMaker
+runtime depends on the Godot MCP tools.
 
 When published with `--agent codex`, the agent-owned files use the Codex
 layout instead: skills go under `.agents/skills/`, templates/config under
@@ -55,6 +60,12 @@ layout instead: skills go under `.agents/skills/`, templates/config under
 written to `.codex/hooks.json`. Shared framework state still lives under
 `.godotmaker/`. Codex approval and sandbox policy are handled by Codex at
 runtime; publish does not create a `.agents/settings.json` equivalent.
+
+When published with `--agent opencode`, the agent-owned files use the OpenCode
+layout instead: skills go under `.opencode/skills/`, agents under
+`.opencode/agents/`, templates/config under `.opencode/`, `godotmaker.yaml` is
+stored at `.opencode/godotmaker.yaml`, and `AGENTS.md` points to the OpenCode
+runtime mapping. OpenCode plugin/hook parity is not assumed by publish.
 
 ### Codex permissions
 
@@ -103,6 +114,7 @@ For the full upgrade policy and migration script details, see [`../../versioning
 ```bash
 python tools/publish.py --force /path/to/my-game
 python tools/publish.py --agent codex --force /path/to/my-game
+python tools/publish.py --agent opencode --force /path/to/my-game
 ```
 
 `--force` does four things at once:
@@ -122,7 +134,7 @@ These files are never overwritten by a normal publish (only `--force` can change
 |------|---------------|
 | `CLAUDE.md` / `AGENTS.md` | You may have added project-specific instructions |
 | `.claude/settings.json` / `.codex/hooks.json` | You may have adjusted hook behavior |
-| `.claude/godotmaker.yaml` / `.agents/godotmaker.yaml` | Contains your machine-specific Godot path |
+| `.claude/godotmaker.yaml` / `.agents/godotmaker.yaml` / `.opencode/godotmaker.yaml` | Contains your machine-specific Godot path |
 | `.godotmaker/config.yaml` | Contains your project-specific preferences |
 
 Your game code, scenes, assets, and planning documents (`GDD.md`, `PLAN.md`, etc.) are not touched by publish — it only manages the framework layer.

--- a/docs/wiki/05-tools/publish.md
+++ b/docs/wiki/05-tools/publish.md
@@ -65,7 +65,9 @@ When published with `--agent opencode`, the agent-owned files use the OpenCode
 layout instead: skills go under `.opencode/skills/`, agents under
 `.opencode/agents/`, templates/config under `.opencode/`, `godotmaker.yaml` is
 stored at `.opencode/godotmaker.yaml`, and `AGENTS.md` points to the OpenCode
-runtime mapping. OpenCode plugin/hook parity is not assumed by publish.
+runtime mapping. The OpenCode hook adapter is written to
+`.opencode/plugins/godotmaker-hooks.js`; it calls the shared GodotMaker hook
+scripts in `.godotmaker/hooks/`.
 
 ### Codex permissions
 
@@ -120,7 +122,7 @@ python tools/publish.py --agent opencode --force /path/to/my-game
 `--force` does four things at once:
 
 1. Clears the selected agent's skill directory before re-deploying, removing any skills left over from a previous version.
-2. Overwrites the selected runner's hook config (`.claude/settings.json` or `.codex/hooks.json`) even if you've already customized it.
+2. Overwrites the selected runner's hook config or adapter (`.claude/settings.json`, `.codex/hooks.json`, or `.opencode/plugins/godotmaker-hooks.js`) even if you've already customized it.
 3. Skips the confirmation prompts for minor and major upgrades.
 4. Allows downgrades.
 
@@ -133,7 +135,7 @@ These files are never overwritten by a normal publish (only `--force` can change
 | File | Why it is kept |
 |------|---------------|
 | `CLAUDE.md` / `AGENTS.md` | You may have added project-specific instructions |
-| `.claude/settings.json` / `.codex/hooks.json` | You may have adjusted hook behavior |
+| `.claude/settings.json` / `.codex/hooks.json` / `.opencode/plugins/godotmaker-hooks.js` | You may have adjusted hook behavior |
 | `.claude/godotmaker.yaml` / `.agents/godotmaker.yaml` / `.opencode/godotmaker.yaml` | Contains your machine-specific Godot path |
 | `.godotmaker/config.yaml` | Contains your project-specific preferences |
 

--- a/docs/wiki/06-configuration/project-config.md
+++ b/docs/wiki/06-configuration/project-config.md
@@ -10,7 +10,7 @@ Framework developers and manual-mode users can still create the same file with `
 
 ## Common fields
 
-**`agent`** — selected coding-agent runtime, such as `claude-code` or `codex`.
+**`agent`** — selected coding-agent runtime, such as `claude-code`, `codex`, or `opencode`.
 
 **`worker_model`** — which Claude model writes game code. Defaults to `sonnet`; set it to `opus` for games that need heavier implementation reasoning.
 
@@ -55,6 +55,10 @@ The template uses native image inspection and native image generation by default
 
 For Codex projects, `asset_image_model: native` maps to Codex native image generation when the host exposes that capability. For Claude Code projects, `native` requires a Claude-side native image tool. If no native path is available, `/gm-asset` must stop and ask you to configure a supported provider or switch to an API-backed selector.
 
+For OpenCode projects, `native` image generation and `native` VQA are not used.
+Set `asset_image_model` and `vqa_model` to `codex` or an API-backed
+selector before running the full pipeline.
+
 For a Claude Code project that should use Codex image generation:
 
 ```yaml
@@ -63,6 +67,22 @@ asset_image_model: codex
 
 This selects Codex as the image-generation provider. It requires Codex CLI on
 PATH and does not require an image API key.
+
+## Provider setup pages
+
+Coding-agent runtimes:
+
+- [Claude Code](providers/agent-runtimes/claude-code.md)
+- [Codex](providers/agent-runtimes/codex.md)
+- [OpenCode](providers/agent-runtimes/opencode.md)
+
+Image and VQA providers:
+
+- [native](providers/image-vqa/native.md)
+- [codex](providers/image-vqa/codex.md)
+- [gemini](providers/image-vqa/gemini.md)
+- [openai](providers/image-vqa/openai.md)
+- [grok](providers/image-vqa/grok.md)
 
 ## API keys
 
@@ -89,6 +109,7 @@ Launch-time `--agent` still wins for that run:
 ```bash
 godotmaker-cli --agent claude-code
 godotmaker-cli --agent codex
+godotmaker-cli --agent opencode
 ```
 
 To use Codex image generation:

--- a/docs/wiki/06-configuration/project-config.md
+++ b/docs/wiki/06-configuration/project-config.md
@@ -126,6 +126,11 @@ asset_image_model: openai:gpt-image-2
 
 The next `/gm-*` command picks up the new value. A command already running will not see changes until the next session or stage invocation.
 
-## About `.claude/settings.json`
+## About hook config files
 
-Claude Code projects also have `.claude/settings.json`, which registers GodotMaker hook scripts. It is framework-managed; running `python tools/publish.py --force <project>` republishes it if hooks stop firing after an upgrade.
+GodotMaker registers hook scripts through the selected runner surface:
+`.claude/settings.json` for Claude Code, `.codex/hooks.json` for Codex, and
+`.opencode/plugins/godotmaker-hooks.js` for OpenCode. These files are
+framework-managed; running `python tools/publish.py --force <project>`
+republishes the selected runner's hook surface if hooks stop firing after an
+upgrade.

--- a/docs/wiki/06-configuration/providers/README.md
+++ b/docs/wiki/06-configuration/providers/README.md
@@ -1,0 +1,23 @@
+# Provider setup
+
+GodotMaker has two independent provider layers:
+
+1. Coding-agent runtimes run the `/gm-*` workflow.
+2. Image/VQA providers generate art sources or inspect screenshots.
+
+Choosing a coding-agent runtime does not automatically choose an image or VQA
+provider. Configure both layers in `.godotmaker/config.yaml`.
+
+## Coding-agent runtimes
+
+- [Claude Code](agent-runtimes/claude-code.md)
+- [Codex](agent-runtimes/codex.md)
+- [OpenCode](agent-runtimes/opencode.md)
+
+## Image and VQA providers
+
+- [native](image-vqa/native.md)
+- [codex](image-vqa/codex.md)
+- [gemini](image-vqa/gemini.md)
+- [openai](image-vqa/openai.md)
+- [grok](image-vqa/grok.md)

--- a/docs/wiki/06-configuration/providers/agent-runtimes/claude-code.md
+++ b/docs/wiki/06-configuration/providers/agent-runtimes/claude-code.md
@@ -1,0 +1,29 @@
+# Claude Code runtime
+
+Use Claude Code when you want the default GodotMaker runtime.
+
+## Setup
+
+1. Install Claude Code.
+2. Sign in through the Claude Code CLI.
+3. Publish the project:
+
+```bash
+python tools/publish.py /path/to/my-game
+```
+
+## Project config
+
+```yaml
+agent: claude-code
+```
+
+Claude Code projects use `.claude/skills`, `.claude/agents`,
+`.claude/templates`, and `CLAUDE.md`.
+
+## Image and VQA
+
+`native` VQA uses the active Claude Code runtime's image-inspection path.
+`native` image generation requires a Claude-side image-generation capability.
+If that is unavailable, set `asset_image_model` to `codex` or an API-backed
+provider.

--- a/docs/wiki/06-configuration/providers/agent-runtimes/codex.md
+++ b/docs/wiki/06-configuration/providers/agent-runtimes/codex.md
@@ -1,0 +1,27 @@
+# Codex runtime
+
+Use Codex when you want GodotMaker to run through Codex skills.
+
+## Setup
+
+1. Install Codex and sign in.
+2. Publish the project:
+
+```bash
+python tools/publish.py --agent codex /path/to/my-game
+```
+
+## Project config
+
+```yaml
+agent: codex
+```
+
+Codex projects use `.agents/skills`, `.agents/agents`, `.agents/templates`,
+`.agents/references`, `.codex/hooks.json`, and `AGENTS.md`.
+
+## Image and VQA
+
+For Codex projects, `native` maps to Codex runtime-native image and vision
+capabilities when the active Codex host exposes them. You can also set
+`asset_image_model: codex` or `vqa_model: codex` explicitly.

--- a/docs/wiki/06-configuration/providers/agent-runtimes/opencode.md
+++ b/docs/wiki/06-configuration/providers/agent-runtimes/opencode.md
@@ -23,6 +23,14 @@ agent: opencode
 OpenCode projects use `.opencode/skills`, `.opencode/agents`,
 `.opencode/templates`, `.opencode/references`, and `AGENTS.md`.
 
+## Role models
+
+OpenCode subagents inherit the active parent OpenCode session model. The
+per-role model settings in `.godotmaker/config.yaml`, such as `worker_model`
+and `asset_producer_model`, currently apply to Claude Code projects and do not
+override OpenCode subagent models. Start the OpenCode session with the model you
+want delegated roles to use.
+
 ## Image and VQA
 
 OpenCode support does not use runtime-native image generation or image

--- a/docs/wiki/06-configuration/providers/agent-runtimes/opencode.md
+++ b/docs/wiki/06-configuration/providers/agent-runtimes/opencode.md
@@ -31,6 +31,25 @@ and `asset_producer_model`, currently apply to Claude Code projects and do not
 override OpenCode subagent models. Start the OpenCode session with the model you
 want delegated roles to use.
 
+## Hooks and permissions
+
+OpenCode does not expose the same subagent lifecycle payloads as Claude Code.
+GodotMaker therefore does not treat OpenCode hooks as full Claude Code hook
+parity.
+
+The OpenCode adapter still runs root-stage and lifecycle gates, including
+stage prerequisites, completion checks, clean-workspace checks, session start,
+and compaction metrics. Known child-session read/write operations are not
+passed through GodotMaker's `agent_id`-based Python subagent gates because
+OpenCode does not expose the same subagent identity payload.
+
+Subagent write boundaries are handled by OpenCode-native
+`.opencode/agents/*.md` `permission` frontmatter. Read-only review-style
+agents such as `reviewer`, `verifier`, and `gdd-auditor` are published with
+`permission.edit: deny`; implementation agents such as `worker` keep the edit
+permissions they need to do their assigned work. This only covers edit
+permissions; it is not a replacement for Claude-style read-access hooks.
+
 ## Image and VQA
 
 OpenCode support does not use runtime-native image generation or image

--- a/docs/wiki/06-configuration/providers/agent-runtimes/opencode.md
+++ b/docs/wiki/06-configuration/providers/agent-runtimes/opencode.md
@@ -1,0 +1,46 @@
+# OpenCode runtime
+
+Use OpenCode when you want GodotMaker's code/text stages to run through
+OpenCode models such as DeepSeek.
+
+## Setup
+
+1. Install OpenCode.
+2. Connect your model provider with OpenCode, for example through
+   `opencode auth login` or the OpenCode TUI `/connect` flow.
+3. Publish the project:
+
+```bash
+python tools/publish.py --agent opencode /path/to/my-game
+```
+
+## Project config
+
+```yaml
+agent: opencode
+```
+
+OpenCode projects use `.opencode/skills`, `.opencode/agents`,
+`.opencode/templates`, `.opencode/references`, and `AGENTS.md`.
+
+## Image and VQA
+
+OpenCode support does not use runtime-native image generation or image
+inspection. Set both fields to `codex` or API-backed providers before running
+the full pipeline.
+
+Recommended options:
+
+```yaml
+asset_image_model: codex
+vqa_model: codex
+```
+
+or API-backed providers:
+
+```yaml
+asset_image_model: gemini:gemini-3.1-flash-image-preview
+vqa_model: gemini:gemini-2.5-flash
+```
+
+Run `python tools/check_env.py` after changing these fields.

--- a/docs/wiki/06-configuration/providers/agent-runtimes/opencode.md
+++ b/docs/wiki/06-configuration/providers/agent-runtimes/opencode.md
@@ -23,6 +23,17 @@ agent: opencode
 OpenCode projects use `.opencode/skills`, `.opencode/agents`,
 `.opencode/templates`, `.opencode/references`, and `AGENTS.md`.
 
+## Known tool limitation
+
+OpenCode currently has a known file-discovery limitation for dot-directories
+such as `.godotmaker/` or `.opencode/`. GodotMaker publishes an OpenCode
+runtime workaround for project state files.
+
+- https://github.com/anomalyco/opencode/issues/11691
+- https://github.com/anomalyco/opencode/issues/10906
+
+Remove the workaround once OpenCode reliably discovers dot-directory files.
+
 ## Role models
 
 OpenCode subagents inherit the active parent OpenCode session model. The
@@ -42,6 +53,19 @@ stage prerequisites, completion checks, clean-workspace checks, session start,
 and compaction metrics. Known child-session read/write operations are not
 passed through GodotMaker's `agent_id`-based Python subagent gates because
 OpenCode does not expose the same subagent identity payload.
+
+This means OpenCode cannot currently reuse the full Claude Code / Codex
+subagent hook contract. Worker report lifecycle checks, subagent metrics, and
+Python read/write gates that depend on a stable subagent identity are degraded
+for OpenCode child sessions. Root-stage gates still run through the OpenCode
+adapter.
+
+Related upstream OpenCode issues:
+
+- https://github.com/anomalyco/opencode/issues/15403
+- https://github.com/anomalyco/opencode/issues/16626
+- https://github.com/anomalyco/opencode/issues/17412
+- https://github.com/anomalyco/opencode/issues/12566
 
 Subagent write boundaries are handled by OpenCode-native
 `.opencode/agents/*.md` `permission` frontmatter. Read-only review-style

--- a/docs/wiki/06-configuration/providers/image-vqa/codex.md
+++ b/docs/wiki/06-configuration/providers/image-vqa/codex.md
@@ -1,0 +1,20 @@
+# codex image and VQA provider
+
+`codex` means Codex supplies image generation or image inspection even when the
+main project runner is not Codex.
+
+## Project config
+
+```yaml
+asset_image_model: codex
+vqa_model: codex
+```
+
+## Setup
+
+1. Install Codex and sign in.
+2. Make sure the `codex` command is on `PATH`.
+3. Run `python tools/check_env.py`.
+
+This provider does not require an image API key. It does require the active
+Codex environment to expose the needed image or vision capability.

--- a/docs/wiki/06-configuration/providers/image-vqa/gemini.md
+++ b/docs/wiki/06-configuration/providers/image-vqa/gemini.md
@@ -1,0 +1,28 @@
+# Gemini image and VQA provider
+
+Use Gemini when you want API-backed image generation or visual QA.
+
+## Project config
+
+```yaml
+asset_image_model: gemini:gemini-3.1-flash-image-preview
+vqa_model: gemini:gemini-2.5-flash
+```
+
+## Setup
+
+1. Create a Gemini API key.
+2. Set one of:
+
+```bash
+export GOOGLE_API_KEY=...
+export GEMINI_API_KEY=...
+```
+
+3. Install the Python package:
+
+```bash
+pip install google-genai
+```
+
+4. Run `python tools/check_env.py`.

--- a/docs/wiki/06-configuration/providers/image-vqa/grok.md
+++ b/docs/wiki/06-configuration/providers/image-vqa/grok.md
@@ -1,0 +1,28 @@
+# Grok image provider
+
+Use Grok when you want API-backed image generation through xAI.
+
+## Project config
+
+```yaml
+asset_image_model: grok:grok-imagine-image
+```
+
+Grok is used for asset image generation only. Use `native`, `codex`,
+`gemini:<model>`, or `openai:<model>` for VQA.
+
+## Setup
+
+1. Set your API key:
+
+```bash
+export XAI_API_KEY=...
+```
+
+2. Install the Python package:
+
+```bash
+pip install xai-sdk
+```
+
+3. Run `python tools/check_env.py`.

--- a/docs/wiki/06-configuration/providers/image-vqa/native.md
+++ b/docs/wiki/06-configuration/providers/image-vqa/native.md
@@ -1,0 +1,23 @@
+# native image and VQA provider
+
+`native` means the active coding-agent runtime supplies the image or vision
+capability. It is not an API provider.
+
+## Project config
+
+```yaml
+asset_image_model: native
+vqa_model: native
+```
+
+## Runtime support
+
+| Runtime | Native image generation | Native VQA |
+|---|---|---|
+| Claude Code | Only when the active host provides it | Supported through runtime image inspection |
+| Codex | Supported when the active Codex host provides it | Supported when the active Codex host provides it |
+| OpenCode | Unsupported | Unsupported |
+
+For OpenCode projects, choose `codex`, `gemini:<model>`, `openai:<model>`, or
+`grok:<model>` for image generation, and choose `codex`, `gemini:<model>`, or
+`openai:<model>` for VQA.

--- a/docs/wiki/06-configuration/providers/image-vqa/openai.md
+++ b/docs/wiki/06-configuration/providers/image-vqa/openai.md
@@ -1,0 +1,26 @@
+# OpenAI image and VQA provider
+
+Use OpenAI when you want API-backed image generation or visual QA.
+
+## Project config
+
+```yaml
+asset_image_model: openai:gpt-image-2
+vqa_model: openai:gpt-5.5
+```
+
+## Setup
+
+1. Set your API key:
+
+```bash
+export OPENAI_API_KEY=...
+```
+
+2. Install the Python package:
+
+```bash
+pip install openai
+```
+
+3. Run `python tools/check_env.py`.

--- a/docs/wiki/07-contributing/codebase-guide.md
+++ b/docs/wiki/07-contributing/codebase-guide.md
@@ -13,7 +13,7 @@ GodotMaker/
 │   └── reviewer/            8 reviewer skills (gotchas.md + checklist.md each)
 ├── tools/                   publish.py, check_env.py, check_project.py, asset_*.py, migrate.py
 ├── config/                  config.yaml.default, stage_schemas.json, addon_versions.json
-├── agent-runtimes/          Runner-specific references, templates, and hook config
+├── agent-runtimes/          Runner-specific references, templates, hook config, and plugin adapters
 ├── templates/               Document templates (GDD, PLAN, STRUCTURE, SCENES, ASSETS, GAP, MEMORY, TOC)
 ├── tests/                   ~320 unit tests for hooks and tools
 ├── docs/                    versioning.md, hooks.md, wiki/, update/, contributing/, reference/
@@ -43,9 +43,10 @@ Scripts and the events they handle:
 | `check_worker_report.py` | Called by on_subagent_stop.py | Yes |
 | `check_completion.py` | Stop | Yes |
 
-Hook registration (which script fires on which event) lives under
-`agent-runtimes/<agent>/config/` and is deployed into the selected runner's
-project-local hook config (`.claude/settings.json` or `.codex/hooks.json`).
+Hook registration (which script fires on which event) is runner-specific.
+Claude Code and Codex use config files under `agent-runtimes/<agent>/config/`;
+OpenCode uses `agent-runtimes/opencode/plugins/godotmaker-hooks.js` as a
+plugin adapter.
 
 ### hooks/metrics/
 
@@ -163,7 +164,7 @@ When you run `python tools/publish.py <target>`:
 4. Copy tools to `<target>/tools/`.
 5. Copy templates to the selected agent template directory.
 6. Copy `config/stage_schemas.json` to `<target>/.godotmaker/stage_schemas.json`.
-7. On fresh install (or `--force`): write agent-specific instructions (`CLAUDE.md` or `AGENTS.md`), prompt for `godotmaker.yaml`, and write the selected runner's hook config.
+7. On fresh install (or `--force`): write agent-specific instructions (`CLAUDE.md` or `AGENTS.md`), prompt for `godotmaker.yaml`, and write the selected runner's hook config or plugin adapter.
 8. Stamp `<target>/.godotmaker/version` with the current version.
 
 ---

--- a/docs/wiki/07-contributing/writing-a-hook.md
+++ b/docs/wiki/07-contributing/writing-a-hook.md
@@ -100,6 +100,12 @@ pipeline by crashing.
 
 `agent_id` is empty for the main agent and non-empty for sub-agents. This is how hooks distinguish between the role skill and its workers.
 
+Runner payloads are not identical. Claude Code and Codex provide
+Claude-style `agent_id`, `SubagentStart`, and `SubagentStop` payloads.
+OpenCode uses an adapter plugin and does not expose the same subagent
+lifecycle payloads, so hooks that depend on those fields must either declare
+Claude Code / Codex support only or provide an explicit OpenCode fallback.
+
 ---
 
 ## Existing hooks

--- a/docs/wiki/07-contributing/writing-a-hook.md
+++ b/docs/wiki/07-contributing/writing-a-hook.md
@@ -1,6 +1,6 @@
 # Writing a Hook
 
-Hooks are small Python scripts that the coding-agent runtime calls on specific events during a session. They enforce rules that the AI cannot bypass on its own — file permission boundaries, required outputs before a role can finish, report quality gates. The hook list is registered per runner in `agent-runtimes/<agent>/config/`; the scripts live in `hooks/` and are deployed to `.godotmaker/hooks/` by `publish.py`.
+Hooks are small Python scripts that the coding-agent runtime calls on specific events during a session. They enforce rules that the AI cannot bypass on its own — file permission boundaries, required outputs before a role can finish, report quality gates. Hook registration is runner-specific: Claude Code and Codex use config files, while OpenCode uses a plugin adapter. The scripts live in `hooks/` and are deployed to `.godotmaker/hooks/` by `publish.py`.
 
 For the full per-hook reference (exact payloads, block conditions, edge cases), see [../../hooks.md](../../hooks.md). This page covers how to write a new hook, not how every existing hook works.
 
@@ -26,7 +26,7 @@ def main():
         return
 
     # Block — write structured JSON to stdout, exit 0
-    # (Claude Code reads stdout, not the exit code, for the decision)
+    # (The runner hook surface reads stdout, not the exit code, for the decision)
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": data.get("hook_event_name", "PreToolUse"),
@@ -47,7 +47,10 @@ Three outcomes:
 | Allow with a reminder | Exit 0, print JSON with `additionalContext` |
 | Block the action | Exit 0, print JSON with `permissionDecision: "deny"` (PreToolUse) or `decision: "block"` (Stop / SubagentStop) |
 
-Claude Code reads stdout for the decision; it does not use the exit code to block. If a hook crashes (non-zero exit, or malformed JSON on stdout), Claude Code logs the error and continues — hooks must never silently break the pipeline by crashing.
+The runner hook surface reads stdout for the decision; it does not use the exit
+code to block. If a hook crashes (non-zero exit, or malformed JSON on stdout),
+the runtime may log the error and continue — hooks must never silently break the
+pipeline by crashing.
 
 ### Block format for PreToolUse
 
@@ -87,7 +90,7 @@ Claude Code reads stdout for the decision; it does not use the exit code to bloc
 
 | Event | When it fires | Key payload fields |
 |-------|--------------|-------------------|
-| `SessionStart` | At the start of every Claude Code session | `hook_event_name` |
+| `SessionStart` | At the start of a supported root runtime session | `hook_event_name` |
 | `PreToolUse` (Write\|Edit) | Before every file write or edit | `tool_name`, `tool_input.file_path`, `tool_input.content`, `agent_id` |
 | `PreToolUse` (Agent) | Before every sub-agent dispatch | `tool_name`, `tool_input.description`, `agent_id` |
 | `PreToolUse` (Read) | Before every file read | `tool_name`, `tool_input.file_path`, `agent_id` |
@@ -191,9 +194,10 @@ State is stored in `.godotmaker/state.json` and reset on every `SessionStart`.
 
 1. Create your hook script in `hooks/<my_hook>.py`.
 
-2. Add it to the appropriate runner hook config under the appropriate event:
-   `agent-runtimes/claude-code/config/settings.json` for Claude Code or
-   `agent-runtimes/codex/config/hooks.json` for Codex.
+2. Add it to every supported runner surface that should trigger it:
+   `agent-runtimes/claude-code/config/settings.json` for Claude Code,
+   `agent-runtimes/codex/config/hooks.json` for Codex, or
+   `agent-runtimes/opencode/plugins/godotmaker-hooks.js` for OpenCode.
 
    ```json
    {

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -17,7 +17,7 @@ GodotMaker turns a game idea into a playable Godot 4 prototype. The normal path 
 | [Skills](03-skills/skill-system.md) | What the role / supporting / reviewer skills are and which one does what |
 | [Troubleshooting](04-troubleshooting/common-problems.md) | A run stopped, was blocked, or behaved oddly - find a fix here |
 | [Tools](05-tools/publish.md) | Reference for `publish.py`, `check_env.py`, `check_project.py`, asset helpers |
-| [Configuration](06-configuration/project-config.md) | Per-project preferences, host paths, addon version pinning |
+| [Configuration](06-configuration/project-config.md) | Per-project preferences, provider setup, host paths, addon version pinning |
 | [Contributing](07-contributing/development-setup.md) | You want to add a skill, hook, or tool, or cut a release |
 | [Reference](08-reference/glossary.md) | Glossary, FAQ, and pointer to the changelog |
 

--- a/docs/zh/hooks.md
+++ b/docs/zh/hooks.md
@@ -1,11 +1,12 @@
 # Hooks 参考手册
 
-GodotMaker 所有 Hook 的完整参考。Hook 是 Python 脚本，在 Claude Code 事件上自动运行，用于执行流水线规则。
+GodotMaker 所有 Hook 的完整参考。Hook 是 Python 脚本，在 coding-agent runtime 事件上自动运行，用于执行流水线规则。
 
 Hook 注册关系按 runner 分开维护：Claude Code 使用
 `agent-runtimes/claude-code/config/settings.json`，Codex 使用
-`agent-runtimes/codex/config/hooks.json`。脚本通过发布流程部署到
-`.godotmaker/hooks/`。
+`agent-runtimes/codex/config/hooks.json`。OpenCode 使用
+`agent-runtimes/opencode/plugins/godotmaker-hooks.js` 作为 adapter plugin。
+脚本通过发布流程部署到 `.godotmaker/hooks/`。
 
 ---
 

--- a/docs/zh/hooks.md
+++ b/docs/zh/hooks.md
@@ -8,6 +8,11 @@ Hook 注册关系按 runner 分开维护：Claude Code 使用
 `agent-runtimes/opencode/plugins/godotmaker-hooks.js` 作为 adapter plugin。
 脚本通过发布流程部署到 `.godotmaker/hooks/`。
 
+OpenCode 使用降级版 runner hook adapter；它的子 Agent 权限边界见
+OpenCode runtime provider 文档。
+下方清单中的 `SubagentStart` 和 `SubagentStop` 适用于 Claude Code / Codex
+hook payload；OpenCode adapter 不会发出这类 Claude-style 生命周期事件。
+
 ---
 
 ## Hook 清单
@@ -18,9 +23,9 @@ Hook 注册关系按 runner 分开维护：Claude Code 使用
 | `check_file_permissions.py` | PreToolUse | Write\|Edit | 是 | 由 `.godotmaker/current_role` 驱动的角色与子代理写规则 |
 | `stage_reminder.py` | PreToolUse | Write\|Edit | 是 | 检测 `stage.jsonl` 追加操作，验证角色输出，注入下一角色提示 |
 | `check_stage_prerequisites.py` | PreToolUse | Agent | 是 | Worker 派发前，验证前置角色已完成且其产出存在 |
-| `check_asset_access.py` | PreToolUse | Read | 是 | 在活跃角色期间，阻止主代理读取 `assets/` 中的图片文件 |
-| `log_subagent.py` | SubagentStart | — | 否 | 记录子代理启动指标（角色检测、agent_id） |
-| `on_subagent_stop.py` | SubagentStop | — | 是 | 分发器：串行执行 `log_subagent.handle_stop` + `check_worker_report`，避免指标文件竞态 |
+| `check_asset_access.py` | PreToolUse | Read | 是 | 在活跃角色期间，阻止主代理/root session 读取 `assets/` 中的图片文件 |
+| `log_subagent.py` | SubagentStart | — | 否 | Claude Code / Codex：记录子代理启动指标（角色检测、agent_id）。OpenCode 不发出这个生命周期 hook。 |
+| `on_subagent_stop.py` | SubagentStop | — | 是 | Claude Code / Codex：串行执行 `log_subagent.handle_stop` + `check_worker_report`，避免指标文件竞态。OpenCode 不发出这个生命周期 hook。 |
 | `check_completion.py` | Stop | — | 是 | 最终门控：仅针对 `build` / `fixgap`，若派发了 Worker 但未运行 Verifier + Reviewer 则阻止结束 |
 
 ---
@@ -56,6 +61,10 @@ Hook 注册关系按 runner 分开维护：Claude Code 使用
 | `accept` / `finalize` | 除 `e2e/` 和游戏代码（`.gd` / `.tscn` / `.tres`）外的任何内容 |
 
 在流水线角色活跃期间，通用子代理会被阻止写入 `e2e/` 和规划文档（`PLAN.md` / `STRUCTURE.md` / `ASSETS.md` / `GAP.md`）。`asset-producer` 可以写入 `assets/`、`references/` 和 `.godotmaker/asset-generation/`。
+
+Runner 说明：这个子代理写入 gate 需要 runtime 提供 `agent_id`。OpenCode child
+session 不暴露该 payload，因此 OpenCode adapter 不会对 child session 运行这个
+Python 子代理写入 gate；该边界依赖 OpenCode 原生 agent edit permission。
 
 未设置角色时，表示当前没有活跃的 `/gm-*` 流水线角色。该 Hook 只记录文件操作，不阻止写入，因此用户可以在 GodotMaker 项目目录中正常开启普通 coding-agent 对话。
 
@@ -109,7 +118,9 @@ Hook 还会重新验证前置角色在 `config/stage_schemas.json` 中的 `files
 仅在流水线角色活跃时（存在 `.godotmaker/current_role`），阻止主代理读取 `assets/` 中的图片文件。
 图片扩展名：.png、.jpg、.jpeg、.svg、.webp、.gif、.bmp、.tga。
 
-没有活跃角色的普通对话被允许。子代理（Analyst）被允许。非图片文件（.json、.ogg）被允许。
+没有活跃角色的普通对话被允许。runtime 提供子代理身份时，子代理被允许。
+OpenCode child session 不暴露同等的 `agent_id` payload，因此它的 adapter 只在
+root stage session 上保留这个 gate。非图片文件（.json、.ogg）被允许。
 
 目的：强制主代理将资源分析委托给 Analyst 子代理，而不是消耗上下文来读取原始图片数据。
 
@@ -117,6 +128,9 @@ Hook 还会重新验证前置角色在 `config/stage_schemas.json` 中的 `files
 
 **事件：** SubagentStart（以及 `on_subagent_stop.py` 调用它处理 SubagentStop）
 **是否阻止：** 从不
+
+Runner 支持：仅 Claude Code / Codex。OpenCode adapter 不发出 Claude-style
+子代理生命周期 hook。
 
 **SubagentStart：** 检测角色并记录 `SUBAGENT_START` 指标，包括 `agent_id`、`agent_type`、`role`、`description`。
 
@@ -135,6 +149,9 @@ Hook 还会重新验证前置角色在 `config/stage_schemas.json` 中的 `files
 
 **事件：** SubagentStop
 **是否阻止：** 是（委托给 `check_worker_report`）
+
+Runner 支持：仅 Claude Code / Codex。OpenCode adapter 不发出 Claude-style
+子代理生命周期 hook。
 
 `SubagentStop` 事件的单一分发器。读取一次 stdin 后串行运行：
 
@@ -210,10 +227,10 @@ PreToolUse(Read)
   └── check_asset_access.py (活跃角色期间阻止主代理读取 assets/ 中的图片)
 
 SubagentStart
-  └── log_subagent.py (记录启动 + 角色)
+  └── log_subagent.py (Claude Code / Codex：记录启动 + 角色)
 
 SubagentStop
-  └── on_subagent_stop.py (串行：log_subagent.handle_stop → check_worker_report)
+  └── on_subagent_stop.py (Claude Code / Codex：串行报告 gate)
 
 Stop
   └── check_completion.py (仅 build/fixgap 的严谨性检查；其他角色为空操作)

--- a/docs/zh/versioning.md
+++ b/docs/zh/versioning.md
@@ -119,15 +119,15 @@ python tools/migrate.py --new fix-state-path
 MAJOR 版本变更意味着无法通过增量迁移处理的破坏性变更。`publish.py` 拒绝跨 MAJOR 边界升级，除非使用 `--force`，该选项会执行干净的重新初始化。
 
 全量重建会清除所有框架管理的内容：
-- `.claude/skills/`、`.claude/agents/`、`.claude/config/`、`.claude/templates/`
+- 所选 runner 的 `skills/`、`agents/`、`config/`、`templates/`
 - `.godotmaker/hooks/`、`.godotmaker/stage_schemas.json`
 - `.godotmaker/state.json`、`.godotmaker/metrics*.jsonl`
 - `.godotmaker/applied_migrations.json`（重新部署后会重建 baseline）
 - `tools/`
-- `.claude/settings.json`（强制覆盖）
+- 所选 runner 的 hook config 或 plugin adapter（强制覆盖）
 
 保留（用户配置）：
-- `CLAUDE.md`、`.claude/godotmaker.yaml`、`.godotmaker/config.yaml`
+- `CLAUDE.md` / `AGENTS.md`、所选 runner 的 `godotmaker.yaml`、`.godotmaker/config.yaml`
 
 重新部署完后，`publish.py` 调用 `baseline_applied()` 把所有当前迁移
 标记为已应用而不执行——跟全新安装一样。迁移时间戳序列本身是单调全局的，
@@ -153,7 +153,7 @@ schema 变更，请从 VCS 快照恢复目标项目。
 
 ## 会话中的版本显示
 
-在已发布的项目中启动 Claude Code 会话时，`session_start.py` Hook 读取 `.godotmaker/version` 并将 `[GodotMaker vX.Y.Z]` 注入会话上下文。这让当前角色技能和用户都能知道部署的是哪个框架版本。
+在已发布的项目中启动受支持的 coding-agent 会话时，`session_start.py` Hook 会读取 `.godotmaker/version`，并在 runtime 支持注入上下文时写入 `[GodotMaker vX.Y.Z]`。这让当前角色技能知道部署的是哪个框架版本。
 
 ## 发布新版本的工作流程
 
@@ -180,20 +180,20 @@ schema 变更，请从 VCS 快照恢复目标项目。
 
 | 目录 | 内容 |
 |------|------|
-| `.claude/skills/` | 所有技能（从 core + reviewer 展平） |
-| `.claude/agents/` | 代理定义（worker、verifier、reviewer、analyst、asset-producer） |
+| 所选 runner 的 `skills/` | 所有技能（从 core + reviewer 展平） |
+| 所选 runner 的 `agents/` | 代理定义（worker、verifier、reviewer、analyst、asset-producer） |
 | `.godotmaker/hooks/` | 所有 Hook 脚本 |
-| `.claude/config/` | 配置文件（仅 `--force` 时覆盖 settings.json） |
-| `.claude/templates/` | 文档模板 |
+| 所选 runner 的 `config/` | 配置文件 |
+| 所选 runner 的 `templates/` | 文档模板 |
 | `tools/` | Python 工具（check_project、check_env 等） |
 
 以下**不会**被覆盖（仅在全新安装时创建）：
 
 | 文件 | 原因 |
 |------|------|
-| `CLAUDE.md` | 用户可能已自定义 |
-| `.claude/settings.json` | 用户 Hook 配置（仅 `--force` 时覆盖） |
-| `.claude/godotmaker.yaml` | 主机特定路径 |
+| `CLAUDE.md` / `AGENTS.md` | 用户可能已自定义 |
+| 所选 runner 的 hook config 或 plugin adapter | 用户 Hook 行为（仅 `--force` 时覆盖） |
+| 所选 runner 的 `godotmaker.yaml` | 主机特定路径 |
 | `.godotmaker/config.yaml` | 项目特定设置 |
 
 ## 关于 addon_versions.json 的说明

--- a/docs/zh/wiki/01-getting-started/installation.md
+++ b/docs/zh/wiki/01-getting-started/installation.md
@@ -10,9 +10,9 @@ GodotMaker 能把你的游戏想法变成一个可以运行的 Godot 4 项目。
 | Git | 2.30+ | 追踪改动并启用隔离 Agent worktree | https://git-scm.com/downloads |
 | Node.js | 22+ | 运行 `godotmaker-cli` 和 Godot MCP 工具 | https://nodejs.org |
 | Python | 3.10+ | 运行 GodotMaker 辅助脚本和验证工具 | https://python.org/downloads |
-| Claude Code 或 Codex | 最新版 | 实现和评估游戏的 Agent runtime | https://claude.ai/code 或 https://openai.com/codex/ |
+| Claude Code、Codex 或 OpenCode | 最新版 | 实现和评估游戏的 Agent runtime | https://claude.ai/code、https://openai.com/codex/ 或 https://opencode.ai/ |
 
-先安装上面的工具，然后继续。Claude Code 和 Codex 不需要同时安装；选择一个已登录的 Agent runtime 即可。
+先安装上面的工具，然后继续。Claude Code、Codex 和 OpenCode 不需要同时安装；选择一个已登录的 Agent runtime 即可。
 
 ## 选择 Agent runner
 
@@ -28,13 +28,19 @@ godotmaker-cli --agent claude-code
 godotmaker-cli --agent codex
 ```
 
+选择 OpenCode：
+
+```bash
+godotmaker-cli --agent opencode
+```
+
 Agent 选择优先级是：启动参数 `--agent`、项目 `.godotmaker/config.yaml`、CLI 全局配置、默认值。
 
 ## API Key
 
 GodotMaker 可以根据 `.godotmaker/config.yaml` 使用 runtime 原生图片和视觉能力，或者使用 API 后端 provider。
 
-只有项目选择 API 后端 provider 时，才需要 API key。GodotMaker 本身不提供外部模型服务。如果你希望 Claude Code 项目由 Codex 负责生图，可以设置 `asset_image_model: codex`；这需要 Codex CLI 位于 PATH 中，不需要图片 API key。
+只有项目选择 API 后端 provider 时，才需要 API key。GodotMaker 本身不提供外部模型服务。如果你希望 Claude Code 或 OpenCode 项目由 Codex 负责生图，可以设置 `asset_image_model: codex`；这需要 Codex CLI 位于 PATH 中，不需要图片 API key。OpenCode 当前不默认使用 native 生图或 native VQA；运行完整流水线前，请把这些字段配置为 `codex` 或 API 后端 provider。
 
 | Key | 什么时候需要 | 用途 |
 |-----|--------------|------|

--- a/docs/zh/wiki/05-tools/check-env.md
+++ b/docs/zh/wiki/05-tools/check-env.md
@@ -42,7 +42,7 @@ All required checks passed! Ready to use GodotMaker.
 
 - Claude Code 项目会检查 `claude` 是否已安装。
 - Codex 项目会检查 `codex` 是否已安装、`.agents` runtime tree 是否存在，以及 `godot` MCP server 是否已配置。
-- OpenCode 项目会检查 `opencode` 是否已安装、`.opencode` runtime tree 是否存在，以及 `godot` MCP server 是否已配置。
+- OpenCode 项目会检查 `opencode` 是否已安装、`.opencode` runtime tree 和 hook adapter 是否存在，以及 `godot` MCP server 是否已配置。
 
 ### API 密钥
 

--- a/docs/zh/wiki/05-tools/check-env.md
+++ b/docs/zh/wiki/05-tools/check-env.md
@@ -38,9 +38,11 @@ All required checks passed! Ready to use GodotMaker.
 
 如果 Godot 不在 PATH 中，这项检查会显示警告而非硬性失败——你仍可以在运行 `publish.py` 时手动输入可执行文件的完整路径，它会被保存到 `.claude/godotmaker.yaml` 供后续使用。
 
-### Claude Code
+### 所选 coding agent
 
-- `claude` 命令行工具已安装且在 PATH 中可用。
+- Claude Code 项目会检查 `claude` 是否已安装。
+- Codex 项目会检查 `codex` 是否已安装、`.agents` runtime tree 是否存在，以及 `godot` MCP server 是否已配置。
+- OpenCode 项目会检查 `opencode` 是否已安装、`.opencode` runtime tree 是否存在，以及 `godot` MCP server 是否已配置。
 
 ### API 密钥
 
@@ -50,6 +52,8 @@ All required checks passed! Ready to use GodotMaker.
 | `OPENAI_API_KEY` | 选中时必填 | OpenAI 图片生成或 VQA |
 | `XAI_API_KEY` | 选中时必填 | xAI Grok 图片生成 |
 
+
+API 后端 selector 在缺少对应 key 时会失败。`asset_image_model: native` 对 Codex 会通过，对 Claude Code 会给出警告，因为检查工具无法证明 Claude 侧一定有原生生图能力。OpenCode 项目如果使用 `native` 生图或 `native` VQA 会失败，直到你把这些字段改成 `codex` 或 API 后端 selector。Claude Code 或 OpenCode 项目使用 `asset_image_model: codex` 时，需要 `codex` CLI 位于 PATH 中。
 
 检查工具还会验证被选中提供方的 Python 包能否正常导入，从而捕获单靠版本号检查无法发现的安装问题。
 

--- a/docs/zh/wiki/05-tools/check-project.md
+++ b/docs/zh/wiki/05-tools/check-project.md
@@ -16,39 +16,39 @@ python tools/check_project.py /path/to/my-game --all
 ## 类别标志
 
 | 标志 | 检查内容 |
-|------|---------------|
-| `--build` | `project.godot` 是否存在，且包含有效的 `[application]` 节 |
-| `--ecs` | gecs 插件是否存在；游戏代码中是否有 Component 和 System 文件 |
-| `--tests` | gdUnit4 插件是否存在；每个 System 是否都有对应的单元测试文件 |
-| `--e2e` | godot-e2e 插件是否已启用；`e2e/` 中是否有真实的测试函数而非占位符 |
-| `--plan` | `PLAN.md` 和 `STRUCTURE.md` 是否存在且包含正确的章节 |
-| `--mcp` | `godot-mcp` 服务器是否已注册到 `.mcp.json` |
+|------|----------|
+| `--build` | `project.godot` 存在、必需插件已安装、git `HEAD` 可解析，且 Godot 无头解析没有阻断性诊断 |
+| `--ecs` | gecs 插件存在；游戏代码中有 Component 和 System 文件 |
+| `--tests` | gdUnit4 插件存在；每个 System 都有对应的单元测试文件 |
+| `--e2e` | godot-e2e 插件已启用；`e2e/` 中有真实测试函数，而不是占位文件 |
+| `--plan` | `PLAN.md` 和 `STRUCTURE.md` 存在，且包含正确章节 |
+| `--mcp` | `godot-mcp` 服务已注册到 `.mcp.json` |
 | `--all` | 执行以上全部检查 |
 
 ## 能发现哪些问题
 
-**构建就绪性** — 确认 `project.godot` 存在且结构有效。项目文件缺失意味着 Godot 根本无法打开该项目。
+**构建就绪** — 确认 `project.godot` 存在且结构有效，必需插件目录是正确的 addon-only 形态，git `HEAD` 可以解析，并且 `<godot_path> --headless --quit` 没有阻断性诊断。Godot shutdown notes 会单独报告；其他 Godot diagnostics 会让检查失败。
 
-**ECS 配置** — 确认 `addons/gecs/` 已安装，且游戏中确实存在 `extend Component` 和 `extend System` 的 GDScript 文件。两者都没有，说明项目尚未开始构建（或构建被中断了）。
+**ECS 配置** — 确认 `addons/gecs/` 已安装，并且游戏中确实存在 `extend Component` 和 `extend System` 的 GDScript 文件。两者都没有，说明项目尚未开始构建，或构建被中断。
 
 **单元测试覆盖率** — 检查每个 System 文件是否都有对应的测试文件。匹配规则包括 `test_movement_system.gd`、`movement_system_test.gd`、`testmovementsystem.gd` 等形式。没有测试文件的 System 会按名称列出。
 
-**端到端测试** — 检查 `e2e/conftest.py` 是否存在，`e2e/` 目录下是否有 `test_*.py` 文件，以及这些文件中是否包含真实的 `def test_` 函数而不是空的桩代码。文件过短或含有 "todo"/"stub" 关键字的占位文件会触发警告。
+**端到端测试** — 检查 `e2e/conftest.py` 是否存在，`e2e/` 目录下是否有 `test_*.py` 文件，以及这些文件中是否包含真实的 `def test_` 函数，而不是空的桩代码。文件过短或含有 "todo" / "stub" 关键字的占位文件会触发警告。
 
 **规划文档** — 确认 `PLAN.md` 存在且包含任务状态标记（`pending`、`in_progress`、`completed` 等），`STRUCTURE.md` 包含 Component Registry 和 System Schedule。这两份文档是 `/gm-build` 和 `/gm-fixgap` 的执行依据。
 
-**MCP 注册** — 检查 `.mcp.json` 中是否包含 `"godot"` 服务器条目，这是由 `publish.py` 创建的。没有它，Claude Code 就无法向 Godot 编辑器发送命令。
+**MCP 注册** — 检查 `.mcp.json` 中是否包含 `"godot"` 服务条目，这是由 `publish.py` 创建的。没有它，Claude Code 就无法向 Godot 编辑器发送命令。
 
 ## 何时运行
 
 - 构建出现报错或意外行为之后。
-- 运行 `/gm-finalize` 之前，确认项目已完整。
+- 运行 `/gm-finalize` 之前，确认项目已经完整。
 - 搁置较久后重新打开项目时，了解当前状态。
 - 手动添加或重命名文件之后，确认没有引入问题。
 
 ## 读懂输出结果
 
-```
+```text
 [PASS] project.godot exists
 [FAIL] No System files found (files extending System)
 [WARN] MEMORY.md not found (optional but recommended)
@@ -56,7 +56,7 @@ python tools/check_project.py /path/to/my-game --all
 
 失败项会在末尾汇总展示：
 
-```
+```text
 ==================================================
 Total: 18 checks
   PASS: 15
@@ -72,7 +72,7 @@ Failed checks:
 ## 退出码
 
 | 退出码 | 含义 |
-|------|---------|
+|--------|------|
 | 0 | 所有检查通过 |
 | 1 | 一项或多项检查失败 |
 | 2 | 项目目录不存在 |

--- a/docs/zh/wiki/05-tools/publish.md
+++ b/docs/zh/wiki/05-tools/publish.md
@@ -16,6 +16,11 @@ claude
 python tools/publish.py --agent codex /path/to/my-game
 cd /path/to/my-game
 codex
+
+# OpenCode
+python tools/publish.py --agent opencode /path/to/my-game
+cd /path/to/my-game
+opencode
 ```
 
 Windows 上：
@@ -42,7 +47,7 @@ python tools\publish.py C:\Games\my-game
 | `CLAUDE.md` | 项目专属指令，Claude Code 每次会话开始时都会读取 |
 | `assets/sprites`、`assets/audio`、`assets/fonts`、`assets/ui`、`references/` | 标准素材文件夹 |
 
-脚本还会为所选 agent 注册 `godot-mcp` 服务器（Claude Code 走 `claude mcp`，Codex 走 `codex mcp`）、在项目中尚无 git 仓库时自动初始化，并创建包含正确条目的 `.gitignore`。Codex 发布必须完成 MCP 注册，因为后续 GodotMaker 运行时依赖 Godot MCP 工具。
+脚本还会为所选 agent 注册 `godot-mcp` 服务器（Claude Code 走 `claude mcp`，Codex 走 `codex mcp`，OpenCode 走 `opencode mcp`）、在项目中尚无 git 仓库时自动初始化，并创建包含正确条目的 `.gitignore`。MCP 注册是必需的，因为后续 GodotMaker 运行时依赖 Godot MCP 工具。
 
 使用 `--agent codex` 时，agent 相关文件会改用 Codex 的项目本地布局：
 技能写入 `.agents/skills/`，模板和配置写入 `.agents/`，`godotmaker.yaml`
@@ -50,6 +55,8 @@ python tools\publish.py C:\Games\my-game
 Codex hook 注册写入 `.codex/hooks.json`。共享框架状态仍然位于
 `.godotmaker/`。Codex 的 approval 与 sandbox 策略由 Codex 运行时处理；
 publish 不会创建 `.agents/settings.json` 等价文件。
+
+使用 `--agent opencode` 时，agent 相关文件会改用 OpenCode 的项目本地布局：技能写入 `.opencode/skills/`，agent 定义写入 `.opencode/agents/`，模板和配置写入 `.opencode/`，`godotmaker.yaml` 位于 `.opencode/godotmaker.yaml`，并创建指向 OpenCode runtime mapping 的 `AGENTS.md`。publish 不默认假设 OpenCode plugin / hook 与 Claude Code 或 Codex 等价。
 
 ### Codex 权限
 
@@ -94,6 +101,7 @@ codex.cmd remote-control -c sandbox_mode='"danger-full-access"' -c approval_poli
 ```bash
 python tools/publish.py --force /path/to/my-game
 python tools/publish.py --agent codex --force /path/to/my-game
+python tools/publish.py --agent opencode --force /path/to/my-game
 ```
 
 `--force` 同时做四件事：
@@ -113,7 +121,7 @@ python tools/publish.py --agent codex --force /path/to/my-game
 |------|---------------|
 | `CLAUDE.md` / `AGENTS.md` | 你可能添加了项目专属指令 |
 | `.claude/settings.json` / `.codex/hooks.json` | 你可能调整过 hook 行为 |
-| `.claude/godotmaker.yaml` / `.agents/godotmaker.yaml` | 包含本机专属的 Godot 路径 |
+| `.claude/godotmaker.yaml` / `.agents/godotmaker.yaml` / `.opencode/godotmaker.yaml` | 包含本机专属的 Godot 路径 |
 | `.godotmaker/config.yaml` | 包含项目专属的偏好设置 |
 
 你的游戏代码、场景、素材以及规划文档（`GDD.md`、`PLAN.md` 等）不受 publish 影响——它只管理框架层。

--- a/docs/zh/wiki/05-tools/publish.md
+++ b/docs/zh/wiki/05-tools/publish.md
@@ -56,7 +56,7 @@ Codex hook 注册写入 `.codex/hooks.json`。共享框架状态仍然位于
 `.godotmaker/`。Codex 的 approval 与 sandbox 策略由 Codex 运行时处理；
 publish 不会创建 `.agents/settings.json` 等价文件。
 
-使用 `--agent opencode` 时，agent 相关文件会改用 OpenCode 的项目本地布局：技能写入 `.opencode/skills/`，agent 定义写入 `.opencode/agents/`，模板和配置写入 `.opencode/`，`godotmaker.yaml` 位于 `.opencode/godotmaker.yaml`，并创建指向 OpenCode runtime mapping 的 `AGENTS.md`。publish 不默认假设 OpenCode plugin / hook 与 Claude Code 或 Codex 等价。
+使用 `--agent opencode` 时，agent 相关文件会改用 OpenCode 的项目本地布局：技能写入 `.opencode/skills/`，agent 定义写入 `.opencode/agents/`，模板和配置写入 `.opencode/`，`godotmaker.yaml` 位于 `.opencode/godotmaker.yaml`，并创建指向 OpenCode runtime mapping 的 `AGENTS.md`。OpenCode hook adapter 会写入 `.opencode/plugins/godotmaker-hooks.js`，并调用 `.godotmaker/hooks/` 中的共享 GodotMaker hook 脚本。
 
 ### Codex 权限
 
@@ -107,7 +107,7 @@ python tools/publish.py --agent opencode --force /path/to/my-game
 `--force` 同时做四件事：
 
 1. 重新部署前清空所选 agent 的技能目录，移除旧版本遗留的技能文件。
-2. 即使你已自定义过所选 runner 的 hook config（`.claude/settings.json` 或 `.codex/hooks.json`），也会强制覆盖。
+2. 即使你已自定义过所选 runner 的 hook config 或 adapter（`.claude/settings.json`、`.codex/hooks.json` 或 `.opencode/plugins/godotmaker-hooks.js`），也会强制覆盖。
 3. 跳过 minor 和 major 升级的确认提示。
 4. 允许降级。
 
@@ -120,7 +120,7 @@ python tools/publish.py --agent opencode --force /path/to/my-game
 | 文件 | 保留原因 |
 |------|---------------|
 | `CLAUDE.md` / `AGENTS.md` | 你可能添加了项目专属指令 |
-| `.claude/settings.json` / `.codex/hooks.json` | 你可能调整过 hook 行为 |
+| `.claude/settings.json` / `.codex/hooks.json` / `.opencode/plugins/godotmaker-hooks.js` | 你可能调整过 hook 行为 |
 | `.claude/godotmaker.yaml` / `.agents/godotmaker.yaml` / `.opencode/godotmaker.yaml` | 包含本机专属的 Godot 路径 |
 | `.godotmaker/config.yaml` | 包含项目专属的偏好设置 |
 

--- a/docs/zh/wiki/06-configuration/project-config.md
+++ b/docs/zh/wiki/06-configuration/project-config.md
@@ -8,7 +8,7 @@
 
 ## 常用字段
 
-**`agent`** — 当前项目选择的编码智能体运行时，例如 `claude-code` 或 `codex`。
+**`agent`** — 当前项目选择的编码智能体运行时，例如 `claude-code`、`codex` 或 `opencode`。
 
 **`worker_model`** — 编写游戏代码的 Claude 模型。默认是 `sonnet`；需要更强实现推理的游戏可改为 `opus`。
 
@@ -50,6 +50,8 @@ decomposer_model: sonnet
 
 对于 Codex 项目，`asset_image_model: native` 映射到 Codex 原生图片生成，前提是当前宿主暴露了这个能力。对于 Claude Code 项目，`native` 需要 Claude 侧有原生生图工具。没有原生路径时，`/gm-asset` 必须停止并要求你改用 `codex` 或 API 后端。
 
+对于 OpenCode 项目，框架不使用 `native` 生图或 `native` VQA。运行完整流水线前，请把 `asset_image_model` 和 `vqa_model` 改成 `codex` 或 API 后端 selector。
+
 如果 Claude Code 项目希望使用 Codex 图片生成：
 
 ```yaml
@@ -57,6 +59,22 @@ asset_image_model: codex
 ```
 
 这会选择 Codex 作为图片生成 provider。它需要 Codex CLI 位于 PATH 中，不需要图片 API key。
+
+## Provider 配置页面
+
+Coding-agent runtime：
+
+- [Claude Code](providers/agent-runtimes/claude-code.md)
+- [Codex](providers/agent-runtimes/codex.md)
+- [OpenCode](providers/agent-runtimes/opencode.md)
+
+图片和 VQA provider：
+
+- [native](providers/image-vqa/native.md)
+- [codex](providers/image-vqa/codex.md)
+- [gemini](providers/image-vqa/gemini.md)
+- [openai](providers/image-vqa/openai.md)
+- [grok](providers/image-vqa/grok.md)
 
 ## API Key
 
@@ -95,6 +113,7 @@ agent: codex
 ```bash
 godotmaker-cli --agent claude-code
 godotmaker-cli --agent codex
+godotmaker-cli --agent opencode
 ```
 
 下一次运行 `/gm-*` 命令时会读取新配置。已经运行中的命令不会自动感知修改，需要下一次会话或阶段调用才会生效。

--- a/docs/zh/wiki/06-configuration/project-config.md
+++ b/docs/zh/wiki/06-configuration/project-config.md
@@ -118,6 +118,9 @@ godotmaker-cli --agent opencode
 
 下一次运行 `/gm-*` 命令时会读取新配置。已经运行中的命令不会自动感知修改，需要下一次会话或阶段调用才会生效。
 
-## 关于 `.claude/settings.json`
+## 关于 hook config 文件
 
-Claude Code 项目还会有 `.claude/settings.json`，它负责注册 GodotMaker hook 脚本。这个文件由框架管理；如果升级后 hook 不再触发，可以运行 `python tools/publish.py --force <project>` 重新发布。
+GodotMaker 会通过所选 runner 的入口注册 hook 脚本：Claude Code 使用
+`.claude/settings.json`，Codex 使用 `.codex/hooks.json`，OpenCode 使用
+`.opencode/plugins/godotmaker-hooks.js`。这些文件由框架管理；如果升级后
+hook 不再触发，可以运行 `python tools/publish.py --force <project>` 重新发布所选 runner 的 hook 入口。

--- a/docs/zh/wiki/06-configuration/providers/README.md
+++ b/docs/zh/wiki/06-configuration/providers/README.md
@@ -1,0 +1,23 @@
+# Provider 配置
+
+GodotMaker 有两层相互独立的 provider：
+
+1. Coding-agent runtime 负责运行 `/gm-*` 工作流。
+2. 图片 / VQA provider 负责生成美术 source 或检查截图。
+
+选择某个 coding-agent runtime 不等于自动选择图片或 VQA provider。两层都通过
+`.godotmaker/config.yaml` 配置。
+
+## Coding-agent runtime
+
+- [Claude Code](agent-runtimes/claude-code.md)
+- [Codex](agent-runtimes/codex.md)
+- [OpenCode](agent-runtimes/opencode.md)
+
+## 图片和 VQA provider
+
+- [native](image-vqa/native.md)
+- [codex](image-vqa/codex.md)
+- [gemini](image-vqa/gemini.md)
+- [openai](image-vqa/openai.md)
+- [grok](image-vqa/grok.md)

--- a/docs/zh/wiki/06-configuration/providers/agent-runtimes/claude-code.md
+++ b/docs/zh/wiki/06-configuration/providers/agent-runtimes/claude-code.md
@@ -1,0 +1,28 @@
+# Claude Code runtime
+
+Claude Code 是 GodotMaker 的默认 runtime。
+
+## 配置步骤
+
+1. 安装 Claude Code。
+2. 通过 Claude Code CLI 登录。
+3. 发布项目：
+
+```bash
+python tools/publish.py /path/to/my-game
+```
+
+## 项目配置
+
+```yaml
+agent: claude-code
+```
+
+Claude Code 项目使用 `.claude/skills`、`.claude/agents`、
+`.claude/templates` 和 `CLAUDE.md`。
+
+## 图片和 VQA
+
+`native` VQA 使用当前 Claude Code runtime 的图片检查路径。`native` 生图需要
+Claude 侧实际提供生图能力。如果不可用，请把 `asset_image_model` 改成 `codex`
+或 API-backed provider。

--- a/docs/zh/wiki/06-configuration/providers/agent-runtimes/codex.md
+++ b/docs/zh/wiki/06-configuration/providers/agent-runtimes/codex.md
@@ -1,0 +1,26 @@
+# Codex runtime
+
+当你希望 GodotMaker 通过 Codex skills 运行时，使用 Codex runtime。
+
+## 配置步骤
+
+1. 安装 Codex 并登录。
+2. 发布项目：
+
+```bash
+python tools/publish.py --agent codex /path/to/my-game
+```
+
+## 项目配置
+
+```yaml
+agent: codex
+```
+
+Codex 项目使用 `.agents/skills`、`.agents/agents`、`.agents/templates`、
+`.agents/references`、`.codex/hooks.json` 和 `AGENTS.md`。
+
+## 图片和 VQA
+
+对于 Codex 项目，`native` 会映射到当前 Codex 宿主暴露的原生图片和视觉能力。
+你也可以显式设置 `asset_image_model: codex` 或 `vqa_model: codex`。

--- a/docs/zh/wiki/06-configuration/providers/agent-runtimes/opencode.md
+++ b/docs/zh/wiki/06-configuration/providers/agent-runtimes/opencode.md
@@ -22,6 +22,16 @@ agent: opencode
 OpenCode 项目使用 `.opencode/skills`、`.opencode/agents`、
 `.opencode/templates`、`.opencode/references` 和 `AGENTS.md`。
 
+## 已知工具限制
+
+OpenCode 目前对 `.godotmaker/` 或 `.opencode/` 这类 dot-directory 存在已知
+文件发现限制。GodotMaker 会为项目状态文件发布 OpenCode runtime workaround。
+
+- https://github.com/anomalyco/opencode/issues/11691
+- https://github.com/anomalyco/opencode/issues/10906
+
+等 OpenCode 能稳定发现 dot-directory 文件后，请删除这段 workaround。
+
 ## 角色模型
 
 OpenCode 子 Agent 会继承当前父 OpenCode 会话的模型。`.godotmaker/config.yaml`
@@ -38,6 +48,18 @@ OpenCode adapter 仍会运行主阶段和生命周期 gate，包括阶段前置�
 工作区清洁检查、会话启动和 compaction 指标。已知的子会话读写操作不会再进入
 GodotMaker 基于 `agent_id` 的 Python 子 Agent gate，因为 OpenCode 不暴露
 同等的子 Agent 身份 payload。
+
+这意味着 OpenCode 当前无法完整复用 Claude Code / Codex 的子 Agent hook
+契约。依赖稳定子 Agent 身份的 Worker report 生命周期检查、子 Agent 指标和
+Python 读写 gate，在 OpenCode 子会话中会降级。主阶段 gate 仍会通过 OpenCode
+adapter 运行。
+
+相关的 OpenCode 上游 issue：
+
+- https://github.com/anomalyco/opencode/issues/15403
+- https://github.com/anomalyco/opencode/issues/16626
+- https://github.com/anomalyco/opencode/issues/17412
+- https://github.com/anomalyco/opencode/issues/12566
 
 子 Agent 的写入边界由 OpenCode 原生的 `.opencode/agents/*.md`
 `permission` frontmatter 处理。`reviewer`、`verifier`、`gdd-auditor`

--- a/docs/zh/wiki/06-configuration/providers/agent-runtimes/opencode.md
+++ b/docs/zh/wiki/06-configuration/providers/agent-runtimes/opencode.md
@@ -22,6 +22,13 @@ agent: opencode
 OpenCode 项目使用 `.opencode/skills`、`.opencode/agents`、
 `.opencode/templates`、`.opencode/references` 和 `AGENTS.md`。
 
+## 角色模型
+
+OpenCode 子 Agent 会继承当前父 OpenCode 会话的模型。`.godotmaker/config.yaml`
+中的按角色模型设置，例如 `worker_model` 和 `asset_producer_model`，目前用于
+Claude Code 项目，不会覆盖 OpenCode 子 Agent 模型。请用你希望委派角色继承
+的模型启动 OpenCode 会话。
+
 ## 图片和 VQA
 
 OpenCode 支持不使用 runtime 原生生图或读图能力。运行完整流水线前，请把这两个字段

--- a/docs/zh/wiki/06-configuration/providers/agent-runtimes/opencode.md
+++ b/docs/zh/wiki/06-configuration/providers/agent-runtimes/opencode.md
@@ -1,0 +1,44 @@
+# OpenCode runtime
+
+当你希望 GodotMaker 的代码和文本阶段通过 DeepSeek 等 OpenCode 模型运行时，
+使用 OpenCode runtime。
+
+## 配置步骤
+
+1. 安装 OpenCode。
+2. 通过 `opencode auth login` 或 OpenCode TUI 的 `/connect` 流程连接模型 provider。
+3. 发布项目：
+
+```bash
+python tools/publish.py --agent opencode /path/to/my-game
+```
+
+## 项目配置
+
+```yaml
+agent: opencode
+```
+
+OpenCode 项目使用 `.opencode/skills`、`.opencode/agents`、
+`.opencode/templates`、`.opencode/references` 和 `AGENTS.md`。
+
+## 图片和 VQA
+
+OpenCode 支持不使用 runtime 原生生图或读图能力。运行完整流水线前，请把这两个字段
+设置为 `codex` 或 API-backed provider。
+
+推荐配置：
+
+```yaml
+asset_image_model: codex
+vqa_model: codex
+```
+
+也可以使用 API-backed provider：
+
+```yaml
+asset_image_model: gemini:gemini-3.1-flash-image-preview
+vqa_model: gemini:gemini-2.5-flash
+```
+
+修改后运行 `python tools/check_env.py`。

--- a/docs/zh/wiki/06-configuration/providers/agent-runtimes/opencode.md
+++ b/docs/zh/wiki/06-configuration/providers/agent-runtimes/opencode.md
@@ -29,6 +29,22 @@ OpenCode 子 Agent 会继承当前父 OpenCode 会话的模型。`.godotmaker/co
 Claude Code 项目，不会覆盖 OpenCode 子 Agent 模型。请用你希望委派角色继承
 的模型启动 OpenCode 会话。
 
+## Hooks 和权限
+
+OpenCode 不暴露与 Claude Code 等价的子 Agent 生命周期 payload。因此，
+GodotMaker 不把 OpenCode hooks 视为完整的 Claude Code hook parity。
+
+OpenCode adapter 仍会运行主阶段和生命周期 gate，包括阶段前置检查、完成检查、
+工作区清洁检查、会话启动和 compaction 指标。已知的子会话读写操作不会再进入
+GodotMaker 基于 `agent_id` 的 Python 子 Agent gate，因为 OpenCode 不暴露
+同等的子 Agent 身份 payload。
+
+子 Agent 的写入边界由 OpenCode 原生的 `.opencode/agents/*.md`
+`permission` frontmatter 处理。`reviewer`、`verifier`、`gdd-auditor`
+这类只读审查角色会发布为 `permission.edit: deny`；`worker` 这类实现角色
+保留完成任务所需的编辑权限。这个边界只覆盖 edit permission；它不是
+Claude-style 读取访问 hook 的替代品。
+
 ## 图片和 VQA
 
 OpenCode 支持不使用 runtime 原生生图或读图能力。运行完整流水线前，请把这两个字段

--- a/docs/zh/wiki/06-configuration/providers/image-vqa/codex.md
+++ b/docs/zh/wiki/06-configuration/providers/image-vqa/codex.md
@@ -1,0 +1,18 @@
+# codex 图片和 VQA provider
+
+`codex` 表示由 Codex 提供图片生成或图片检查能力，即使当前项目 runner 不是 Codex。
+
+## 项目配置
+
+```yaml
+asset_image_model: codex
+vqa_model: codex
+```
+
+## 配置步骤
+
+1. 安装 Codex 并登录。
+2. 确认 `codex` 命令位于 `PATH` 中。
+3. 运行 `python tools/check_env.py`。
+
+这个 provider 不需要图片 API key，但需要当前 Codex 环境实际暴露所需的图片或视觉能力。

--- a/docs/zh/wiki/06-configuration/providers/image-vqa/gemini.md
+++ b/docs/zh/wiki/06-configuration/providers/image-vqa/gemini.md
@@ -1,0 +1,28 @@
+# Gemini 图片和 VQA provider
+
+当你希望通过 API 后端生成图片或执行视觉 QA 时，可以使用 Gemini。
+
+## 项目配置
+
+```yaml
+asset_image_model: gemini:gemini-3.1-flash-image-preview
+vqa_model: gemini:gemini-2.5-flash
+```
+
+## 配置步骤
+
+1. 创建 Gemini API key。
+2. 设置以下任一环境变量：
+
+```bash
+export GOOGLE_API_KEY=...
+export GEMINI_API_KEY=...
+```
+
+3. 安装 Python 包：
+
+```bash
+pip install google-genai
+```
+
+4. 运行 `python tools/check_env.py`。

--- a/docs/zh/wiki/06-configuration/providers/image-vqa/grok.md
+++ b/docs/zh/wiki/06-configuration/providers/image-vqa/grok.md
@@ -1,0 +1,28 @@
+# Grok 图片 provider
+
+当你希望通过 xAI API 生成图片时，可以使用 Grok。
+
+## 项目配置
+
+```yaml
+asset_image_model: grok:grok-imagine-image
+```
+
+Grok 只用于素材图片生成。VQA 请使用 `native`、`codex`、`gemini:<model>` 或
+`openai:<model>`。
+
+## 配置步骤
+
+1. 设置 API key：
+
+```bash
+export XAI_API_KEY=...
+```
+
+2. 安装 Python 包：
+
+```bash
+pip install xai-sdk
+```
+
+3. 运行 `python tools/check_env.py`。

--- a/docs/zh/wiki/06-configuration/providers/image-vqa/native.md
+++ b/docs/zh/wiki/06-configuration/providers/image-vqa/native.md
@@ -1,0 +1,21 @@
+# native 图片和 VQA provider
+
+`native` 表示由当前 coding-agent runtime 提供图片或视觉能力。它不是 API provider。
+
+## 项目配置
+
+```yaml
+asset_image_model: native
+vqa_model: native
+```
+
+## Runtime 支持情况
+
+| Runtime | 原生生图 | 原生 VQA |
+|---|---|---|
+| Claude Code | 只有当前宿主提供时才支持 | 通过 runtime 图片检查路径支持 |
+| Codex | 当前 Codex 宿主提供时支持 | 当前 Codex 宿主提供时支持 |
+| OpenCode | 不支持 | 不支持 |
+
+OpenCode 项目请为生图选择 `codex`、`gemini:<model>`、`openai:<model>` 或
+`grok:<model>`，为 VQA 选择 `codex`、`gemini:<model>` 或 `openai:<model>`。

--- a/docs/zh/wiki/06-configuration/providers/image-vqa/openai.md
+++ b/docs/zh/wiki/06-configuration/providers/image-vqa/openai.md
@@ -1,0 +1,26 @@
+# OpenAI 图片和 VQA provider
+
+当你希望通过 OpenAI API 生成图片或执行视觉 QA 时，可以使用 OpenAI。
+
+## 项目配置
+
+```yaml
+asset_image_model: openai:gpt-image-2
+vqa_model: openai:gpt-5.5
+```
+
+## 配置步骤
+
+1. 设置 API key：
+
+```bash
+export OPENAI_API_KEY=...
+```
+
+2. 安装 Python 包：
+
+```bash
+pip install openai
+```
+
+3. 运行 `python tools/check_env.py`。

--- a/docs/zh/wiki/07-contributing/codebase-guide.md
+++ b/docs/zh/wiki/07-contributing/codebase-guide.md
@@ -13,7 +13,7 @@ GodotMaker/
 │   └── reviewer/            8 个审查技能（各含 gotchas.md + checklist.md）
 ├── tools/                   publish.py, check_env.py, check_project.py, asset_*.py, migrate.py
 ├── config/                  config.yaml.default, stage_schemas.json, addon_versions.json
-├── agent-runtimes/          runner 专属 reference、template 和 hook config
+├── agent-runtimes/          runner 专属 reference、template、hook config 和 plugin adapter
 ├── templates/               文档模板（GDD, PLAN, STRUCTURE, SCENES, ASSETS, GAP, MEMORY, TOC）
 ├── tests/                   ~320 个 hook 和工具的单元测试
 ├── docs/                    versioning.md, hooks.md, wiki/, update/, contributing/, reference/
@@ -43,9 +43,9 @@ GodotMaker/
 | `check_worker_report.py` | 由 on_subagent_stop.py 调用 | 是 |
 | `check_completion.py` | Stop | 是 |
 
-Hook 注册关系（哪个脚本响应哪个事件）存储在
-`agent-runtimes/<agent>/config/` 下，并发布到所选 runner 的项目级 hook
-配置（`.claude/settings.json` 或 `.codex/hooks.json`）。
+Hook 注册关系（哪个脚本响应哪个事件）按 runner 区分。Claude Code 和
+Codex 使用 `agent-runtimes/<agent>/config/` 下的配置文件；OpenCode 使用
+`agent-runtimes/opencode/plugins/godotmaker-hooks.js` 作为 plugin adapter。
 
 ### hooks/metrics/
 
@@ -163,7 +163,7 @@ manifest 的 schema、添加/移除流程和调试技巧见 `docs/contributing/s
 4. 复制 tools → `<target>/tools/`。
 5. 复制 templates 到所选 agent 的模板目录。
 6. 复制 `config/stage_schemas.json` → `<target>/.godotmaker/stage_schemas.json`。
-7. 首次安装（或使用 `--force`）时：写入对应 agent 的项目指令文件（`CLAUDE.md` 或 `AGENTS.md`），提示配置 `godotmaker.yaml`；Claude Code 目标还会写入 `.claude/settings.json`。
+7. 首次安装（或使用 `--force`）时：写入对应 agent 的项目指令文件（`CLAUDE.md` 或 `AGENTS.md`），提示配置 `godotmaker.yaml`，并写入所选 runner 的 hook config 或 plugin adapter。
 8. 将当前版本号写入 `<target>/.godotmaker/version`。
 
 ---

--- a/docs/zh/wiki/07-contributing/writing-a-hook.md
+++ b/docs/zh/wiki/07-contributing/writing-a-hook.md
@@ -1,6 +1,6 @@
 # 编写 Hook
 
-Hook 是 coding-agent runtime 在会话特定事件发生时调用的小型 Python 脚本。它们强制执行 AI 自身无法绕过的规则——文件权限边界、角色完成前的必要输出、报告质量门禁。Hook 列表按 runner 注册在 `agent-runtimes/<agent>/config/` 下；脚本存放在 `hooks/` 下，由 `publish.py` 部署到 `.godotmaker/hooks/`。
+Hook 是 coding-agent runtime 在会话特定事件发生时调用的小型 Python 脚本。它们强制执行 AI 自身无法绕过的规则——文件权限边界、角色完成前的必要输出、报告质量门禁。Hook 注册按 runner 区分：Claude Code 和 Codex 使用配置文件，OpenCode 使用 plugin adapter。脚本存放在 `hooks/` 下，由 `publish.py` 部署到 `.godotmaker/hooks/`。
 
 关于每个 hook 的完整参考（精确的 payload、拦截条件、边界情况），请参阅 [../../hooks.md](../../hooks.md)。本页专注于如何编写新的 hook，而不是讲解每个现有 hook 的工作原理。
 
@@ -26,7 +26,7 @@ def main():
         return
 
     # 拦截——向 stdout 写入结构化 JSON，exit 0
-    # （Claude Code 读取 stdout 来做决策，而不是依赖退出码）
+    # （runner hook 入口读取 stdout 来做决策，而不是依赖退出码）
     print(json.dumps({
         "hookSpecificOutput": {
             "hookEventName": data.get("hook_event_name", "PreToolUse"),
@@ -47,7 +47,7 @@ if __name__ == "__main__":
 | 放行并附带提示 | Exit 0，向 stdout 输出带 `additionalContext` 的 JSON |
 | 拦截操作 | Exit 0，向 stdout 输出带 `permissionDecision: "deny"`（PreToolUse）或 `decision: "block"`（Stop / SubagentStop）的 JSON |
 
-Claude Code 读取 stdout 来做决策，不使用退出码来执行拦截。如果 hook 崩溃（非零退出，或 stdout 输出格式错误的 JSON），Claude Code 会记录错误并继续执行——hook 绝不能因崩溃而静默地破坏流水线。
+runner hook 入口读取 stdout 来做决策，不使用退出码来执行拦截。如果 hook 崩溃（非零退出，或 stdout 输出格式错误的 JSON），runtime 可能只记录错误并继续执行——hook 绝不能因崩溃而静默地破坏流水线。
 
 ### PreToolUse 的拦截格式
 
@@ -87,7 +87,7 @@ Claude Code 读取 stdout 来做决策，不使用退出码来执行拦截。如
 
 | 事件 | 触发时机 | 关键 payload 字段 |
 |-------|--------------|-------------------|
-| `SessionStart` | 每次 Claude Code 会话开始时 | `hook_event_name` |
+| `SessionStart` | 受支持的 root runtime 会话开始时 | `hook_event_name` |
 | `PreToolUse` (Write\|Edit) | 每次文件写入或编辑之前 | `tool_name`, `tool_input.file_path`, `tool_input.content`, `agent_id` |
 | `PreToolUse` (Agent) | 每次分发子 Agent 之前 | `tool_name`, `tool_input.description`, `agent_id` |
 | `PreToolUse` (Read) | 每次文件读取之前 | `tool_name`, `tool_input.file_path`, `agent_id` |
@@ -191,9 +191,10 @@ value = state.get("my_flag", default=False)
 
 1. 在 `hooks/<my_hook>.py` 创建 hook 脚本。
 
-2. 在对应 runner 的 hook config 中将其添加到对应事件下：Claude Code 使用
+2. 将它添加到需要触发该 hook 的 runner 入口：Claude Code 使用
    `agent-runtimes/claude-code/config/settings.json`，Codex 使用
-   `agent-runtimes/codex/config/hooks.json`。
+   `agent-runtimes/codex/config/hooks.json`，OpenCode 使用
+   `agent-runtimes/opencode/plugins/godotmaker-hooks.js`。
 
    ```json
    {

--- a/docs/zh/wiki/07-contributing/writing-a-hook.md
+++ b/docs/zh/wiki/07-contributing/writing-a-hook.md
@@ -97,6 +97,11 @@ runner hook 入口读取 stdout 来做决策，不使用退出码来执行拦截
 
 `agent_id` 对主 Agent 为空，对子 Agent 为非空。Hook 通过这一字段区分角色技能和其 worker。
 
+不同 runner 的 payload 不完全一致。Claude Code 和 Codex 提供 Claude-style
+`agent_id`、`SubagentStart` 和 `SubagentStop` payload。OpenCode 使用 adapter
+plugin，不暴露同等的子 Agent 生命周期 payload；依赖这些字段的 hook 必须明确只支持
+Claude Code / Codex，或提供显式的 OpenCode fallback。
+
 ---
 
 ## 现有 Hook 概览

--- a/docs/zh/wiki/Home.md
+++ b/docs/zh/wiki/Home.md
@@ -17,7 +17,7 @@ GodotMaker 把你的游戏想法变成可运行的 Godot 4 原型。正常路径
 | [技能系统](03-skills/skill-system.md) | 了解角色技能、辅助技能、审查员技能分别做什么 |
 | [故障排查](04-troubleshooting/common-problems.md) | 运行卡住、被拦截或行为异常时，在这里找解法 |
 | [工具](05-tools/publish.md) | `publish.py`、`check_env.py`、`check_project.py` 及资源工具参考 |
-| [配置](06-configuration/project-config.md) | 每个项目的偏好设置、主机路径、插件版本锁定 |
+| [配置](06-configuration/project-config.md) | 每个项目的偏好设置、provider 配置、主机路径、插件版本锁定 |
 | [参与贡献](07-contributing/development-setup.md) | 想新增技能、Hook 或工具，或发布版本 |
 | [参考](08-reference/glossary.md) | 词汇表、FAQ，以及指向 Changelog 的链接 |
 

--- a/skills/core/gdunit-driver/SKILL.md
+++ b/skills/core/gdunit-driver/SKILL.md
@@ -17,12 +17,8 @@ $ARGUMENTS
 Read the path from the project's config file. This avoids hardcoding paths that differ per machine.
 
 ```bash
-# From a skill script:
-GODOT=$(bash "${CLAUDE_SKILL_DIR}/../_read_config.sh" godot_path)
-
-# Or parse directly — .claude/godotmaker.yaml contains:
-#   godot_path: "C:/path/to/Godot.exe"
-# Fall back to "godot" if config is missing.
+# From the project root:
+python tools/agent_runtime.py godot_path
 ```
 
 ## 2. Run tests
@@ -31,16 +27,16 @@ The CLI runner across all supported versions (v4.x, v5.x, v6.x) is `addons/gdUni
 
 ```bash
 # Single file
-"$GODOT" --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
+"<godot_path>" --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
   --add res://test/test_example.gd --ignoreHeadlessMode
 
 # Multiple files
-"$GODOT" --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
+"<godot_path>" --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
   --add res://test/test_physics.gd --add res://test/test_spawner.gd \
   --ignoreHeadlessMode
 
 # All tests in a directory
-"$GODOT" --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
+"<godot_path>" --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
   --add res://test/ --ignoreHeadlessMode
 ```
 
@@ -55,7 +51,7 @@ Notes:
 `GdUnitCmdTool.gd` supports C# test files too, but ensure `dotnet build` passes first — gdUnit4 runs compiled assemblies, not source files.
 
 ```bash
-dotnet build && "$GODOT" --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
+dotnet build && "<godot_path>" --headless -s res://addons/gdUnit4/bin/GdUnitCmdTool.gd \
   --add res://test/csharp/TestExample.cs --ignoreHeadlessMode
 ```
 

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -68,6 +68,7 @@ Read `.godotmaker/config.yaml` and use `asset_image_model`.
 | `native` | `references/providers/native.md` |
 | `codex` | `references/providers/codex.md` |
 | `gemini:<model>` or `gemini` | `references/providers/gemini.md` |
+| `openai:<model>` or `openai` | `references/providers/openai.md` |
 
 If the configured provider is unavailable, stop and ask the user to choose
 another `asset_image_model`.

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -27,6 +27,7 @@ Use exactly one provider doc per production unit:
 1. `references/providers/native.md`
 2. `references/providers/codex.md`
 3. `references/providers/gemini.md`
+4. `references/providers/openai.md`
 
 ## Production Shapes
 

--- a/skills/core/gm-asset/references/providers/openai.md
+++ b/skills/core/gm-asset/references/providers/openai.md
@@ -1,0 +1,48 @@
+# OpenAI Image Provider
+
+Use this file when `.godotmaker/config.yaml` sets `asset_image_model` to
+`openai` or `openai:<model>`.
+
+## Source Generation
+
+Write one spec per generated source under
+`.godotmaker/asset-generation/specs/`:
+
+```json
+{
+  "asset_id": "<asset_id>",
+  "model": "<openai selector>",
+  "prompt": "<full prompt>",
+  "prompt_path": ".godotmaker/asset-generation/prompts/<asset_id>.txt",
+  "source_path": ".godotmaker/asset-generation/sources/<asset_id>_source.png",
+  "size": "1K",
+  "aspect_ratio": "1:1",
+  "reference_images": [],
+  "report_path": ".godotmaker/asset-generation/reports/<asset_id>_source.json"
+}
+```
+
+Run:
+
+```bash
+python tools/asset_source_generate.py --spec <spec.json>
+```
+
+## Requirements
+
+1. `OPENAI_API_KEY` is set.
+2. The Python `openai` package is installed.
+3. `size` is `1K`.
+
+## Reference Images
+
+Put every required local reference path in `reference_images`. Use only images
+listed by the production-unit brief or selected by the manager.
+
+## Handoff
+
+After generation:
+
+1. Verify the planned source path exists.
+2. Run the production-unit processing or finalization steps.
+3. Keep the source-generation report path in the unit report.

--- a/skills/core/gm-asset/references/providers/openai.md
+++ b/skills/core/gm-asset/references/providers/openai.md
@@ -33,11 +33,16 @@ python tools/asset_source_generate.py --spec <spec.json>
 1. `OPENAI_API_KEY` is set.
 2. The Python `openai` package is installed.
 3. `size` is `1K`.
+4. Use at most 16 reference images.
 
 ## Reference Images
 
 Put every required local reference path in `reference_images`. Use only images
 listed by the production-unit brief or selected by the manager.
+
+When `reference_images` is non-empty, the source generator uses the OpenAI image
+edit endpoint and sends every listed reference image. One reference is sent as a
+single image file; multiple references are sent as an image-file list.
 
 ## Handoff
 

--- a/skills/core/gm-scaffold/SKILL.md
+++ b/skills/core/gm-scaffold/SKILL.md
@@ -42,7 +42,7 @@ Scaffold is **lifetime-once** — its event gets cleared after each tag's finali
 1. **Do NOT design the game here.**
 2. **Use fixed 2D defaults.** Use the project-scaffold default viewport (`1280x720`) and rendering method.
 3. **Do NOT create Component/System stubs.**
-4. **All addons MUST come from `.claude/config/addon_versions.json`** — do not guess versions.
+4. **All addons MUST come from the active runtime's `config/addon_versions.json`** — do not guess versions.
 5. **Initial git commit is mandatory and must include import metadata.** Run `<godot_path> --headless --import` before the commit and include generated `.uid` files.
 
 ## Scaffold Steps
@@ -81,23 +81,23 @@ The remaining items in project-scaffold belong to other parts of the pipeline:
 | Post-Scaffold publish (Step 5) | already done by `tools/publish.py` before scaffold runs |
 | Addon install | step 2b below |
 
-### 2b. Install addons and enable godot-e2e plugin
+### 2b. Install addon-only directories
 
-For each entry in `.claude/config/addon_versions.json` matching the chosen
-Godot version, clone the repo at the listed tag into the listed `install_path`:
+Install required addons from the active runtime's `config/addon_versions.json`.
+Follow `project-scaffold/references/addons.md`.
 
-- `addons/gecs/` (csprance/gecs)
-- `addons/gdUnit4/` (MikeSchulze/gdUnit4)
-- `addons/godot_e2e/` (RandallLiuXin/godot-e2e)
+Required result:
 
-Then enable each addon in `[editor_plugins]` of `project.godot` by
-listing its `plugin.cfg` (consult the `plugin: true|false` flag in
-`addon_versions.json` — at the time of writing, gecs / gdUnit4 /
-godot-e2e are all plugin-enabled).
+1. `addons/gecs/plugin.cfg`
+2. `addons/gdUnit4/plugin.cfg`
+3. `addons/gdUnit4/bin/GdUnitCmdTool.gd`
+4. `addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd`
+5. `addons/godot_e2e/plugin.cfg`
+6. `addons/godot_e2e/automation_server.gd`
+7. no `addons/*/project.godot`
 
-Ensure `AutomationServer` is registered once in `[autoload]` for
-`res://addons/godot_e2e/automation_server.gd`; do not add a second entry
-if the template or plugin already registered it.
+Then enable plugin entries in `project.godot` and register
+`AutomationServer`.
 
 `.godotmaker/config.yaml` is created by `tools/publish.py` before this skill
 runs — verify it exists and move on.
@@ -168,6 +168,10 @@ python tools/check_project.py <project_dir> --build
 
 - `project.godot` exists with `[application]`
 - `addons/gecs/`, `addons/gdUnit4/`, `addons/godot_e2e/` present
+- each required addon has `plugin.cfg`
+- no required addon contains a nested `project.godot`
+- `addons/gdUnit4/bin/GdUnitCmdTool.gd` and
+  `addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd` exist
 - `godot-e2e` plugin enabled in `[editor_plugins]`
 - `AutomationServer` autoload registered for `godot-e2e`
 - `e2e/conftest.py` imports `GodotE2E`
@@ -176,9 +180,7 @@ python tools/check_project.py <project_dir> --build
   (godot_path read from `.claude/godotmaker.yaml`, validated at publish time)
 
 All entries must report `[PASS]` for scaffold to be considered done.
-If `.claude/godotmaker.yaml` lacks `godot_path` the headless check
-emits `[FAIL]` because headless parse is part of the build gate. Re-run
-`tools/publish.py` to set the path.
+If `.claude/godotmaker.yaml` lacks `godot_path`, re-run `tools/publish.py`.
 
 ## Available Skills & Tools
 

--- a/skills/core/gm-scaffold/SKILL.md
+++ b/skills/core/gm-scaffold/SKILL.md
@@ -176,10 +176,10 @@ python tools/check_project.py <project_dir> --build
 - `AutomationServer` autoload registered for `godot-e2e`
 - `e2e/conftest.py` imports `GodotE2E`
 - `.git/` resolves `HEAD` (worker worktree isolation needs it)
-- `<godot_path> --headless --quit` exits 0 with no `ERROR` lines
-  (godot_path read from `.claude/godotmaker.yaml`, validated at publish time)
+- `<godot_path> --headless --quit` exits 0 with no blocking Godot diagnostics
 
-All entries must report `[PASS]` for scaffold to be considered done.
+The command must exit 0 with no `[FAIL]` entries for scaffold to be
+considered done. Shutdown-note `[WARN]` entries do not block scaffold.
 If `.claude/godotmaker.yaml` lacks `godot_path`, re-run `tools/publish.py`.
 
 ## Available Skills & Tools

--- a/skills/core/gm-verify/SKILL.md
+++ b/skills/core/gm-verify/SKILL.md
@@ -45,8 +45,8 @@ What the script does:
 - Reads `godot_path` from `.claude/godotmaker.yaml`; falls back to
   plain `godot` from PATH. A missing or broken binary surfaces as a
   `tooling_notes[].suggested_fallback = "escalate"` entry.
-- Runs `<godot_path> --headless --quit` and parses `ERROR:` lines into
-  `checks.build.errors[]`.
+- Runs `<godot_path> --headless --quit` and writes blocking Godot diagnostics
+  to `checks.build.errors[]`.
 - Runs `<godot_path> --headless ... res://addons/gdUnit4/bin/GdUnitCmdTool.gd
   --ignoreHeadlessMode --add res://test/ --report-directory <temp>` and
   parses the generated JUnit XML into

--- a/skills/core/headless-build/SKILL.md
+++ b/skills/core/headless-build/SKILL.md
@@ -15,8 +15,13 @@ Compile-check a Godot project. Fastest feedback loop: "did my code parse?"
 ## Run
 
 ```bash
-GODOT_PATH=$(bash "${CLAUDE_SKILL_DIR}/../_read_config.sh" godot_path)
-"${GODOT_PATH}" --headless --quit 2>&1
+python tools/agent_runtime.py godot_path
+```
+
+Then substitute the printed value for `<godot_path>`:
+
+```bash
+"<godot_path>" --headless --quit 2>&1
 ```
 
 Run from the project root (where `project.godot` lives). Should exit within 30 seconds.

--- a/skills/core/project-scaffold/SKILL.md
+++ b/skills/core/project-scaffold/SKILL.md
@@ -159,9 +159,9 @@ After all files are written, tell the user what to do next:
    (prompts for Godot executable path on first run), and creates
    `.godotmaker/config.yaml` with default project settings.
 
-2. **Install addons** — pick the row matching your Godot version from
-   `.claude/config/addon_versions.json` (the source of truth for repo
-   + tag + install path), then clone each into the listed install path:
+2. **Install addons** — pick the row matching your Godot version from the
+   active runtime's `config/addon_versions.json` (the source of truth for repo,
+   tag, and install path), then install addon-only directories:
    - gecs -> `addons/gecs/`
    - gdUnit4 -> `addons/gdUnit4/`
    - godot_e2e -> `addons/godot_e2e/`
@@ -169,7 +169,7 @@ After all files are written, tell the user what to do next:
    `tools/check_project.py --e2e` and the gm-* skills expect those
    exact paths (note `gdUnit4/` is capital U — matches the upstream
    repo layout). See `references/addons.md` for the step-by-step
-   clone commands.
+   installation contract.
 
 3. **Register godot-mcp** for runtime debugging:
    ```bash

--- a/skills/core/project-scaffold/references/addons.md
+++ b/skills/core/project-scaffold/references/addons.md
@@ -5,8 +5,15 @@ Install them after scaffold, before running headless-build or tests.
 
 ## Version Compatibility — MANDATORY
 
-Read `.claude/config/addon_versions.json` to determine the correct version for each addon.
-The JSON maps Godot versions to compatible addon versions. You MUST use the exact tag specified.
+Read the active runtime's `config/addon_versions.json` to determine the
+correct version for each addon:
+
+- Claude Code: `.claude/config/addon_versions.json`
+- Codex: `.agents/config/addon_versions.json`
+- OpenCode: `.opencode/config/addon_versions.json`
+
+The JSON maps Godot versions to compatible addon versions. You MUST use the
+exact tag specified.
 
 **Steps:**
 1. Detect Godot version: `godot --version` (e.g., "4.4.stable")
@@ -18,14 +25,30 @@ If the Godot version is not in the mapping, use the closest lower version. If no
 
 ## Download Method
 
-For each addon in the version mapping:
+For each addon in the version mapping, install the addon-only directory:
 
 ```bash
-# Clone specific tag, copy addon directory, clean up
-git clone --depth 1 --branch {tag} https://github.com/{repo}.git /tmp/{addon_name}
-cp -r /tmp/{addon_name}/{install_path}/ {install_path}/
-rm -rf /tmp/{addon_name}
+# Clone specific tag outside addons/, copy addon subdirectory, clean up.
+git clone --depth 1 --branch {tag} https://github.com/{repo}.git .godotmaker/scratch/{addon_name}
+cp -r .godotmaker/scratch/{addon_name}/{install_path}/ {install_path}/
+rm -rf .godotmaker/scratch/{addon_name}
 ```
+
+Required copy sources:
+
+- `addons/gecs/` from the source repo's `addons/gecs/`
+- `addons/gdUnit4/` from the source repo's `addons/gdUnit4/`
+- `addons/godot_e2e/` from the source repo's `addons/godot_e2e/`
+
+Do not clone the full source repository directly into `addons/gecs/`,
+`addons/gdUnit4/`, or `addons/godot_e2e/`.
+
+After copying each addon:
+
+1. Confirm `plugin.cfg` exists in the copied addon root.
+2. Confirm `project.godot` does not exist in the copied addon root.
+3. For gdUnit4, confirm `bin/GdUnitCmdTool.gd` and
+   `src/core/runners/GdUnitTestCIRunner.gd` exist.
 
 ## Post-Download Configuration
 
@@ -54,7 +77,11 @@ If `"plugin": true` in the mapping:
   enabled=PackedStringArray("res://addons/gecs/plugin.cfg", "res://addons/gdUnit4/plugin.cfg", "res://addons/godot_e2e/plugin.cfg")
   ```
 
-The plugin automatically registers the `AutomationServer` autoload.
+Ensure `AutomationServer` is registered once in `[autoload]`:
+
+```
+AutomationServer="*res://addons/godot_e2e/automation_server.gd"
+```
 
 ## godot-mcp (Runtime Debug Server)
 
@@ -77,4 +104,6 @@ godot --headless --quit 2>&1
 No `SCRIPT ERROR:` lines means success. Common errors:
 - `World` class not found → gecs not installed or not enabled
 - `GdUnitRunner` error → gdUnit4 version mismatch with Godot version
+- `GdUnitTestCIRunner` not found -> reinstall the gdUnit4 addon-only
+  directory and run `godot --headless --import`
 - `AutomationServer` error → godot-e2e plugin not enabled or addon files missing

--- a/tests/agent_runtimes/test_opencode_hooks_plugin.py
+++ b/tests/agent_runtimes/test_opencode_hooks_plugin.py
@@ -107,3 +107,161 @@ process.exit(2);
 
     assert result.returncode == 0, result.stderr
     assert result.stdout.strip() == "write denied"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_child_session_write_skips_root_stage_file_gate(tmp_path: Path):
+    marker = tmp_path / "stage-reminder-ran.txt"
+    write_hook(
+        tmp_path,
+        "check_file_permissions.py",
+        (
+            "import json\n"
+            "print(json.dumps({'hookSpecificOutput': {"
+            "'permissionDecision': 'deny', "
+            "'permissionDecisionReason': 'root gate should not run'"
+            "}}))\n"
+        ),
+    )
+    write_hook(
+        tmp_path,
+        "stage_reminder.py",
+        f"from pathlib import Path\nPath({json.dumps(str(marker))}).write_text('yes')\n",
+    )
+
+    source = f"""
+import {{ pathToFileURL }} from 'node:url';
+const {{ GodotMakerHooks }} = await import(pathToFileURL({json.dumps(str(PLUGIN))}).href);
+const hooks = await GodotMakerHooks({{ directory: {json.dumps(str(tmp_path))} }});
+await hooks.event({{
+  event: {{
+    type: 'session.created',
+    properties: {{ info: {{ id: 'child', parentID: 'root' }} }}
+  }}
+}});
+await hooks['tool.execute.before'](
+  {{ tool: 'write', callID: 'call-1', sessionID: 'child' }},
+  {{ args: {{ filePath: 'systems/player.gd', content: 'x' }} }}
+);
+console.log('allowed');
+"""
+    result = run_node(source, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "allowed"
+    assert marker.read_text(encoding="utf-8") == "yes"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_root_read_runs_asset_access_gate(tmp_path: Path):
+    write_hook(
+        tmp_path,
+        "check_asset_access.py",
+        (
+            "import json\n"
+            "print(json.dumps({'hookSpecificOutput': {"
+            "'permissionDecision': 'deny', "
+            "'permissionDecisionReason': 'asset read denied'"
+            "}}))\n"
+        ),
+    )
+
+    source = f"""
+import {{ pathToFileURL }} from 'node:url';
+const {{ GodotMakerHooks }} = await import(pathToFileURL({json.dumps(str(PLUGIN))}).href);
+const hooks = await GodotMakerHooks({{ directory: {json.dumps(str(tmp_path))} }});
+try {{
+  await hooks['tool.execute.before'](
+    {{ tool: 'read', callID: 'call-1', sessionID: 'root' }},
+    {{ args: {{ filePath: 'assets/player.png' }} }}
+  );
+}} catch (error) {{
+  console.log(error.message);
+  process.exit(0);
+}}
+console.error('expected read block to throw');
+process.exit(2);
+"""
+    result = run_node(source, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "asset read denied"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_child_session_read_skips_asset_access_gate(tmp_path: Path):
+    write_hook(
+        tmp_path,
+        "check_asset_access.py",
+        (
+            "import json\n"
+            "print(json.dumps({'hookSpecificOutput': {"
+            "'permissionDecision': 'deny', "
+            "'permissionDecisionReason': 'child asset gate should not run'"
+            "}}))\n"
+        ),
+    )
+
+    source = f"""
+import {{ pathToFileURL }} from 'node:url';
+const {{ GodotMakerHooks }} = await import(pathToFileURL({json.dumps(str(PLUGIN))}).href);
+const hooks = await GodotMakerHooks({{ directory: {json.dumps(str(tmp_path))} }});
+await hooks.event({{
+  event: {{
+    type: 'session.created',
+    properties: {{ info: {{ id: 'child', parentID: 'root' }} }}
+  }}
+}});
+await hooks['tool.execute.before'](
+  {{ tool: 'read', callID: 'call-1', sessionID: 'child' }},
+  {{ args: {{ filePath: 'assets/player.png' }} }}
+);
+console.log('allowed');
+"""
+    result = run_node(source, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "allowed"
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_task_tool_does_not_emit_claude_style_subagent_lifecycle(tmp_path: Path):
+    write_hook(
+        tmp_path,
+        "check_stage_prerequisites.py",
+        "import sys\nsys.exit(0)\n",
+    )
+    write_hook(
+        tmp_path,
+        "log_agent_tool.py",
+        "import sys\nsys.exit(0)\n",
+    )
+    write_hook(
+        tmp_path,
+        "log_subagent.py",
+        "raise SystemExit('log_subagent should not run for OpenCode')\n",
+    )
+    write_hook(
+        tmp_path,
+        "on_subagent_stop.py",
+        "raise SystemExit('on_subagent_stop should not run for OpenCode')\n",
+    )
+
+    source = f"""
+import {{ pathToFileURL }} from 'node:url';
+const {{ GodotMakerHooks }} = await import(pathToFileURL({json.dumps(str(PLUGIN))}).href);
+const hooks = await GodotMakerHooks({{ directory: {json.dumps(str(tmp_path))} }});
+await hooks['tool.execute.before'](
+  {{ tool: 'task', callID: 'task-1', sessionID: 'root' }},
+  {{ args: {{ subagent_type: 'worker', description: 'do work' }} }}
+);
+await hooks['tool.execute.after'](
+  {{ tool: 'task', callID: 'task-1', sessionID: 'root', args: {{ subagent_type: 'worker' }} }},
+  {{ output: 'done', metadata: {{}} }}
+);
+console.log('ok');
+"""
+    result = run_node(source, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"

--- a/tests/agent_runtimes/test_opencode_hooks_plugin.py
+++ b/tests/agent_runtimes/test_opencode_hooks_plugin.py
@@ -1,0 +1,109 @@
+"""Tests for the OpenCode hook adapter plugin."""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN = REPO_ROOT / "agent-runtimes" / "opencode" / "plugins" / "godotmaker-hooks.js"
+
+
+def write_hook(project: Path, name: str, body: str) -> None:
+    hooks = project / ".godotmaker" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    (hooks / name).write_text(body, encoding="utf-8")
+
+
+def run_node(source: str, project: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["node", "--input-type=module", "-e", source],
+        cwd=project,
+        text=True,
+        capture_output=True,
+        timeout=20,
+    )
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_session_idle_stop_block_sends_prompt_to_agent(tmp_path: Path):
+    write_hook(
+        tmp_path,
+        "session_start.py",
+        "import sys\nsys.exit(0)\n",
+    )
+    write_hook(
+        tmp_path,
+        "check_completion.py",
+        "import json\nprint(json.dumps({'decision': 'block', 'reason': 'completion stop'}))\n",
+    )
+    write_hook(
+        tmp_path,
+        "check_clean_workspace.py",
+        "import json\nprint(json.dumps({'decision': 'block', 'reason': 'dirty stop'}))\n",
+    )
+
+    source = f"""
+import {{ pathToFileURL }} from 'node:url';
+const {{ GodotMakerHooks }} = await import(pathToFileURL({json.dumps(str(PLUGIN))}).href);
+const prompts = [];
+const client = {{
+  session: {{
+    prompt: async (input) => {{
+      prompts.push(input);
+    }},
+  }},
+}};
+const hooks = await GodotMakerHooks({{ directory: {json.dumps(str(tmp_path))}, client }});
+await hooks.event({{ event: {{ type: 'session.created', properties: {{ info: {{ id: 'root' }} }} }} }});
+await hooks.event({{ event: {{ type: 'session.idle', properties: {{ sessionID: 'root' }} }} }});
+console.log(JSON.stringify(prompts));
+"""
+    result = run_node(source, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    prompts = json.loads(result.stdout)
+    assert len(prompts) == 1
+    assert prompts[0]["path"]["id"] == "root"
+    text = prompts[0]["body"]["parts"][0]["text"]
+    assert "GodotMaker Stop hooks blocked this stage from finishing." in text
+    assert "check_completion.py: completion stop" in text
+    assert "check_clean_workspace.py: dirty stop" in text
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node is required")
+def test_pre_tool_block_still_throws(tmp_path: Path):
+    write_hook(
+        tmp_path,
+        "check_file_permissions.py",
+        (
+            "import json\n"
+            "print(json.dumps({'hookSpecificOutput': {"
+            "'permissionDecision': 'deny', "
+            "'permissionDecisionReason': 'write denied'"
+            "}}))\n"
+        ),
+    )
+
+    source = f"""
+import {{ pathToFileURL }} from 'node:url';
+const {{ GodotMakerHooks }} = await import(pathToFileURL({json.dumps(str(PLUGIN))}).href);
+const hooks = await GodotMakerHooks({{ directory: {json.dumps(str(tmp_path))} }});
+try {{
+  await hooks['tool.execute.before'](
+    {{ tool: 'write', callID: 'call-1', sessionID: 'root' }},
+    {{ args: {{ filePath: 'PLAN.md', content: 'x' }} }}
+  );
+}} catch (error) {{
+  console.log(error.message);
+  process.exit(0);
+}}
+console.error('expected tool block to throw');
+process.exit(2);
+"""
+    result = run_node(source, tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "write denied"

--- a/tests/tools/test_asset_source_generate.py
+++ b/tests/tools/test_asset_source_generate.py
@@ -2,6 +2,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
@@ -32,6 +33,21 @@ def make_spec(tmp_path: Path, **overrides):
 def write_png(path: Path, size=(12, 10)):
     path.parent.mkdir(parents=True, exist_ok=True)
     Image.new("RGB", size, (255, 210, 40)).save(path, format="PNG")
+
+
+def png_bytes(size=(12, 10)):
+    buf = source_generate.io.BytesIO()
+    Image.new("RGB", size, (255, 210, 40)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def write_refs(tmp_path: Path, count: int) -> list[str]:
+    refs = []
+    for index in range(count):
+        path = tmp_path / f"ref-{index}.png"
+        write_png(path)
+        refs.append(str(path))
+    return refs
 
 
 def test_load_spec_requires_explicit_model(tmp_path, monkeypatch):
@@ -97,6 +113,65 @@ def test_generate_source_supports_openai_selector(tmp_path, monkeypatch):
     assert result["cost_cents"] == 5
     assert (tmp_path / result["source_path"]).exists()
     assert (tmp_path / result["report_path"]).exists()
+
+
+def test_openai_uses_all_reference_images_for_edit(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    spec = source_generate.load_spec(
+        make_spec(
+            tmp_path,
+            model="openai:gpt-image-2",
+            reference_images=write_refs(tmp_path, 2),
+        )
+    )
+    seen = {}
+    image_b64 = source_generate.base64.b64encode(png_bytes()).decode()
+    output = Path(spec["source_path"])
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    class FakeImages:
+        def edit(self, **kwargs):
+            seen.update(kwargs)
+            assert all(not image.closed for image in kwargs["image"])
+            assert [Path(image.name).name for image in kwargs["image"]] == [
+                "ref-0.png",
+                "ref-1.png",
+            ]
+            return SimpleNamespace(data=[SimpleNamespace(b64_json=image_b64)])
+
+        def generate(self, **_kwargs):
+            raise AssertionError("reference image specs must use images.edit")
+
+    class FakeOpenAI:
+        def __init__(self):
+            self.images = FakeImages()
+
+    monkeypatch.setitem(
+        sys.modules,
+        "openai",
+        SimpleNamespace(OpenAI=FakeOpenAI),
+    )
+
+    source_generate._generate_openai(spec, output, "gpt-image-2")
+
+    assert seen["model"] == "gpt-image-2"
+    assert seen["prompt"] == spec["prompt"]
+    assert seen["size"] == "1024x1024"
+    assert (tmp_path / spec["source_path"]).exists()
+
+
+def test_openai_rejects_more_than_sixteen_reference_images(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    spec = source_generate.load_spec(
+        make_spec(
+            tmp_path,
+            model="openai:gpt-image-2",
+            reference_images=write_refs(tmp_path, 17),
+        )
+    )
+
+    with pytest.raises(source_generate.SourceGenerateError, match="at most 16"):
+        source_generate._generate_openai(spec, Path(spec["source_path"]), "gpt-image-2")
 
 
 def test_generate_source_does_not_write_report_when_validation_fails(

--- a/tests/tools/test_asset_source_generate.py
+++ b/tests/tools/test_asset_source_generate.py
@@ -72,6 +72,33 @@ def test_generate_source_writes_prompt_source_and_report(tmp_path, monkeypatch):
     assert report["source_path"] == result["source_path"]
 
 
+def test_generate_source_supports_openai_selector(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    spec = source_generate.load_spec(
+        make_spec(
+            tmp_path,
+            model="openai:gpt-image-2",
+            report_path=".godotmaker/asset-generation/reports/coin_source.json",
+        )
+    )
+
+    def fake_openai(spec_data, output, model_name):
+        assert model_name == "gpt-image-2"
+        assert spec_data["aspect_ratio"] == "1:1"
+        write_png(output)
+
+    monkeypatch.setattr(source_generate, "_generate_openai", fake_openai)
+
+    result = source_generate.generate_source(spec)
+
+    assert result["ok"] is True
+    assert result["provider"] == "openai"
+    assert result["model"] == "gpt-image-2"
+    assert result["cost_cents"] == 5
+    assert (tmp_path / result["source_path"]).exists()
+    assert (tmp_path / result["report_path"]).exists()
+
+
 def test_generate_source_does_not_write_report_when_validation_fails(
     tmp_path,
     monkeypatch,

--- a/tests/tools/test_check_env.py
+++ b/tests/tools/test_check_env.py
@@ -362,7 +362,8 @@ class TestCheckFunctions:
             agent="opencode",
         )
 
-        assert any("native image provider is unsupported" in f for f in r.failed)
+        assert any("asset_image_model" in f for f in r.failed)
+        assert any("vqa_model" in f for f in r.failed)
 
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True)
     def test_claude_native_vqa_inspection_can_pass(self):

--- a/tests/tools/test_check_env.py
+++ b/tests/tools/test_check_env.py
@@ -238,18 +238,23 @@ class TestCheckFunctions:
         (tmp_path / ".opencode" / "skills").mkdir(parents=True)
         (tmp_path / ".opencode" / "agents").mkdir()
         (tmp_path / ".opencode" / "references").mkdir()
+        (tmp_path / ".opencode" / "plugins").mkdir()
         (
             tmp_path / ".opencode" / "references" / "runtime-mapping.md"
         ).write_text("")
         (
             tmp_path / ".opencode" / "godotmaker.yaml"
         ).write_text("godot_path: /opt/godot\n")
+        (
+            tmp_path / ".opencode" / "plugins" / "godotmaker-hooks.js"
+        ).write_text("export const GodotMakerHooks = async () => ({})\n")
         mock_run.return_value = MagicMock(returncode=0, stdout="godot\n", stderr="")
 
         r = EnvCheck()
         check_opencode(r, tmp_path)
 
         assert any("OpenCode CLI found" in p for p in r.passed)
+        assert any(".opencode/plugins/godotmaker-hooks.js present" in p for p in r.passed)
         assert any("OpenCode MCP server 'godot' configured" in p for p in r.passed)
         assert len(r.failed) == 0
 

--- a/tests/tools/test_check_env.py
+++ b/tests/tools/test_check_env.py
@@ -190,6 +190,16 @@ class TestCheckFunctions:
         check_selected_agent(r, tmp_path)
         mock_codex.assert_called_once_with(r, tmp_path)
 
+    @patch("check_env.check_opencode")
+    @patch("check_env.detect_agent", return_value="opencode")
+    def test_check_selected_agent_uses_opencode(
+        self, mock_detect, mock_opencode, tmp_path
+    ):
+        from check_env import check_selected_agent
+        r = EnvCheck()
+        check_selected_agent(r, tmp_path)
+        mock_opencode.assert_called_once_with(r, tmp_path)
+
     @patch("check_env.check_claude")
     @patch("check_env.detect_agent", return_value="claude-code")
     def test_check_selected_agent_uses_claude(self, mock_detect, mock_claude, tmp_path):
@@ -216,6 +226,31 @@ class TestCheckFunctions:
 
         assert any("Codex CLI found" in p for p in r.passed)
         assert any("Codex MCP server 'godot' configured" in p for p in r.passed)
+        assert len(r.failed) == 0
+
+    @patch("check_env.get_version", return_value="1.17.7")
+    @patch("check_env.shutil.which", return_value="/usr/bin/opencode")
+    @patch("check_env.subprocess.run")
+    def test_check_opencode_validates_runtime_files_and_mcp(
+        self, mock_run, mock_which, mock_ver, tmp_path: Path
+    ):
+        from check_env import check_opencode
+        (tmp_path / ".opencode" / "skills").mkdir(parents=True)
+        (tmp_path / ".opencode" / "agents").mkdir()
+        (tmp_path / ".opencode" / "references").mkdir()
+        (
+            tmp_path / ".opencode" / "references" / "runtime-mapping.md"
+        ).write_text("")
+        (
+            tmp_path / ".opencode" / "godotmaker.yaml"
+        ).write_text("godot_path: /opt/godot\n")
+        mock_run.return_value = MagicMock(returncode=0, stdout="godot\n", stderr="")
+
+        r = EnvCheck()
+        check_opencode(r, tmp_path)
+
+        assert any("OpenCode CLI found" in p for p in r.passed)
+        assert any("OpenCode MCP server 'godot' configured" in p for p in r.passed)
         assert len(r.failed) == 0
 
     @patch.dict(os.environ, {"GOOGLE_API_KEY": "AIzaSyTestKey12345678"}, clear=False)
@@ -312,6 +347,22 @@ class TestCheckFunctions:
 
         assert not r.failed
         assert any("native image generation for Claude Code" in w for w in r.warnings)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_opencode_native_image_generation_fails_until_supported(self):
+        from check_env import check_api_keys
+
+        r = EnvCheck()
+        check_api_keys(
+            r,
+            {
+                "asset_image_model": "native",
+                "vqa_model": "native",
+            },
+            agent="opencode",
+        )
+
+        assert any("native image provider is unsupported" in f for f in r.failed)
 
     @patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}, clear=True)
     def test_claude_native_vqa_inspection_can_pass(self):

--- a/tests/tools/test_check_project.py
+++ b/tests/tools/test_check_project.py
@@ -47,9 +47,24 @@ def _seed_scaffolded_project(project_dir: str):
             '"res://addons/godot_e2e/plugin.cfg"'
             ')\n'
         )
-    # Required addon dirs
-    for addon in ("gecs", "gdUnit4", "godot_e2e"):
-        os.makedirs(os.path.join(project_dir, "addons", addon), exist_ok=True)
+    # Required addon dirs with minimal addon-only shape.
+    required_files = {
+        "gecs": ("plugin.cfg",),
+        "gdUnit4": (
+            "plugin.cfg",
+            os.path.join("bin", "GdUnitCmdTool.gd"),
+            os.path.join("src", "core", "runners", "GdUnitTestCIRunner.gd"),
+        ),
+        "godot_e2e": ("plugin.cfg", "automation_server.gd"),
+    }
+    for addon, files in required_files.items():
+        addon_dir = os.path.join(project_dir, "addons", addon)
+        os.makedirs(addon_dir, exist_ok=True)
+        for rel_path in files:
+            path = os.path.join(addon_dir, rel_path)
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                f.write("# fixture\n")
     # e2e/conftest.py with GodotE2E import
     e2e_dir = os.path.join(project_dir, "e2e")
     os.makedirs(e2e_dir, exist_ok=True)
@@ -106,6 +121,7 @@ class TestBuildCheck:
         assert "[application] section" in stdout
         for addon in ("gecs", "gdUnit4", "godot_e2e"):
             assert f"addons/{addon}/ present" in stdout
+            assert f"addons/{addon}/plugin.cfg present" in stdout
         assert "godot-e2e plugin enabled" in stdout
         assert "AutomationServer autoload registered" in stdout
         assert "e2e/conftest.py imports GodotE2E" in stdout
@@ -128,6 +144,70 @@ class TestBuildCheck:
         stdout, code = run_check(project_dir, "--build")
         assert code == 1
         assert "addons/gecs/ missing" in stdout
+
+    def test_addon_without_plugin_cfg_fails(self, project_dir):
+        _seed_scaffolded_project(project_dir)
+        _write_godot_config(project_dir, _write_fake_godot(project_dir))
+        os.remove(os.path.join(project_dir, "addons", "gecs", "plugin.cfg"))
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 1
+        assert "addons/gecs/plugin.cfg missing" in stdout
+
+    @pytest.mark.parametrize("addon", ("gecs", "gdUnit4", "godot_e2e"))
+    def test_full_repo_addon_with_nested_project_godot_fails(self, project_dir, addon):
+        _seed_scaffolded_project(project_dir)
+        _write_godot_config(project_dir, _write_fake_godot(project_dir))
+        with open(
+            os.path.join(project_dir, "addons", addon, "project.godot"),
+            "w",
+            encoding="utf-8",
+        ) as f:
+            f.write("[application]\nconfig/name=\"Nested\"\n")
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 1
+        assert f"addons/{addon}/ contains nested project.godot" in stdout
+
+    def test_gdunit_without_cmd_tool_fails(self, project_dir):
+        _seed_scaffolded_project(project_dir)
+        _write_godot_config(project_dir, _write_fake_godot(project_dir))
+        os.remove(
+            os.path.join(
+                project_dir,
+                "addons",
+                "gdUnit4",
+                "bin",
+                "GdUnitCmdTool.gd",
+            )
+        )
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 1
+        assert "addons/gdUnit4/bin/GdUnitCmdTool.gd missing" in stdout
+
+    def test_gdunit_without_cmd_runner_fails(self, project_dir):
+        _seed_scaffolded_project(project_dir)
+        _write_godot_config(project_dir, _write_fake_godot(project_dir))
+        os.remove(
+            os.path.join(
+                project_dir,
+                "addons",
+                "gdUnit4",
+                "src",
+                "core",
+                "runners",
+                "GdUnitTestCIRunner.gd",
+            )
+        )
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 1
+        assert "addons/gdUnit4/src/core/runners/GdUnitTestCIRunner.gd missing" in stdout
 
     def test_godot_e2e_plugin_not_enabled_fails(self, project_dir):
         _seed_scaffolded_project(project_dir)

--- a/tests/tools/test_check_project.py
+++ b/tests/tools/test_check_project.py
@@ -81,15 +81,32 @@ def _seed_scaffolded_project(project_dir: str):
     )
 
 
-def _write_fake_godot(project_dir: str, *, name: str = "fake-godot") -> str:
+def _write_fake_godot(
+    project_dir: str,
+    *,
+    name: str = "fake-godot",
+    output: str = "",
+    returncode: int = 0,
+) -> str:
     if os.name == "nt":
         path = os.path.join(project_dir, f"{name}.cmd")
         with open(path, "w", encoding="utf-8") as f:
-            f.write("@echo off\nexit /B 0\n")
+            lines = ["@echo off"]
+            if output:
+                for line in output.splitlines():
+                    lines.append(f"echo {line}")
+            lines.append(f"exit /B {returncode}")
+            f.write("\n".join(lines) + "\n")
     else:
         path = os.path.join(project_dir, name)
         with open(path, "w", encoding="utf-8") as f:
-            f.write("#!/bin/sh\nexit 0\n")
+            lines = ["#!/bin/sh"]
+            if output:
+                for line in output.splitlines():
+                    escaped = line.replace("'", "'\"'\"'")
+                    lines.append(f"printf '%s\\n' '{escaped}'")
+            lines.append(f"exit {returncode}")
+            f.write("\n".join(lines) + "\n")
         os.chmod(path, 0o755)
     return path
 
@@ -303,6 +320,62 @@ class TestBuildCheck:
         assert code == 1
         assert "godot executable not found" in stdout
         assert ".agents" in stdout
+
+    def test_headless_shutdown_note_does_not_block_headless_parse(self, project_dir):
+        _seed_scaffolded_project(project_dir)
+        fake_godot = _write_fake_godot(
+            project_dir,
+            output="ERROR: 7 resources still in use at exit (run with --verbose for details).",
+        )
+        _write_godot_config(project_dir, fake_godot)
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 0, stdout
+        assert "no blocking diagnostics" in stdout
+        assert "shutdown notes" in stdout
+
+    def test_headless_script_error_is_blocking(self, project_dir):
+        _seed_scaffolded_project(project_dir)
+        fake_godot = _write_fake_godot(
+            project_dir,
+            output="SCRIPT ERROR: Parse Error: Identifier 'BirdController' not declared.",
+        )
+        _write_godot_config(project_dir, fake_godot)
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 1
+        assert "blocking diagnostic" in stdout
+        assert "BirdController" in stdout
+
+    def test_headless_unknown_error_is_blocking_even_with_zero_exit(self, project_dir):
+        _seed_scaffolded_project(project_dir)
+        fake_godot = _write_fake_godot(
+            project_dir,
+            output="ERROR: Provider emitted an uncategorized runtime diagnostic.",
+        )
+        _write_godot_config(project_dir, fake_godot)
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 1
+        assert "blocking diagnostic" in stdout
+        assert "uncategorized runtime diagnostic" in stdout
+
+    def test_headless_shader_error_is_blocking_even_with_zero_exit(self, project_dir):
+        _seed_scaffolded_project(project_dir)
+        fake_godot = _write_fake_godot(
+            project_dir,
+            output="SHADER ERROR: Invalid shader code.",
+        )
+        _write_godot_config(project_dir, fake_godot)
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 1
+        assert "blocking diagnostic" in stdout
+        assert "Invalid shader code" in stdout
 
 
 class TestEcsCheck:

--- a/tests/tools/test_check_project.py
+++ b/tests/tools/test_check_project.py
@@ -335,6 +335,25 @@ class TestBuildCheck:
         assert "no blocking diagnostics" in stdout
         assert "shutdown notes" in stdout
 
+    def test_headless_display_and_objectdb_noise_does_not_block_headless_parse(
+        self, project_dir
+    ):
+        _seed_scaffolded_project(project_dir)
+        fake_godot = _write_fake_godot(
+            project_dir,
+            output=(
+                "ERROR: Screen index 0 is invalid.\n"
+                "ERROR: ObjectDB instances leaked at exit (run with --verbose for details)."
+            ),
+        )
+        _write_godot_config(project_dir, fake_godot)
+
+        stdout, code = run_check(project_dir, "--build")
+
+        assert code == 0, stdout
+        assert "no blocking diagnostics" in stdout
+        assert "shutdown notes" in stdout
+
     def test_headless_script_error_is_blocking(self, project_dir):
         _seed_scaffolded_project(project_dir)
         fake_godot = _write_fake_godot(

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -30,6 +30,7 @@ from publish import (
     publish_agents,
     publish_skills,
     register_codex_mcp,
+    register_opencode_mcp,
     register_godot_permissions,
     rmtree_force,
     _verify_godot_path,
@@ -187,6 +188,8 @@ def _publish_opencode_project(tmp_path, monkeypatch, before_publish=None):
         lambda *_args, **_kwargs: (True, "FRESH", None, SemVer(0, 3, 5)),
     )
     monkeypatch.setattr(publish, "register_codex_mcp",
+                        lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(publish, "register_opencode_mcp",
                         lambda *_args, **_kwargs: True)
     monkeypatch.setattr(publish, "register_mcp",
                         lambda *_args, **_kwargs: None)
@@ -510,6 +513,41 @@ class TestRegisterCodexMcp:
             "npx", "@coding-solo/godot-mcp",
         ]
         assert calls[1][1]["cwd"] == str(tmp_path)
+
+
+class TestRegisterOpenCodeMcp:
+    def test_fails_when_opencode_missing(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(publish.shutil, "which", lambda name: None)
+        assert register_opencode_mcp(tmp_path, "/usr/bin/godot") is False
+        out = capsys.readouterr().out
+        assert "OpenCode CLI not found" in out
+        assert "opencode mcp add godot" in out
+
+    def test_invokes_opencode_mcp_add(self, tmp_path, monkeypatch):
+        calls = []
+
+        def _which(name):
+            if name in ("opencode", "npx"):
+                return name
+            return None
+
+        def _run(cmd, **kwargs):
+            calls.append((cmd, kwargs))
+            return subprocess.CompletedProcess(args=cmd, returncode=0)
+
+        monkeypatch.setattr(publish.shutil, "which", _which)
+        monkeypatch.setattr(publish.subprocess, "run", _run)
+        monkeypatch.setattr(publish.sys, "platform", "linux")
+
+        assert register_opencode_mcp(tmp_path, "/usr/bin/godot") is True
+
+        assert calls == [
+            ([
+                "opencode", "mcp", "add", "godot",
+                "--env", "GODOT_PATH=/usr/bin/godot", "--",
+                "npx", "@coding-solo/godot-mcp",
+            ], {"cwd": str(tmp_path), "timeout": 60})
+        ]
 
 
 class TestCreateProjectConfig:
@@ -1357,7 +1395,8 @@ class TestPublishMainAgentBranches:
             "publish_directory",
             "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas", "create_project_dirs",
-            "register_mcp", "register_codex_mcp", "register_godot_permissions", "ensure_gitignore",
+            "register_mcp", "register_codex_mcp", "register_opencode_mcp",
+            "register_godot_permissions", "ensure_gitignore",
             "ensure_gitattributes",
             "ensure_worktreeinclude", "ensure_git_repo", "write_target_version",
             "deploy_agent_hook_config",
@@ -1441,7 +1480,8 @@ class TestPublishMainAgentBranches:
             "publish_directory",
             "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas", "create_project_dirs",
-            "register_mcp", "register_codex_mcp", "register_godot_permissions", "ensure_gitignore",
+            "register_mcp", "register_codex_mcp", "register_opencode_mcp",
+            "register_godot_permissions", "ensure_gitignore",
             "ensure_gitattributes",
             "ensure_worktreeinclude", "ensure_git_repo", "write_target_version",
             "deploy_agent_hook_config",
@@ -1459,7 +1499,7 @@ class TestPublishMainAgentBranches:
         assert "register_godot_permissions" in calls
         assert "ensure_worktreeinclude" in calls
 
-    def test_opencode_publish_skips_claude_and_codex_specific_integrations(
+    def test_opencode_publish_registers_opencode_mcp_and_skips_other_integrations(
         self, tmp_path, monkeypatch
     ):
         from _version import SemVer
@@ -1471,7 +1511,7 @@ class TestPublishMainAgentBranches:
         def _record(name):
             def _inner(*_args, **_kwargs):
                 calls.append(name)
-                if name == "create_godotmaker_yaml":
+                if name in ("create_godotmaker_yaml", "register_opencode_mcp"):
                     return True
                 return None
             return _inner
@@ -1486,7 +1526,8 @@ class TestPublishMainAgentBranches:
             "publish_directory", "deploy_agent_instructions",
             "create_godotmaker_yaml", "create_project_config",
             "deploy_stage_schemas", "create_project_dirs", "register_mcp",
-            "register_codex_mcp", "register_godot_permissions",
+            "register_codex_mcp", "register_opencode_mcp",
+            "register_godot_permissions",
             "ensure_gitignore", "ensure_gitattributes",
             "ensure_worktreeinclude", "ensure_git_repo", "write_target_version",
             "deploy_agent_hook_config", "baseline_applied",
@@ -1505,6 +1546,7 @@ class TestPublishMainAgentBranches:
         assert "deploy_agent_hook_config" not in calls
         assert "register_mcp" not in calls
         assert "register_codex_mcp" not in calls
+        assert "register_opencode_mcp" in calls
         assert "register_godot_permissions" not in calls
         assert "ensure_worktreeinclude" not in calls
 
@@ -1544,7 +1586,8 @@ class TestPublishMainForceRmtree:
             "publish_directory",
             "deploy_agent_hook_config", "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas",
-            "create_project_dirs", "register_mcp", "register_codex_mcp", "register_godot_permissions",
+            "create_project_dirs", "register_mcp", "register_codex_mcp",
+            "register_opencode_mcp", "register_godot_permissions",
             "ensure_gitignore", "ensure_gitattributes",
             "ensure_worktreeinclude", "ensure_git_repo", "write_target_version",
         ):

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -639,6 +639,22 @@ class TestCreateProjectConfig:
         )
         assert agent_runtime.read_godot_path(tmp_path) == "/opt/opencode-godot"
 
+    def test_agent_runtime_cli_reads_config_from_project_subdir(
+        self, tmp_path, capsys
+    ):
+        create_project_config(tmp_path, publish.AGENT_OPENCODE)
+        (tmp_path / "project.godot").write_text("[application]\n", encoding="utf-8")
+        (tmp_path / ".opencode").mkdir()
+        (tmp_path / ".opencode" / "godotmaker.yaml").write_text(
+            "godot_path: /opt/opencode-godot\n", encoding="utf-8"
+        )
+        subdir = tmp_path / "src" / "systems"
+        subdir.mkdir(parents=True)
+        capsys.readouterr()
+
+        assert agent_runtime.main(["godot_path", "--project", str(subdir)]) == 0
+        assert capsys.readouterr().out.strip() == "/opt/opencode-godot"
+
     def test_default_config_template_is_valid_yaml(self):
         assert DEFAULT_CONFIG_TEMPLATE.exists(), "config.yaml.default template must exist"
         content = DEFAULT_CONFIG_TEMPLATE.read_text(encoding="utf-8")
@@ -1453,6 +1469,19 @@ class TestOpenCodePublishParity:
         assert "OpenCode" in content
         assert ".opencode/references/runtime-mapping.md" in content
         assert "CLAUDE.md" not in content
+
+    def test_opencode_runtime_test_skills_use_project_config_reader(
+        self, tmp_path, monkeypatch
+    ):
+        target = _publish_opencode_project(tmp_path, monkeypatch)
+
+        for skill_name in ("headless-build", "gdunit-driver"):
+            content = (
+                target / ".opencode" / "skills" / skill_name / "SKILL.md"
+            ).read_text(encoding="utf-8")
+            assert "python tools/agent_runtime.py godot_path" in content
+            assert "CLAUDE_SKILL_DIR" not in content
+            assert ".claude/godotmaker.yaml" not in content
 
     def test_opencode_publish_deploys_hook_adapter_plugin(
         self, tmp_path, monkeypatch

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -1376,6 +1376,7 @@ class TestOpenCodePublishParity:
         assert "check_file_permissions.py" in content
         assert "stage_reminder.py" in content
         assert "on_subagent_stop.py" in content
+        assert "runStopHook" in content
 
     def test_publish_agent_plugins_noops_for_non_plugin_runtimes(self, tmp_path):
         repo = Path(__file__).resolve().parents[2]

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -970,7 +970,10 @@ class TestPublishAgents:
         content = (target / "reviewer.md").read_text(encoding="utf-8")
         frontmatter = _parse_simple_frontmatter(content)
         assert frontmatter["mode"] == "subagent"
-        assert frontmatter["permission"] == {"edit": "deny"}
+        assert frontmatter["permission"] == {
+            "external_directory": "allow",
+            "edit": "deny",
+        }
         assert "model: inherit" not in content
         assert ".opencode/skills/*/checklist.md" in content
         assert ".claude/skills" not in content
@@ -992,7 +995,10 @@ class TestPublishAgents:
         content = (target / "verifier.md").read_text(encoding="utf-8")
         frontmatter = _parse_simple_frontmatter(content)
         assert frontmatter["mode"] == "subagent"
-        assert frontmatter["permission"] == {"edit": "deny"}
+        assert frontmatter["permission"] == {
+            "external_directory": "allow",
+            "edit": "deny",
+        }
         assert ".opencode/skills/*/checklist.md" in content
         assert ".claude/skills" not in content
 
@@ -1418,10 +1424,21 @@ class TestOpenCodePublishParity:
         assert reviewer_frontmatter["mode"] == "subagent"
         assert verifier_frontmatter["mode"] == "subagent"
         assert auditor_frontmatter["mode"] == "subagent"
-        assert "permission" not in worker_frontmatter
-        assert reviewer_frontmatter["permission"] == {"edit": "deny"}
-        assert verifier_frontmatter["permission"] == {"edit": "deny"}
-        assert auditor_frontmatter["permission"] == {"edit": "deny"}
+        assert worker_frontmatter["permission"] == {
+            "external_directory": "allow",
+        }
+        assert reviewer_frontmatter["permission"] == {
+            "external_directory": "allow",
+            "edit": "deny",
+        }
+        assert verifier_frontmatter["permission"] == {
+            "external_directory": "allow",
+            "edit": "deny",
+        }
+        assert auditor_frontmatter["permission"] == {
+            "external_directory": "allow",
+            "edit": "deny",
+        }
         assert "model" not in worker_frontmatter
         assert "model" not in reviewer_frontmatter
         assert "model: inherit" not in worker

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -50,6 +50,34 @@ PRIMARY_ROLE_SKILLS = [
     "gm-finalize",
 ]
 
+def _parse_simple_frontmatter(content: str) -> dict:
+    lines = content.splitlines()
+    assert lines and lines[0] == "---"
+    end = lines.index("---", 1)
+    result: dict[str, object] = {}
+    i = 1
+    while i < end:
+        line = lines[i]
+        if not line.strip() or line.startswith((" ", "\t")):
+            i += 1
+            continue
+        key, raw_value = line.split(":", 1)
+        key = key.strip()
+        value = raw_value.strip()
+        if value:
+            result[key] = value
+            i += 1
+            continue
+        nested: dict[str, str] = {}
+        i += 1
+        while i < end and lines[i].startswith("  "):
+            child_key, child_value = lines[i].strip().split(":", 1)
+            nested[child_key.strip()] = child_value.strip()
+            i += 1
+        result[key] = nested
+    return result
+
+
 CODEX_RUNTIME_TEXT_SUFFIXES = {
     ".md",
     ".yaml",
@@ -940,8 +968,31 @@ class TestPublishAgents:
         assert publish_agents(repo, target, publish.AGENT_OPENCODE) == 1
 
         content = (target / "reviewer.md").read_text(encoding="utf-8")
-        assert "mode: subagent" in content
+        frontmatter = _parse_simple_frontmatter(content)
+        assert frontmatter["mode"] == "subagent"
+        assert frontmatter["permission"] == {"edit": "deny"}
         assert "model: inherit" not in content
+        assert ".opencode/skills/*/checklist.md" in content
+        assert ".claude/skills" not in content
+
+    def test_opencode_agent_without_frontmatter_keeps_readonly_permission(
+        self, tmp_path
+    ):
+        repo = tmp_path / "repo"
+        agents = repo / "agents"
+        agents.mkdir(parents=True)
+        (agents / "verifier.md").write_text(
+            "Read `.claude/skills/*/checklist.md`.\n",
+            encoding="utf-8",
+        )
+
+        target = tmp_path / "target" / ".opencode" / "agents"
+        assert publish_agents(repo, target, publish.AGENT_OPENCODE) == 1
+
+        content = (target / "verifier.md").read_text(encoding="utf-8")
+        frontmatter = _parse_simple_frontmatter(content)
+        assert frontmatter["mode"] == "subagent"
+        assert frontmatter["permission"] == {"edit": "deny"}
         assert ".opencode/skills/*/checklist.md" in content
         assert ".claude/skills" not in content
 
@@ -964,6 +1015,11 @@ class TestPublishAgents:
         content = (target / "worker.md").read_text(encoding="utf-8")
         assert "mode: subagent" not in content
         assert ".claude/godotmaker.yaml" in content
+
+        claude_target = tmp_path / "target" / ".claude" / "agents"
+        assert publish_agents(repo, claude_target, publish.AGENT_CLAUDE_CODE) == 1
+        claude_content = (claude_target / "worker.md").read_text(encoding="utf-8")
+        assert claude_content == content
 
 
 class TestDeployAgentInstructions:
@@ -1347,9 +1403,27 @@ class TestOpenCodePublishParity:
         reviewer = (target / ".opencode" / "agents" / "reviewer.md").read_text(
             encoding="utf-8"
         )
+        verifier = (target / ".opencode" / "agents" / "verifier.md").read_text(
+            encoding="utf-8"
+        )
+        gdd_auditor = (
+            target / ".opencode" / "agents" / "gdd-auditor.md"
+        ).read_text(encoding="utf-8")
 
-        assert "mode: subagent" in worker
-        assert "mode: subagent" in reviewer
+        worker_frontmatter = _parse_simple_frontmatter(worker)
+        reviewer_frontmatter = _parse_simple_frontmatter(reviewer)
+        verifier_frontmatter = _parse_simple_frontmatter(verifier)
+        auditor_frontmatter = _parse_simple_frontmatter(gdd_auditor)
+        assert worker_frontmatter["mode"] == "subagent"
+        assert reviewer_frontmatter["mode"] == "subagent"
+        assert verifier_frontmatter["mode"] == "subagent"
+        assert auditor_frontmatter["mode"] == "subagent"
+        assert "permission" not in worker_frontmatter
+        assert reviewer_frontmatter["permission"] == {"edit": "deny"}
+        assert verifier_frontmatter["permission"] == {"edit": "deny"}
+        assert auditor_frontmatter["permission"] == {"edit": "deny"}
+        assert "model" not in worker_frontmatter
+        assert "model" not in reviewer_frontmatter
         assert "model: inherit" not in worker
         assert "model: inherit" not in reviewer
         assert ".opencode/skills/*/checklist.md" in reviewer
@@ -1375,8 +1449,9 @@ class TestOpenCodePublishParity:
         assert '"tool.execute.after"' in content
         assert "check_file_permissions.py" in content
         assert "stage_reminder.py" in content
-        assert "on_subagent_stop.py" in content
-        assert "runStopHook" in content
+        assert "log_agent_tool.py" in content
+        assert "on_subagent_stop.py" not in content
+        assert "log_subagent.py" not in content
 
     def test_publish_agent_plugins_noops_for_non_plugin_runtimes(self, tmp_path):
         repo = Path(__file__).resolve().parents[2]

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -941,6 +941,7 @@ class TestPublishAgents:
 
         content = (target / "reviewer.md").read_text(encoding="utf-8")
         assert "mode: subagent" in content
+        assert "model: inherit" not in content
         assert ".opencode/skills/*/checklist.md" in content
         assert ".claude/skills" not in content
 
@@ -1349,6 +1350,8 @@ class TestOpenCodePublishParity:
 
         assert "mode: subagent" in worker
         assert "mode: subagent" in reviewer
+        assert "model: inherit" not in worker
+        assert "model: inherit" not in reviewer
         assert ".opencode/skills/*/checklist.md" in reviewer
         assert ".claude/skills/*/checklist.md" not in reviewer
 

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -27,6 +27,7 @@ from publish import (
     ensure_gitattributes,
     ensure_gitignore,
     ensure_worktreeinclude,
+    publish_agents,
     publish_skills,
     register_codex_mcp,
     register_godot_permissions,
@@ -158,6 +159,49 @@ def _publish_claude_project(tmp_path, monkeypatch, before_publish=None):
     monkeypatch.setattr(sys, "argv",
                         [
                             "publish.py",
+                            "--force",
+                            "--no-config-review",
+                            str(target),
+                        ])
+
+    publish.main()
+    return target
+
+
+def _publish_opencode_project(tmp_path, monkeypatch, before_publish=None):
+    from _version import SemVer
+
+    target = tmp_path / "target"
+    config_dir = target / ".opencode"
+    config_dir.mkdir(parents=True)
+    (config_dir / "godotmaker.yaml").write_text(
+        'godot_path: "/test/godot"\n',
+        encoding="utf-8",
+    )
+    if before_publish is not None:
+        before_publish(target)
+
+    monkeypatch.setattr(
+        publish,
+        "check_version_upgrade",
+        lambda *_args, **_kwargs: (True, "FRESH", None, SemVer(0, 3, 5)),
+    )
+    monkeypatch.setattr(publish, "register_codex_mcp",
+                        lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(publish, "register_mcp",
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(publish, "register_godot_permissions",
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(publish, "ensure_git_repo",
+                        lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(publish, "baseline_applied",
+                        lambda *_args, **_kwargs: 0)
+    monkeypatch.setattr(publish, "run_migrations",
+                        lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(sys, "argv",
+                        [
+                            "publish.py",
+                            "--agent", "opencode",
                             "--force",
                             "--no-config-review",
                             str(target),
@@ -509,6 +553,25 @@ class TestCreateProjectConfig:
         )
         assert agent_runtime.read_godot_path(tmp_path) == "/opt/godot"
 
+    def test_published_opencode_agent_selects_opencode_runtime_config(self, tmp_path):
+        create_project_config(tmp_path, publish.AGENT_OPENCODE)
+        (tmp_path / ".opencode").mkdir()
+        (tmp_path / ".opencode" / "godotmaker.yaml").write_text(
+            "godot_path: /opt/opencode-godot\n", encoding="utf-8"
+        )
+
+        assert agent_runtime.detect_agent(tmp_path) == publish.AGENT_OPENCODE
+        assert agent_runtime.godotmaker_yaml(tmp_path) == (
+            tmp_path / ".opencode" / "godotmaker.yaml"
+        )
+        assert agent_runtime.agent_skill_root(tmp_path) == (
+            tmp_path / ".opencode" / "skills"
+        )
+        assert agent_runtime.agent_runtime_mapping(tmp_path) == (
+            tmp_path / ".opencode" / "references" / "runtime-mapping.md"
+        )
+        assert agent_runtime.read_godot_path(tmp_path) == "/opt/opencode-godot"
+
     def test_default_config_template_is_valid_yaml(self):
         assert DEFAULT_CONFIG_TEMPLATE.exists(), "config.yaml.default template must exist"
         content = DEFAULT_CONFIG_TEMPLATE.read_text(encoding="utf-8")
@@ -819,6 +882,50 @@ class TestPublishSkills:
         assert (target / "gecs" / "SKILL.md").read_text() == "# updated\n"
 
 
+class TestPublishAgents:
+    def test_opencode_agent_render_adds_subagent_mode_and_paths(self, tmp_path):
+        repo = tmp_path / "repo"
+        agents = repo / "agents"
+        agents.mkdir(parents=True)
+        (agents / "reviewer.md").write_text(
+            "---\n"
+            "name: reviewer\n"
+            "description: Reviews code\n"
+            "model: inherit\n"
+            "---\n\n"
+            "Glob `.claude/skills/*/checklist.md`.\n",
+            encoding="utf-8",
+        )
+
+        target = tmp_path / "target" / ".opencode" / "agents"
+        assert publish_agents(repo, target, publish.AGENT_OPENCODE) == 1
+
+        content = (target / "reviewer.md").read_text(encoding="utf-8")
+        assert "mode: subagent" in content
+        assert ".opencode/skills/*/checklist.md" in content
+        assert ".claude/skills" not in content
+
+    def test_non_opencode_agent_render_preserves_source(self, tmp_path):
+        repo = tmp_path / "repo"
+        agents = repo / "agents"
+        agents.mkdir(parents=True)
+        (agents / "worker.md").write_text(
+            "---\n"
+            "name: worker\n"
+            "description: Implements tasks\n"
+            "---\n\n"
+            "Read `.claude/godotmaker.yaml`.\n",
+            encoding="utf-8",
+        )
+
+        target = tmp_path / "target" / ".agents" / "agents"
+        assert publish_agents(repo, target, publish.AGENT_CODEX) == 1
+
+        content = (target / "worker.md").read_text(encoding="utf-8")
+        assert "mode: subagent" not in content
+        assert ".claude/godotmaker.yaml" in content
+
+
 class TestDeployAgentInstructions:
     def _make_repo(self, tmp_path):
         repo = tmp_path / "repo"
@@ -835,6 +942,13 @@ class TestDeployAgentInstructions:
         (codex_templates / "agents-bootstrap.md").write_text(
             "Before executing any `$gm-*` skill, apply the GodotMaker Codex "
             "runtime mapping at `.agents/references/runtime-mapping.md`.\n\n",
+            encoding="utf-8",
+        )
+        opencode_templates = repo / "agent-runtimes" / "opencode" / "templates"
+        opencode_templates.mkdir(parents=True)
+        (opencode_templates / "agents-bootstrap.md").write_text(
+            "Before executing any GodotMaker stage skill in OpenCode, apply "
+            "the runtime mapping at `.opencode/references/runtime-mapping.md`.\n\n",
             encoding="utf-8",
         )
         return repo
@@ -869,6 +983,17 @@ class TestDeployAgentInstructions:
         assert ".agents/references/runtime-mapping.md" in content
         assert "$gm-" in content
         assert "`/gm-*`" in content
+
+    def test_opencode_derives_agents_md_from_claude_template(self, tmp_path):
+        repo = self._make_repo(tmp_path)
+        target = tmp_path / "target"
+        target.mkdir()
+        deploy_agent_instructions(repo, target, publish.AGENT_OPENCODE)
+        content = (target / "AGENTS.md").read_text(encoding="utf-8")
+        assert content.startswith("# AGENTS.md")
+        assert "OpenCode" in content
+        assert ".opencode/references/runtime-mapping.md" in content
+        assert not (target / "CLAUDE.md").exists()
 
     def test_claude_instructions_do_not_include_codex_bootstrap(self):
         content = render_agent_instructions(
@@ -1135,6 +1260,78 @@ class TestCodexPublishParity:
         assert "PreToolUse" not in deployed["hooks"]
 
 
+class TestOpenCodePublishParity:
+    def test_opencode_publish_outputs_required_runtime_contract(
+        self, tmp_path, monkeypatch
+    ):
+        target = _publish_opencode_project(tmp_path, monkeypatch)
+
+        for skill_name in PRIMARY_ROLE_SKILLS:
+            assert (
+                target / ".opencode" / "skills" / skill_name / "SKILL.md"
+            ).exists(), f"missing OpenCode skill: {skill_name}"
+
+        assert (target / ".opencode" / "agents" / "worker.md").exists()
+        assert (target / ".opencode" / "references" / "runtime-mapping.md").exists()
+        assert (target / ".opencode" / "templates" / "ROADMAP.md").exists()
+        assert (target / ".opencode" / "config" / "config.yaml.default").exists()
+        assert (target / ".opencode" / "godotmaker.yaml").exists()
+        assert (target / "AGENTS.md").exists()
+        assert not (target / "CLAUDE.md").exists()
+        assert not (target / ".codex" / "hooks.json").exists()
+        assert not (target / ".agents" / "skills").exists()
+
+    def test_published_opencode_mapping_uses_opencode_paths(
+        self, tmp_path, monkeypatch
+    ):
+        target = _publish_opencode_project(tmp_path, monkeypatch)
+        mapping = (
+            target / ".opencode" / "references" / "runtime-mapping.md"
+        ).read_text(encoding="utf-8")
+
+        assert "`/gm-*`" in mapping
+        assert ".opencode/skills" in mapping
+        assert ".opencode/agents" in mapping
+        assert ".opencode/templates" in mapping
+        assert ".opencode/godotmaker.yaml" in mapping
+        assert ".codex" not in mapping
+
+    def test_published_opencode_agents_are_native_subagents(
+        self, tmp_path, monkeypatch
+    ):
+        target = _publish_opencode_project(tmp_path, monkeypatch)
+
+        worker = (target / ".opencode" / "agents" / "worker.md").read_text(
+            encoding="utf-8"
+        )
+        reviewer = (target / ".opencode" / "agents" / "reviewer.md").read_text(
+            encoding="utf-8"
+        )
+
+        assert "mode: subagent" in worker
+        assert "mode: subagent" in reviewer
+        assert ".opencode/skills/*/checklist.md" in reviewer
+        assert ".claude/skills/*/checklist.md" not in reviewer
+
+    def test_opencode_agents_md_indexes_runtime_mapping(self, tmp_path, monkeypatch):
+        target = _publish_opencode_project(tmp_path, monkeypatch)
+        content = (target / "AGENTS.md").read_text(encoding="utf-8")
+
+        assert "OpenCode" in content
+        assert ".opencode/references/runtime-mapping.md" in content
+        assert "CLAUDE.md" not in content
+
+    def test_opencode_publish_updates_project_config_agent(
+        self, tmp_path, monkeypatch
+    ):
+        target = _publish_opencode_project(tmp_path, monkeypatch)
+        config = (target / ".godotmaker" / "config.yaml").read_text(
+            encoding="utf-8"
+        )
+
+        assert "agent: opencode" in config
+
+
 class TestPublishMainAgentBranches:
     def test_codex_publish_registers_mcp_by_default(
         self, tmp_path, monkeypatch
@@ -1156,7 +1353,8 @@ class TestPublishMainAgentBranches:
         monkeypatch.setattr(publish, "check_version_upgrade",
                             lambda *_args, **_kwargs: (True, "FRESH", None, SemVer(0, 3, 5)))
         for name in (
-            "publish_skills", "publish_shared_refs", "publish_directory",
+            "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_directory",
             "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas", "create_project_dirs",
             "register_mcp", "register_codex_mcp", "register_godot_permissions", "ensure_gitignore",
@@ -1197,7 +1395,8 @@ class TestPublishMainAgentBranches:
             lambda *_args, **_kwargs: (True, "FRESH", None, SemVer(0, 3, 5)),
         )
         for name in (
-            "publish_skills", "publish_shared_refs", "publish_directory",
+            "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_directory",
             "deploy_agent_instructions",
             "create_project_config", "deploy_stage_schemas", "create_project_dirs",
             "register_mcp", "register_godot_permissions", "ensure_gitignore",
@@ -1238,7 +1437,8 @@ class TestPublishMainAgentBranches:
         monkeypatch.setattr(publish, "check_version_upgrade",
                             lambda *_args, **_kwargs: (True, "FRESH", None, SemVer(0, 3, 5)))
         for name in (
-            "publish_skills", "publish_shared_refs", "publish_directory",
+            "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_directory",
             "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas", "create_project_dirs",
             "register_mcp", "register_codex_mcp", "register_godot_permissions", "ensure_gitignore",
@@ -1258,6 +1458,55 @@ class TestPublishMainAgentBranches:
         assert "register_codex_mcp" not in calls
         assert "register_godot_permissions" in calls
         assert "ensure_worktreeinclude" in calls
+
+    def test_opencode_publish_skips_claude_and_codex_specific_integrations(
+        self, tmp_path, monkeypatch
+    ):
+        from _version import SemVer
+
+        target = tmp_path / "target"
+        target.mkdir()
+        calls: list[str] = []
+
+        def _record(name):
+            def _inner(*_args, **_kwargs):
+                calls.append(name)
+                if name == "create_godotmaker_yaml":
+                    return True
+                return None
+            return _inner
+
+        monkeypatch.setattr(
+            publish,
+            "check_version_upgrade",
+            lambda *_args, **_kwargs: (True, "FRESH", None, SemVer(0, 3, 5)),
+        )
+        for name in (
+            "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_directory", "deploy_agent_instructions",
+            "create_godotmaker_yaml", "create_project_config",
+            "deploy_stage_schemas", "create_project_dirs", "register_mcp",
+            "register_codex_mcp", "register_godot_permissions",
+            "ensure_gitignore", "ensure_gitattributes",
+            "ensure_worktreeinclude", "ensure_git_repo", "write_target_version",
+            "deploy_agent_hook_config", "baseline_applied",
+        ):
+            monkeypatch.setattr(publish, name, _record(name))
+        monkeypatch.setattr(publish, "read_godot_path", lambda *_args, **_kwargs: "godot")
+        monkeypatch.setattr(
+            sys, "argv",
+            ["publish.py", "--agent", "opencode", "--force", str(target)],
+        )
+
+        publish.main()
+
+        assert "publish_agents" in calls
+        assert "deploy_agent_instructions" in calls
+        assert "deploy_agent_hook_config" not in calls
+        assert "register_mcp" not in calls
+        assert "register_codex_mcp" not in calls
+        assert "register_godot_permissions" not in calls
+        assert "ensure_worktreeinclude" not in calls
 
 
 class TestPublishMainForceRmtree:
@@ -1291,7 +1540,8 @@ class TestPublishMainForceRmtree:
             return None
 
         for name in (
-            "publish_skills", "publish_shared_refs", "publish_directory",
+            "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_directory",
             "deploy_agent_hook_config", "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas",
             "create_project_dirs", "register_mcp", "register_codex_mcp", "register_godot_permissions",

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -28,6 +28,7 @@ from publish import (
     ensure_gitignore,
     ensure_worktreeinclude,
     publish_agents,
+    publish_agent_plugins,
     publish_skills,
     register_codex_mcp,
     register_opencode_mcp,
@@ -1359,6 +1360,42 @@ class TestOpenCodePublishParity:
         assert ".opencode/references/runtime-mapping.md" in content
         assert "CLAUDE.md" not in content
 
+    def test_opencode_publish_deploys_hook_adapter_plugin(
+        self, tmp_path, monkeypatch
+    ):
+        target = _publish_opencode_project(tmp_path, monkeypatch)
+        plugin = target / ".opencode" / "plugins" / "godotmaker-hooks.js"
+        content = plugin.read_text(encoding="utf-8")
+
+        assert plugin.exists()
+        assert '"tool.execute.before"' in content
+        assert '"tool.execute.after"' in content
+        assert "check_file_permissions.py" in content
+        assert "stage_reminder.py" in content
+        assert "on_subagent_stop.py" in content
+
+    def test_publish_agent_plugins_noops_for_non_plugin_runtimes(self, tmp_path):
+        repo = Path(__file__).resolve().parents[2]
+        target = tmp_path / "target"
+
+        assert publish_agent_plugins(repo, target, publish.AGENT_CLAUDE_CODE) == 0
+        assert publish_agent_plugins(repo, target, publish.AGENT_CODEX) == 0
+        assert not (target / ".claude" / "plugins").exists()
+        assert not (target / ".agents" / "plugins").exists()
+
+    def test_publish_agent_plugins_preserves_existing_without_force(self, tmp_path):
+        repo = Path(__file__).resolve().parents[2]
+        target = tmp_path / "target"
+        plugin = target / ".opencode" / "plugins" / "godotmaker-hooks.js"
+        plugin.parent.mkdir(parents=True)
+        plugin.write_text("custom\n", encoding="utf-8")
+
+        assert publish_agent_plugins(repo, target, publish.AGENT_OPENCODE) == 0
+        assert plugin.read_text(encoding="utf-8") == "custom\n"
+
+        assert publish_agent_plugins(repo, target, publish.AGENT_OPENCODE, force=True) == 1
+        assert "GodotMakerHooks" in plugin.read_text(encoding="utf-8")
+
     def test_opencode_publish_updates_project_config_agent(
         self, tmp_path, monkeypatch
     ):
@@ -1392,6 +1429,7 @@ class TestPublishMainAgentBranches:
                             lambda *_args, **_kwargs: (True, "FRESH", None, SemVer(0, 3, 5)))
         for name in (
             "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_agent_plugins",
             "publish_directory",
             "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas", "create_project_dirs",
@@ -1435,6 +1473,7 @@ class TestPublishMainAgentBranches:
         )
         for name in (
             "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_agent_plugins",
             "publish_directory",
             "deploy_agent_instructions",
             "create_project_config", "deploy_stage_schemas", "create_project_dirs",
@@ -1477,6 +1516,7 @@ class TestPublishMainAgentBranches:
                             lambda *_args, **_kwargs: (True, "FRESH", None, SemVer(0, 3, 5)))
         for name in (
             "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_agent_plugins",
             "publish_directory",
             "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas", "create_project_dirs",
@@ -1523,6 +1563,7 @@ class TestPublishMainAgentBranches:
         )
         for name in (
             "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_agent_plugins",
             "publish_directory", "deploy_agent_instructions",
             "create_godotmaker_yaml", "create_project_config",
             "deploy_stage_schemas", "create_project_dirs", "register_mcp",
@@ -1542,6 +1583,7 @@ class TestPublishMainAgentBranches:
         publish.main()
 
         assert "publish_agents" in calls
+        assert "publish_agent_plugins" in calls
         assert "deploy_agent_instructions" in calls
         assert "deploy_agent_hook_config" not in calls
         assert "register_mcp" not in calls
@@ -1583,6 +1625,7 @@ class TestPublishMainForceRmtree:
 
         for name in (
             "publish_skills", "publish_shared_refs", "publish_agents",
+            "publish_agent_plugins",
             "publish_directory",
             "deploy_agent_hook_config", "deploy_agent_instructions", "create_godotmaker_yaml",
             "create_project_config", "deploy_stage_schemas",

--- a/tests/tools/test_publish_shared.py
+++ b/tests/tools/test_publish_shared.py
@@ -13,6 +13,7 @@ sys.path.insert(0, os.path.join(
 from publish import (
     AGENT_CLAUDE_CODE,
     AGENT_CODEX,
+    AGENT_OPENCODE,
     render_agent_instructions,
     publish_skills,
     publish_shared_refs,
@@ -92,7 +93,11 @@ def _root_instruction_indexes(
     """
     if agent is not None:
         content = render_agent_instructions(REPO_ROOT, agent) or ""
-        runtime_root = ".agents" if agent == AGENT_CODEX else ".claude"
+        runtime_root = {
+            AGENT_CLAUDE_CODE: ".claude",
+            AGENT_CODEX: ".agents",
+            AGENT_OPENCODE: ".opencode",
+        }[agent]
         return (
             f"{runtime_root}/skills/{skill_name}/references/{filename}"
             in content
@@ -101,6 +106,7 @@ def _root_instruction_indexes(
     deployed_paths = [
         f".claude/skills/{skill_name}/references/{filename}",
         f".agents/skills/{skill_name}/references/{filename}",
+        f".opencode/skills/{skill_name}/references/{filename}",
     ]
     for template_path in ROOT_INSTRUCTION_TEMPLATES:
         if not template_path.exists():

--- a/tests/tools/test_run_verify.py
+++ b/tests/tools/test_run_verify.py
@@ -100,6 +100,37 @@ def test_check_build_ignores_headless_shutdown_diagnostics():
     assert note is None
 
 
+def test_check_build_ignores_headless_display_and_objectdb_noise():
+    output = (
+        "ERROR: Screen index 0 is invalid.\n"
+        "ERROR: ObjectDB instances leaked at exit (run with --verbose for details).\n"
+    )
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stdout=output, returncode=0)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result == {"result": "pass", "errors": []}
+    assert note is None
+
+
+def test_check_build_engine_cpp_location_remains_blocking_without_file_pointer():
+    output = (
+        "ERROR: Cannot open file 'res://bad_scene.tscn'.\n"
+        "   at: load (scene/resources/resource_format_text.cpp:123)\n"
+    )
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stderr=output, returncode=0)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result["result"] == "fail"
+    assert result["errors"] == [{
+        "file": "",
+        "line": 0,
+        "message": "Cannot open file 'res://bad_scene.tscn'.",
+    }]
+    assert note is None
+
+
 def test_check_build_shutdown_note_plus_real_error_fails():
     output = (
         "ERROR: 7 resources still in use at exit (run with --verbose for details).\n"
@@ -566,6 +597,21 @@ def test_check_static_timeout_is_error():
     assert result["result"] == "error"
     assert result["issues"] == []
     assert note["tool"] == "check_project"
+
+
+def test_check_static_nonzero_without_fail_output_is_error():
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(
+            stderr="Traceback (most recent call last):\nImportError: broken\n",
+            returncode=2,
+        )
+        result, note = run_verify.check_static(Path("/x"))
+
+    assert result == {"result": "error", "issues": []}
+    assert note["tool"] == "check_project"
+    assert note["suggested_fallback"] == "escalate"
+    assert "exited with code 2" in note["error"]
+    assert "ImportError: broken" in note["error"]
 
 
 # ---------- godot_path resolution ----------

--- a/tests/tools/test_run_verify.py
+++ b/tests/tools/test_run_verify.py
@@ -90,6 +90,115 @@ def test_check_build_fail_with_errors_and_locations():
     assert note is None
 
 
+def test_check_build_ignores_headless_shutdown_diagnostics():
+    output = "ERROR: 7 resources still in use at exit (run with --verbose for details).\n"
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stdout=output, returncode=0)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result == {"result": "pass", "errors": []}
+    assert note is None
+
+
+def test_check_build_shutdown_note_plus_real_error_fails():
+    output = (
+        "ERROR: 7 resources still in use at exit (run with --verbose for details).\n"
+        "ERROR: Failed loading resource: res://scenes/main.tscn.\n"
+    )
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stdout=output, returncode=0)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result["result"] == "fail"
+    assert result["errors"] == [{
+        "file": "",
+        "line": 0,
+        "message": "Failed loading resource: res://scenes/main.tscn.",
+    }]
+    assert note is None
+
+
+def test_check_build_shutdown_note_plus_nonzero_exit_fails():
+    output = "ERROR: 7 resources still in use at exit (run with --verbose for details).\n"
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stdout=output, returncode=1)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result["result"] == "fail"
+    assert result["errors"] == [{
+        "file": "",
+        "line": 0,
+        "message": "godot exited 1 without a recognized blocking diagnostic",
+    }]
+    assert note is None
+
+
+def test_check_build_script_error_still_fails():
+    output = (
+        "SCRIPT ERROR: Parse Error: Identifier 'BirdController' not declared.\n"
+        "   at: GDScript::reload (src/bird.gd:12)\n"
+    )
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stderr=output, returncode=0)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result["result"] == "fail"
+    assert result["errors"] == [{
+        "file": "src/bird.gd",
+        "line": 12,
+        "message": "Parse Error: Identifier 'BirdController' not declared.",
+    }]
+    assert note is None
+
+
+def test_check_build_unknown_error_with_zero_exit_fails():
+    output = "ERROR: Provider emitted an uncategorized runtime diagnostic.\n"
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stderr=output, returncode=0)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result["result"] == "fail"
+    assert result["errors"] == [{
+        "file": "",
+        "line": 0,
+        "message": "Provider emitted an uncategorized runtime diagnostic.",
+    }]
+    assert note is None
+
+
+def test_check_build_shader_error_with_zero_exit_fails():
+    output = (
+        "SHADER ERROR: Invalid shader code.\n"
+        "   at: GDScript::reload (res://shaders/card.gdshader:3)\n"
+    )
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stderr=output, returncode=0)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result["result"] == "fail"
+    assert result["errors"] == [{
+        "file": "res://shaders/card.gdshader",
+        "line": 3,
+        "message": "Invalid shader code.",
+    }]
+    assert note is None
+
+
+def test_check_build_unknown_error_with_nonzero_exit_fails():
+    output = "ERROR: Provider emitted an uncategorized runtime diagnostic.\n"
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stderr=output, returncode=1)
+        result, note = run_verify.check_build("/usr/bin/godot", Path("/x"))
+
+    assert result["result"] == "fail"
+    assert result["errors"] == [{
+        "file": "",
+        "line": 0,
+        "message": "Provider emitted an uncategorized runtime diagnostic.",
+    }]
+    assert note is None
+
+
 def test_check_build_locations_are_scoped_to_each_error():
     """A GDScript location after ERROR_B must not be attributed to ERROR_A."""
     output = (
@@ -548,6 +657,29 @@ def test_build_report_all_pass_is_schema_valid(project_dir: Path):
     assert report["result"] == "pass"
     assert report["tooling_notes"] == []
     assert report["checks"]["lint"]["format_drift"] is None
+    assert validate_report(report) == []
+
+
+def test_build_report_shutdown_note_keeps_overall_pass(project_dir: Path):
+    base_fake = _fake_run_factory()
+
+    def fake_run(cmd, *args, **kwargs):
+        cmd_str = " ".join(str(c) for c in cmd)
+        if "GdUnitCmdTool" not in cmd_str and "check_project.py" not in cmd_str:
+            return _make_proc(
+                stdout=(
+                    "ERROR: 7 resources still in use at exit "
+                    "(run with --verbose for details).\n"
+                ),
+                returncode=0,
+            )
+        return base_fake(cmd, *args, **kwargs)
+
+    with patch.object(run_verify.subprocess, "run", side_effect=fake_run):
+        report = run_verify.build_report(project_dir)
+
+    assert report["result"] == "pass"
+    assert report["checks"]["build"] == {"result": "pass", "errors": []}
     assert validate_report(report) == []
 
 

--- a/tools/agent_runtime.py
+++ b/tools/agent_runtime.py
@@ -1,7 +1,9 @@
 """Agent runtime helpers for project-local GodotMaker tools."""
 from __future__ import annotations
 
+import argparse
 from pathlib import Path
+import sys
 
 
 AGENT_CLAUDE_CODE = "claude-code"
@@ -78,9 +80,73 @@ def godotmaker_yaml(project_dir: Path, agent: str | None = None) -> Path:
     return agent_config_root(project_dir, agent) / "godotmaker.yaml"
 
 
-def read_godot_path(project_dir: Path, default: str | None = None) -> str | None:
-    value = _read_yaml_scalar(godotmaker_yaml(project_dir), "godot_path")
+def find_project_dir(start: Path | None = None) -> Path:
+    """Find the nearest Godot project root at or above `start`."""
+    current = (start or Path.cwd()).resolve()
+    if current.is_file():
+        current = current.parent
+
+    for candidate in (current, *current.parents):
+        if (candidate / "project.godot").exists():
+            return candidate
+    return current
+
+
+def read_config_value(
+    project_dir: Path,
+    key: str,
+    *,
+    agent: str | None = None,
+    default: str | None = None,
+) -> str | None:
+    value = _read_yaml_scalar(godotmaker_yaml(project_dir, agent), key)
     return value if value else default
+
+
+def read_godot_path(project_dir: Path, default: str | None = None) -> str | None:
+    return read_config_value(project_dir, "godot_path", default=default)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Read a value from the selected GodotMaker agent config."
+    )
+    parser.add_argument("key", help="Config key to read, for example godot_path")
+    parser.add_argument(
+        "--project",
+        default=".",
+        help="Project directory or a path inside the project (default: cwd)",
+    )
+    parser.add_argument(
+        "--agent",
+        choices=[AGENT_CLAUDE_CODE, AGENT_CODEX, AGENT_OPENCODE],
+        default=None,
+        help="Override selected agent runtime",
+    )
+    parser.add_argument(
+        "--default",
+        default=None,
+        help="Value to print when the key is absent",
+    )
+    args = parser.parse_args(argv)
+
+    project_dir = find_project_dir(Path(args.project))
+    value = read_config_value(
+        project_dir,
+        args.key,
+        agent=args.agent,
+        default=args.default,
+    )
+    if value:
+        print(value)
+        return 0
+
+    config_path = godotmaker_yaml(project_dir, args.agent)
+    print(
+        f"Error: key '{args.key}' not found in {config_path}",
+        file=sys.stderr,
+    )
+    return 1
 
 
 def prefer_console_godot_path(godot_path: str | None) -> str | None:
@@ -106,3 +172,7 @@ def prefer_console_godot_path(godot_path: str | None) -> str | None:
     except OSError:
         return godot_path
     return godot_path
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/agent_runtime.py
+++ b/tools/agent_runtime.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 AGENT_CLAUDE_CODE = "claude-code"
 AGENT_CODEX = "codex"
+AGENT_OPENCODE = "opencode"
 
 
 def _read_yaml_scalar(path: Path, key: str) -> str | None:
@@ -28,6 +29,8 @@ def normalize_agent(value: str | None) -> str | None:
     normalized = value.strip().lower().replace("_", "-")
     if normalized in {"codex", "openai-codex"}:
         return AGENT_CODEX
+    if normalized in {"opencode", "open-code"}:
+        return AGENT_OPENCODE
     if normalized in {"claude", "claude-code", "anthropic-claude-code"}:
         return AGENT_CLAUDE_CODE
     return None
@@ -44,6 +47,8 @@ def detect_agent(project_dir: Path) -> str:
     # Backward-compatible fallback for older projects without `agent`.
     if (project_dir / ".agents").exists():
         return AGENT_CODEX
+    if (project_dir / ".opencode").exists():
+        return AGENT_OPENCODE
     return AGENT_CLAUDE_CODE
 
 
@@ -51,6 +56,8 @@ def agent_config_root(project_dir: Path, agent: str | None = None) -> Path:
     selected = normalize_agent(agent) or detect_agent(project_dir)
     if selected == AGENT_CODEX:
         return project_dir / ".agents"
+    if selected == AGENT_OPENCODE:
+        return project_dir / ".opencode"
     return project_dir / ".claude"
 
 
@@ -62,6 +69,8 @@ def agent_runtime_mapping(project_dir: Path, agent: str | None = None) -> Path:
     selected = normalize_agent(agent) or detect_agent(project_dir)
     if selected == AGENT_CODEX:
         return project_dir / ".agents" / "references" / "runtime-mapping.md"
+    if selected == AGENT_OPENCODE:
+        return project_dir / ".opencode" / "references" / "runtime-mapping.md"
     return project_dir / ".claude" / "references" / "runtime-mapping.md"
 
 

--- a/tools/asset_source_generate.py
+++ b/tools/asset_source_generate.py
@@ -6,6 +6,7 @@ import base64
 import io
 import json
 import sys
+from contextlib import ExitStack
 from pathlib import Path
 
 from asset_image_finalize import ImageFinalizeError, finalize_image_asset
@@ -58,6 +59,7 @@ GROK_ASPECT_RATIOS = [
 ALL_SIZES = ["512", "1K", "2K", "4K"]
 ALL_ASPECT_RATIOS = sorted(set(GEMINI_ASPECT_RATIOS + GROK_ASPECT_RATIOS))
 OPENAI_MODEL = "gpt-image-2"
+OPENAI_MAX_REFERENCE_IMAGES = 16
 OPENAI_COSTS = {"1:1": 5, "portrait": 7, "landscape": 7}
 
 
@@ -227,17 +229,23 @@ def _save_openai_b64(response, output: Path):
 
 
 def _generate_openai(spec, output: Path, model_name: str):
+    if len(spec["reference_images"]) > OPENAI_MAX_REFERENCE_IMAGES:
+        raise SourceGenerateError(
+            f"OpenAI image editing supports at most {OPENAI_MAX_REFERENCE_IMAGES} reference images"
+        )
+
     from openai import OpenAI
 
     api_size, _ = _openai_size(spec["size"], spec["aspect_ratio"])
     client = OpenAI()
     try:
         if spec["reference_images"]:
-            ref_path = spec["reference_images"][0]
-            with ref_path.open("rb") as image_file:
+            with ExitStack() as stack:
+                image_files = [stack.enter_context(path.open("rb")) for path in spec["reference_images"]]
+                image = image_files[0] if len(image_files) == 1 else image_files
                 response = client.images.edit(
                     model=model_name,
-                    image=image_file,
+                    image=image,
                     prompt=spec["prompt"],
                     size=api_size,
                 )

--- a/tools/check_env.py
+++ b/tools/check_env.py
@@ -14,7 +14,13 @@ import subprocess
 import sys
 from pathlib import Path
 
-from agent_runtime import AGENT_CLAUDE_CODE, AGENT_CODEX, detect_agent, read_godot_path
+from agent_runtime import (
+    AGENT_CLAUDE_CODE,
+    AGENT_CODEX,
+    AGENT_OPENCODE,
+    detect_agent,
+    read_godot_path,
+)
 
 
 class EnvCheck:
@@ -41,7 +47,8 @@ def get_version(cmd: str, pattern: str = r"(\d+(?:\.\d+)+)") -> str | None:
     try:
         result = subprocess.run(
             [cmd, "--version"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=10,
         )
         output = result.stdout + result.stderr
         match = re.search(pattern, output)
@@ -186,7 +193,8 @@ def _get_version_from_path(path: str, pattern: str = r"(\d+(?:\.\d+)+)") -> str 
     try:
         result = subprocess.run(
             [path, "--version"],
-            capture_output=True, text=True, timeout=10,
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=10,
         )
         output = result.stdout + result.stderr
         match = re.search(pattern, output)
@@ -267,7 +275,8 @@ def check_codex(r: EnvCheck, project_dir: Path):
         result = subprocess.run(
             [cmd, "mcp", "list"],
             cwd=str(project_dir),
-            capture_output=True, text=True, timeout=15,
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=15,
         )
         output = (result.stdout or "") + (result.stderr or "")
         if result.returncode == 0 and "godot" in output:
@@ -280,6 +289,52 @@ def check_codex(r: EnvCheck, project_dir: Path):
         r.fail("Could not list Codex MCP servers")
 
 
+def check_opencode(r: EnvCheck, project_dir: Path):
+    print("\n--- OpenCode ---")
+    cmd = (
+        shutil.which("opencode")
+        or shutil.which("opencode.cmd")
+        or shutil.which("opencode.exe")
+    )
+    if not cmd:
+        r.fail("OpenCode CLI not found. Install OpenCode before using agent: opencode.")
+        return
+    version = get_version(cmd, pattern=r"(\d+(?:\.\d+)+)")
+    r.ok(f"OpenCode CLI found: {cmd}" + (f" ({version})" if version else ""))
+
+    mapping = project_dir / ".opencode" / "references" / "runtime-mapping.md"
+    skills = project_dir / ".opencode" / "skills"
+    agents = project_dir / ".opencode" / "agents"
+    config = project_dir / ".opencode" / "godotmaker.yaml"
+    for path, label in [
+        (skills, ".opencode/skills"),
+        (agents, ".opencode/agents"),
+        (mapping, ".opencode/references/runtime-mapping.md"),
+        (config, ".opencode/godotmaker.yaml"),
+    ]:
+        if path.exists():
+            r.ok(f"{label} present")
+        else:
+            r.fail(f"{label} missing; re-run publish with --agent opencode")
+
+    try:
+        result = subprocess.run(
+            [cmd, "mcp", "list"],
+            cwd=str(project_dir),
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=15,
+        )
+        output = (result.stdout or "") + (result.stderr or "")
+        if result.returncode == 0 and "godot" in output:
+            r.ok("OpenCode MCP server 'godot' configured")
+        elif result.returncode == 0:
+            r.fail("OpenCode MCP server 'godot' missing; re-run publish")
+        else:
+            r.fail("Could not list OpenCode MCP servers")
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        r.fail("Could not list OpenCode MCP servers")
+
+
 def check_selected_agent(r: EnvCheck, project_dir: Path):
     agent = detect_agent(project_dir)
     print(f"\n--- Selected Agent ({agent}) ---")
@@ -287,6 +342,8 @@ def check_selected_agent(r: EnvCheck, project_dir: Path):
         check_codex(r, project_dir)
     elif agent == AGENT_CLAUDE_CODE:
         check_claude(r)
+    elif agent == AGENT_OPENCODE:
+        check_opencode(r, project_dir)
     else:
         r.fail(f"Unsupported GodotMaker agent: {agent}")
 

--- a/tools/check_env.py
+++ b/tools/check_env.py
@@ -306,11 +306,13 @@ def check_opencode(r: EnvCheck, project_dir: Path):
     skills = project_dir / ".opencode" / "skills"
     agents = project_dir / ".opencode" / "agents"
     config = project_dir / ".opencode" / "godotmaker.yaml"
+    hook_adapter = project_dir / ".opencode" / "plugins" / "godotmaker-hooks.js"
     for path, label in [
         (skills, ".opencode/skills"),
         (agents, ".opencode/agents"),
         (mapping, ".opencode/references/runtime-mapping.md"),
         (config, ".opencode/godotmaker.yaml"),
+        (hook_adapter, ".opencode/plugins/godotmaker-hooks.js"),
     ]:
         if path.exists():
             r.ok(f"{label} present")

--- a/tools/check_env.py
+++ b/tools/check_env.py
@@ -356,6 +356,19 @@ def check_runtime_model_provider(
 ):
     print("\n--- Runtime Image Provider ---")
     if provider == "native":
+        if agent == AGENT_OPENCODE:
+            if capability == "image_generation":
+                r.fail(
+                    "native image generation is unsupported for OpenCode; "
+                    "set asset_image_model to codex, gemini:<model>, "
+                    "openai:<model>, or grok:<model>"
+                )
+            else:
+                r.fail(
+                    "native image inspection is unsupported for OpenCode; "
+                    "set vqa_model to codex, gemini:<model>, or openai:<model>"
+                )
+            return
         if capability == "image_inspection" and agent in {AGENT_CODEX, AGENT_CLAUDE_CODE}:
             r.ok("native image inspection uses the active agent runtime")
         elif capability == "image_generation" and agent == AGENT_CODEX:
@@ -402,8 +415,7 @@ def check_api_keys(
     if vqa_provider in {"native", "codex"}:
         required.discard("native")
         required.discard("codex")
-        if vqa_provider != image_provider:
-            check_runtime_model_provider(r, vqa_provider, agent, "image_inspection")
+        check_runtime_model_provider(r, vqa_provider, agent, "image_inspection")
 
     google_key = os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
     if "gemini" in required:

--- a/tools/check_project.py
+++ b/tools/check_project.py
@@ -68,7 +68,24 @@ def find_gd_files(project_dir: Path, pattern: str) -> list[Path]:
     return results
 
 
-SCAFFOLD_REQUIRED_ADDONS = ("gecs", "gdUnit4", "godot_e2e")
+SCAFFOLD_ADDON_CONTRACTS = {
+    "gecs": {
+        "path": "addons/gecs",
+        "required_files": ("plugin.cfg",),
+    },
+    "gdUnit4": {
+        "path": "addons/gdUnit4",
+        "required_files": (
+            "plugin.cfg",
+            "bin/GdUnitCmdTool.gd",
+            "src/core/runners/GdUnitTestCIRunner.gd",
+        ),
+    },
+    "godot_e2e": {
+        "path": "addons/godot_e2e",
+        "required_files": ("plugin.cfg", "automation_server.gd"),
+    },
+}
 
 
 def _run_headless_godot(godot_path: str, project_dir: Path
@@ -91,7 +108,7 @@ def check_build(project_dir: Path, result: CheckResult):
 
     Verifies (in order):
       1. project.godot exists with `[application]`.
-      2. addons/gecs, addons/gdUnit4, addons/godot_e2e directories.
+      2. addons/gecs, addons/gdUnit4, addons/godot_e2e addon shapes.
       3. godot-e2e plugin enabled in `[editor_plugins]`.
       4. AutomationServer autoload registered for godot-e2e.
       5. e2e/conftest.py imports GodotE2E.
@@ -114,13 +131,28 @@ def check_build(project_dir: Path, result: CheckResult):
     else:
         result.fail("project.godot missing [application] section")
 
-    # 2. Required addon directories
-    for addon in SCAFFOLD_REQUIRED_ADDONS:
-        addon_dir = project_dir / "addons" / addon
-        if addon_dir.exists():
-            result.ok(f"addons/{addon}/ present")
+    # 2. Required addon directories and addon-only shape
+    for addon, contract in SCAFFOLD_ADDON_CONTRACTS.items():
+        addon_path = contract["path"]
+        addon_dir = project_dir / addon_path
+        if addon_dir.is_dir():
+            result.ok(f"{addon_path}/ present")
         else:
-            result.fail(f"addons/{addon}/ missing")
+            result.fail(f"{addon_path}/ missing")
+            continue
+
+        if (addon_dir / "project.godot").exists():
+            result.fail(
+                f"{addon_path}/ contains nested project.godot; "
+                "install the addon subdirectory, not the full repository"
+            )
+
+        for rel_path in contract["required_files"]:
+            expected = addon_dir / rel_path
+            if expected.is_file():
+                result.ok(f"{addon_path}/{rel_path} present")
+            else:
+                result.fail(f"{addon_path}/{rel_path} missing")
 
     # 3. godot-e2e plugin enabled
     if "godot_e2e/plugin.cfg" in content or "godot-e2e/plugin.cfg" in content:

--- a/tools/check_project.py
+++ b/tools/check_project.py
@@ -26,6 +26,7 @@ from agent_runtime import (
     prefer_console_godot_path,
     read_godot_path,
 )
+from godot_output import classify_godot_headless_output
 
 PLACEHOLDER_KEYWORDS = ["placeholder", "todo", "stub", "not implemented"]
 
@@ -98,7 +99,8 @@ def _run_headless_godot(godot_path: str, project_dir: Path
     """
     proc = subprocess.run(
         [godot_path, "--headless", "--path", str(project_dir), "--quit"],
-        capture_output=True, text=True, timeout=60,
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", timeout=60,
     )
     return proc.returncode, (proc.stdout or "") + (proc.stderr or "")
 
@@ -113,7 +115,7 @@ def check_build(project_dir: Path, result: CheckResult):
       4. AutomationServer autoload registered for godot-e2e.
       5. e2e/conftest.py imports GodotE2E.
       6. .git/ resolves HEAD (worker worktree isolation requires it).
-      7. `<godot_path> --headless --quit` exits 0 with no ERROR lines.
+      7. `<godot_path> --headless --quit` exits 0 with no blocking diagnostics.
          Missing `godot_path` is a FAIL because this is a build gate.
     """
     print("\n--- Build Readiness ---")
@@ -220,16 +222,21 @@ def check_build(project_dir: Path, result: CheckResult):
     except subprocess.TimeoutExpired:
         result.fail("godot --headless --quit did not finish within 60s")
         return
-    error_lines = [ln for ln in output.splitlines()
-                   if "ERROR" in ln.upper() and "0 ERROR" not in ln.upper()]
-    if rc == 0 and not error_lines:
-        result.ok("godot --headless --quit produces no ERROR lines")
-    elif error_lines:
-        result.fail(f"godot --headless produced {len(error_lines)} ERROR "
-                    f"line(s); first: {error_lines[0][:120]}")
-    else:
-        result.fail(f"godot --headless --quit exited {rc} (no ERROR lines "
-                    "but non-zero return — check for crashes / segfaults)")
+    classified = classify_godot_headless_output(output, returncode=rc)
+    if not classified.blockers:
+        result.ok("godot --headless --quit produced no blocking diagnostics")
+        if classified.shutdown_notes:
+            result.warn(
+                "godot --headless emitted shutdown notes; first: "
+                f"{classified.shutdown_notes[0][:120]}"
+            )
+    elif classified.blockers:
+        first = classified.blockers[0]
+        result.fail(
+            "godot --headless produced "
+            f"{len(classified.blockers)} blocking diagnostic(s); "
+            f"first: {first.message[:120]}"
+        )
 
 
 def check_ecs(project_dir: Path, result: CheckResult):

--- a/tools/godot_output.py
+++ b/tools/godot_output.py
@@ -14,6 +14,12 @@ _GD_LOC = re.compile(r"\s+at:\s+[^()]+\((.+):(\d+)\)")
 _SHUTDOWN_NOTE_PATTERNS = (
     re.compile(r"\d+\s+resources?\s+still\s+in\s+use\s+at\s+exit", re.IGNORECASE),
     re.compile(r"Found\s+\d+\s+possible\s+orphan\s+nodes?\.?", re.IGNORECASE),
+    re.compile(r"ObjectDB\s+instances?\s+leaked\s+at\s+exit", re.IGNORECASE),
+    re.compile(r"Screen\s+index\s+\d+\s+is\s+invalid\.?", re.IGNORECASE),
+)
+
+_ENGINE_SOURCE_FILE = re.compile(
+    r"(?:^|[/\\])(?:core|drivers|editor|main|modules|platform|scene|servers)[/\\].+\.cpp$"
 )
 
 @dataclass(frozen=True)
@@ -38,6 +44,15 @@ def _is_shutdown_note(message: str) -> bool:
     return any(pattern.search(message) for pattern in _SHUTDOWN_NOTE_PATTERNS)
 
 
+def _diagnostic_location(loc_match: re.Match[str] | None) -> tuple[str, int]:
+    if not loc_match:
+        return "", 0
+    file = loc_match.group(1)
+    if _ENGINE_SOURCE_FILE.search(file.replace("\\", "/")):
+        return "", 0
+    return file, int(loc_match.group(2))
+
+
 def classify_godot_headless_output(
     output: str,
     *,
@@ -55,10 +70,11 @@ def classify_godot_headless_output(
             shutdown_notes.append(message)
             continue
 
+        file, line = _diagnostic_location(loc_match)
         blockers.append(GodotDiagnostic(
             message=message,
-            file=loc_match.group(1) if loc_match else "",
-            line=int(loc_match.group(2)) if loc_match else 0,
+            file=file,
+            line=line,
         ))
 
     if returncode != 0 and not blockers:

--- a/tools/godot_output.py
+++ b/tools/godot_output.py
@@ -1,0 +1,75 @@
+"""Classify Godot headless output for mechanical gates."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+
+
+_GODOT_DIAGNOSTIC_LINE = re.compile(
+    r"^\s*(?P<label>(?:[A-Z_ ]+)?ERROR):\s+(?P<message>.+)$",
+    re.MULTILINE,
+)
+_GD_LOC = re.compile(r"\s+at:\s+[^()]+\((.+):(\d+)\)")
+
+_SHUTDOWN_NOTE_PATTERNS = (
+    re.compile(r"\d+\s+resources?\s+still\s+in\s+use\s+at\s+exit", re.IGNORECASE),
+    re.compile(r"Found\s+\d+\s+possible\s+orphan\s+nodes?\.?", re.IGNORECASE),
+)
+
+@dataclass(frozen=True)
+class GodotDiagnostic:
+    message: str
+    file: str = ""
+    line: int = 0
+
+
+@dataclass(frozen=True)
+class GodotOutputClassification:
+    blockers: list[GodotDiagnostic]
+    shutdown_notes: list[str]
+
+
+def _next_error_offset(text: str, start: int) -> int:
+    match = _GODOT_DIAGNOSTIC_LINE.search(text, start)
+    return match.start() if match else len(text)
+
+
+def _is_shutdown_note(message: str) -> bool:
+    return any(pattern.search(message) for pattern in _SHUTDOWN_NOTE_PATTERNS)
+
+
+def classify_godot_headless_output(
+    output: str,
+    *,
+    returncode: int = 0,
+) -> GodotOutputClassification:
+    blockers: list[GodotDiagnostic] = []
+    shutdown_notes: list[str] = []
+
+    for match in _GODOT_DIAGNOSTIC_LINE.finditer(output):
+        message = match.group("message").strip()
+        bound = _next_error_offset(output, match.end())
+        loc_match = _GD_LOC.search(output, match.end(), bound)
+
+        if _is_shutdown_note(message):
+            shutdown_notes.append(message)
+            continue
+
+        blockers.append(GodotDiagnostic(
+            message=message,
+            file=loc_match.group(1) if loc_match else "",
+            line=int(loc_match.group(2)) if loc_match else 0,
+        ))
+
+    if returncode != 0 and not blockers:
+        blockers.append(GodotDiagnostic(
+            message=(
+                f"godot exited {returncode} without a recognized blocking "
+                "diagnostic"
+            ),
+        ))
+
+    return GodotOutputClassification(
+        blockers=blockers,
+        shutdown_notes=shutdown_notes,
+    )

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -89,6 +89,7 @@ class AgentPublishAdapter:
     agents_root: str
     config_root: str
     templates_root: str
+    plugins_root: str | None
     runtime_references_root: str | None
     root_instruction_filename: str
     register_claude_mcp: bool
@@ -110,6 +111,11 @@ class AgentPublishAdapter:
     def templates_dir(self, target: Path) -> Path:
         return target / self.templates_root
 
+    def plugins_dir(self, target: Path) -> Path | None:
+        if self.plugins_root is None:
+            return None
+        return target / self.plugins_root
+
     def runtime_references_dir(self, target: Path) -> Path | None:
         if self.runtime_references_root is None:
             return None
@@ -124,6 +130,7 @@ AGENT_ADAPTERS = {
         agents_root=".claude/agents",
         config_root=".claude/config",
         templates_root=".claude/templates",
+        plugins_root=None,
         runtime_references_root=None,
         root_instruction_filename="CLAUDE.md",
         register_claude_mcp=True,
@@ -137,6 +144,7 @@ AGENT_ADAPTERS = {
         agents_root=".agents/agents",
         config_root=".agents/config",
         templates_root=".agents/templates",
+        plugins_root=None,
         runtime_references_root=".agents/references",
         root_instruction_filename="AGENTS.md",
         register_claude_mcp=False,
@@ -150,6 +158,7 @@ AGENT_ADAPTERS = {
         agents_root=".opencode/agents",
         config_root=".opencode/config",
         templates_root=".opencode/templates",
+        plugins_root=".opencode/plugins",
         runtime_references_root=".opencode/references",
         root_instruction_filename="AGENTS.md",
         register_claude_mcp=False,
@@ -621,6 +630,33 @@ def publish_agents(repo_root: Path, agents_target: Path,
         count += 1
 
     print(f"Published agents/ ({count} files)")
+    return count
+
+
+def publish_agent_plugins(repo_root: Path, target: Path,
+                          agent: str = AGENT_CLAUDE_CODE,
+                          force: bool = False) -> int:
+    """Publish selected-runtime plugin adapters, when the runtime uses them."""
+    adapter = get_agent_adapter(agent)
+    plugins_target = adapter.plugins_dir(target)
+    if plugins_target is None:
+        return 0
+
+    source_root = AGENT_RUNTIME_SOURCE_ROOTS.get(agent)
+    if source_root is None:
+        return 0
+    plugins_src = repo_root / source_root / "plugins"
+    if not plugins_src.exists():
+        return 0
+
+    if plugins_target.exists() and not force:
+        relative = plugins_target.relative_to(target)
+        print(f"{relative} already exists, skipping (use --force to overwrite)")
+        return 0
+
+    copy_tree(plugins_src, plugins_target)
+    count = len([p for p in plugins_target.rglob("*") if p.is_file()])
+    print(f"Published {agent} plugins/ ({count} files)")
     return count
 
 
@@ -1274,6 +1310,10 @@ def main():
             if d.exists():
                 print(f"  Cleaning {d}")
                 rmtree_force(d)
+        plugins_dir = adapter.plugins_dir(target)
+        if plugins_dir is not None and plugins_dir.exists():
+            print(f"  Cleaning {plugins_dir}")
+            rmtree_force(plugins_dir)
         runtime_refs_dir = adapter.runtime_references_dir(target)
         if runtime_refs_dir is not None and runtime_refs_dir.exists():
             print(f"  Cleaning {runtime_refs_dir}")
@@ -1303,6 +1343,7 @@ def main():
     publish_shared_refs(repo_root, skills_target, agent)
     publish_runtime_references(repo_root, target, agent)
     publish_agents(repo_root, adapter.agents_dir(target), agent)
+    publish_agent_plugins(repo_root, target, agent, args.force)
     publish_directory(repo_root / "tools", target / "tools", "tools/")
     publish_directory(repo_root / "config", adapter.config_dir(target),
                       "config/", "*")

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -2,7 +2,8 @@
 """Publish GodotMaker skills into a target Godot project directory.
 
 Flattens skills/core/* and skills/reviewer/* into the selected agent-native
-skill location: .claude/skills/ for Claude Code or .agents/skills/ for Codex.
+skill location: .claude/skills/ for Claude Code, .agents/skills/ for Codex,
+or .opencode/skills/ for OpenCode.
 Also copies tools, config, hooks, templates, and sets up agent-specific files.
 
 Supports versioned upgrades: compares source VERSION against the
@@ -11,6 +12,7 @@ target's .godotmaker/version and prompts accordingly.
 Usage:
     python tools/publish.py <target_godot_project_dir>
     python tools/publish.py --agent codex <target_godot_project_dir>
+    python tools/publish.py --agent opencode <target_godot_project_dir>
     python tools/publish.py --force <target_godot_project_dir>
 """
 import argparse
@@ -25,7 +27,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import NamedTuple
 
-from agent_runtime import AGENT_CLAUDE_CODE, AGENT_CODEX
+from agent_runtime import AGENT_CLAUDE_CODE, AGENT_CODEX, AGENT_OPENCODE
 from project_config import (
     ProjectConfigResult,
     create_project_config as create_project_config_file,
@@ -47,19 +49,24 @@ class VersionCheckResult(NamedTuple):
     source_ver: SemVer | None
 
 EXCLUDE_DIRS = {"__pycache__", "doc_source", ".workspace"}
-AGENT_CHOICES = (AGENT_CLAUDE_CODE, AGENT_CODEX)
+AGENT_CHOICES = (AGENT_CLAUDE_CODE, AGENT_CODEX, AGENT_OPENCODE)
 AGENT_RUNTIME_SOURCE_ROOTS = {
     AGENT_CLAUDE_CODE: Path("agent-runtimes") / "claude-code",
     AGENT_CODEX: Path("agent-runtimes") / "codex",
+    AGENT_OPENCODE: Path("agent-runtimes") / "opencode",
 }
 AGENT_RUNTIME_REFERENCES = {
     AGENT_CODEX: (
         Path("references") / "runtime-mapping.md",
         Path("references") / "delegation-worktree.md",
     ),
+    AGENT_OPENCODE: (
+        Path("references") / "runtime-mapping.md",
+    ),
 }
 AGENT_ROOT_BOOTSTRAP_TEMPLATES = {
     AGENT_CODEX: Path("templates") / "agents-bootstrap.md",
+    AGENT_OPENCODE: Path("templates") / "agents-bootstrap.md",
 }
 AGENT_HOOK_CONFIGS = {
     AGENT_CLAUDE_CODE: (
@@ -131,6 +138,19 @@ AGENT_ADAPTERS = {
         config_root=".agents/config",
         templates_root=".agents/templates",
         runtime_references_root=".agents/references",
+        root_instruction_filename="AGENTS.md",
+        register_claude_mcp=False,
+        register_godot_permissions=False,
+        ensure_worktreeinclude=False,
+    ),
+    AGENT_OPENCODE: AgentPublishAdapter(
+        agent_id=AGENT_OPENCODE,
+        project_config_root=".opencode",
+        skill_root=".opencode/skills",
+        agents_root=".opencode/agents",
+        config_root=".opencode/config",
+        templates_root=".opencode/templates",
+        runtime_references_root=".opencode/references",
         root_instruction_filename="AGENTS.md",
         register_claude_mcp=False,
         register_godot_permissions=False,
@@ -534,6 +554,76 @@ def publish_directory(
     print(f"Published {label} ({count} files)")
 
 
+def _ensure_frontmatter_scalar(text: str, key: str, value: str) -> str:
+    """Set a simple top-level YAML frontmatter scalar."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return text
+
+    updated = False
+    for i in range(1, end):
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        current_key = stripped.split(":", 1)[0].strip()
+        if current_key == key:
+            lines[i] = f"{key}: {value}"
+            updated = True
+            break
+
+    if not updated:
+        lines.insert(end, f"{key}: {value}")
+
+    return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+
+
+def render_agent_role_text(text: str, agent: str) -> str:
+    """Render a shared GodotMaker role definition for a selected runtime."""
+    if agent != AGENT_OPENCODE:
+        return text
+
+    rendered = _ensure_frontmatter_scalar(text, "mode", "subagent")
+    replacements = {
+        ".claude/skills": ".opencode/skills",
+        ".claude/agents": ".opencode/agents",
+        ".claude/templates": ".opencode/templates",
+        ".claude/config": ".opencode/config",
+        ".claude/godotmaker.yaml": ".opencode/godotmaker.yaml",
+    }
+    for old, new in replacements.items():
+        rendered = rendered.replace(old, new)
+    return rendered
+
+
+def publish_agents(repo_root: Path, agents_target: Path,
+                   agent: str = AGENT_CLAUDE_CODE) -> int:
+    """Publish GodotMaker role definitions for the selected runtime."""
+    src = repo_root / "agents"
+    if not src.exists():
+        return 0
+
+    if agents_target.exists():
+        rmtree_force(agents_target)
+    agents_target.mkdir(parents=True, exist_ok=True)
+
+    count = 0
+    for file in sorted(src.glob("*.md")):
+        rendered = render_agent_role_text(file.read_text(encoding="utf-8"), agent)
+        (agents_target / file.name).write_text(rendered, encoding="utf-8")
+        count += 1
+
+    print(f"Published agents/ ({count} files)")
+    return count
+
+
 def deploy_agent_hook_config(repo_root: Path, target: Path, agent: str, force: bool):
     """Deploy selected-agent hook config."""
     spec = AGENT_HOOK_CONFIGS.get(agent)
@@ -577,8 +667,7 @@ def render_agent_instructions(repo_root: Path, agent: str) -> str | None:
         return None
     content = template.read_text(encoding="utf-8")
     rendered = render_root_instruction_text(content, adapter)
-    if adapter.agent_id == AGENT_CODEX:
-        rendered = _inject_agent_root_bootstrap(repo_root, rendered, adapter)
+    rendered = _inject_agent_root_bootstrap(repo_root, rendered, adapter)
     return rendered
 
 
@@ -1173,8 +1262,7 @@ def main():
     publish_skills(repo_root, skills_target, agent)
     publish_shared_refs(repo_root, skills_target, agent)
     publish_runtime_references(repo_root, target, agent)
-    publish_directory(repo_root / "agents", adapter.agents_dir(target),
-                      "agents/", "*.md")
+    publish_agents(repo_root, adapter.agents_dir(target), agent)
     publish_directory(repo_root / "tools", target / "tools", "tools/")
     publish_directory(repo_root / "config", adapter.config_dir(target),
                       "config/", "*")

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -602,6 +602,10 @@ def _frontmatter_without_key(lines: list[str], key: str) -> list[str]:
     return result
 
 
+OPENCODE_BASE_AGENT_PERMISSION: dict[str, object] = {
+    "external_directory": "allow",
+}
+
 OPENCODE_AGENT_PERMISSION_POLICIES: dict[str, dict[str, object]] = {
     # OpenCode uses one `edit` permission for write, edit, and apply_patch.
     # These reviewer-style agents must not mutate project files.
@@ -631,9 +635,11 @@ def render_opencode_agent_role_text(text: str, role_name: str) -> str:
     updated = _frontmatter_without_key(updated, "mode")
     updated = _frontmatter_without_key(updated, "permission")
     _append_yaml_value(updated, "mode", "subagent")
-    permission = OPENCODE_AGENT_PERMISSION_POLICIES.get(role_name)
-    if permission:
-        _append_yaml_value(updated, "permission", permission)
+    permission = {
+        **OPENCODE_BASE_AGENT_PERMISSION,
+        **OPENCODE_AGENT_PERMISSION_POLICIES.get(role_name, {}),
+    }
+    _append_yaml_value(updated, "permission", permission)
     rendered = "---\n" + "\n".join(updated) + "\n---\n" + body
 
     replacements = {

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -952,6 +952,46 @@ def register_codex_mcp(target: Path, godot_path: str) -> bool:
         return False
 
 
+def register_opencode_mcp(target: Path, godot_path: str) -> bool:
+    """Register godot-mcp for OpenCode via `opencode mcp`."""
+    opencode_cmd = (
+        shutil.which("opencode")
+        or shutil.which("opencode.cmd")
+        or shutil.which("opencode.exe")
+    )
+    if not opencode_cmd:
+        print("ERROR: OpenCode CLI not found. Cannot register godot-mcp.")
+        print("  Install OpenCode, then run manually:")
+        print(f'  opencode mcp add godot --env GODOT_PATH="{godot_path}" -- npx @coding-solo/godot-mcp')
+        return False
+
+    if not shutil.which("npx"):
+        print("ERROR: npx not found. Cannot register godot-mcp.")
+        print("  Install Node.js, then run manually:")
+        print(f'  opencode mcp add godot --env GODOT_PATH="{godot_path}" -- npx @coding-solo/godot-mcp')
+        return False
+
+    print("Registering godot-mcp MCP server for OpenCode...")
+    cmd = [opencode_cmd, "mcp", "add", "godot",
+           "--env", f"GODOT_PATH={godot_path}", "--"]
+
+    if sys.platform == "win32":
+        cmd.extend(["cmd", "/c", "npx", "@coding-solo/godot-mcp"])
+    else:
+        cmd.extend(["npx", "@coding-solo/godot-mcp"])
+
+    try:
+        result = subprocess.run(cmd, cwd=str(target), timeout=60)
+        if result.returncode == 0:
+            print("godot-mcp registered for OpenCode")
+            return True
+        print("ERROR: OpenCode godot-mcp registration failed.")
+        return False
+    except (subprocess.TimeoutExpired, OSError):
+        print("ERROR: OpenCode godot-mcp registration failed.")
+        return False
+
+
 def _escape_permission_rule_content(content: str) -> str:
     """Mirror claude-code's permissionRuleParser.ts `escapeRuleContent`.
 
@@ -1297,6 +1337,13 @@ def main():
                   "registration can run.")
             sys.exit(1)
         if not register_codex_mcp(target, godot_path):
+            sys.exit(1)
+    elif adapter.agent_id == AGENT_OPENCODE:
+        if not config_ready:
+            print("ERROR: OpenCode publish requires godotmaker.yaml before MCP "
+                  "registration can run.")
+            sys.exit(1)
+        if not register_opencode_mcp(target, godot_path):
             sys.exit(1)
     if adapter.register_godot_permissions:
         register_godot_permissions(config_dir / "settings.json", godot_path)

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -594,12 +594,42 @@ def _ensure_frontmatter_scalar(text: str, key: str, value: str) -> str:
     return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
 
 
+def _remove_frontmatter_scalar(text: str, key: str, value: str | None = None) -> str:
+    """Remove a simple top-level YAML frontmatter scalar."""
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return text
+
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return text
+
+    for i in range(1, end):
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith("#") or ":" not in stripped:
+            continue
+        current_key, current_value = stripped.split(":", 1)
+        if current_key.strip() != key:
+            continue
+        if value is not None and current_value.strip() != value:
+            continue
+        del lines[i]
+        return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+
+    return text
+
+
 def render_agent_role_text(text: str, agent: str) -> str:
     """Render a shared GodotMaker role definition for a selected runtime."""
     if agent != AGENT_OPENCODE:
         return text
 
-    rendered = _ensure_frontmatter_scalar(text, "mode", "subagent")
+    rendered = _remove_frontmatter_scalar(text, "model", "inherit")
+    rendered = _ensure_frontmatter_scalar(rendered, "mode", "subagent")
     replacements = {
         ".claude/skills": ".opencode/skills",
         ".claude/agents": ".opencode/agents",

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -563,11 +563,11 @@ def publish_directory(
     print(f"Published {label} ({count} files)")
 
 
-def _ensure_frontmatter_scalar(text: str, key: str, value: str) -> str:
-    """Set a simple top-level YAML frontmatter scalar."""
+def _split_frontmatter(text: str) -> tuple[list[str] | None, str]:
+    """Return YAML frontmatter lines and markdown body."""
     lines = text.splitlines()
     if not lines or lines[0].strip() != "---":
-        return text
+        return None, text
 
     end = None
     for i in range(1, len(lines)):
@@ -575,61 +575,67 @@ def _ensure_frontmatter_scalar(text: str, key: str, value: str) -> str:
             end = i
             break
     if end is None:
-        return text
+        return None, text
 
-    updated = False
-    for i in range(1, end):
-        stripped = lines[i].strip()
-        if not stripped or stripped.startswith("#") or ":" not in stripped:
-            continue
-        current_key = stripped.split(":", 1)[0].strip()
-        if current_key == key:
-            lines[i] = f"{key}: {value}"
-            updated = True
-            break
-
-    if not updated:
-        lines.insert(end, f"{key}: {value}")
-
-    return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
+    body = "\n".join(lines[end + 1:])
+    if text.endswith("\n"):
+        body += "\n"
+    return lines[1:end], body
 
 
-def _remove_frontmatter_scalar(text: str, key: str, value: str | None = None) -> str:
-    """Remove a simple top-level YAML frontmatter scalar."""
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
-        return text
-
-    end = None
-    for i in range(1, len(lines)):
-        if lines[i].strip() == "---":
-            end = i
-            break
-    if end is None:
-        return text
-
-    for i in range(1, end):
-        stripped = lines[i].strip()
-        if not stripped or stripped.startswith("#") or ":" not in stripped:
-            continue
-        current_key, current_value = stripped.split(":", 1)
-        if current_key.strip() != key:
-            continue
-        if value is not None and current_value.strip() != value:
-            continue
-        del lines[i]
-        return "\n".join(lines) + ("\n" if text.endswith("\n") else "")
-
-    return text
+def _frontmatter_without_key(lines: list[str], key: str) -> list[str]:
+    """Remove a top-level scalar or simple block key from frontmatter."""
+    result: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        if stripped and not line.startswith((" ", "\t")) and ":" in stripped:
+            current_key = stripped.split(":", 1)[0].strip()
+            if current_key == key:
+                i += 1
+                while i < len(lines) and lines[i].startswith((" ", "\t")):
+                    i += 1
+                continue
+        result.append(line)
+        i += 1
+    return result
 
 
-def render_agent_role_text(text: str, agent: str) -> str:
-    """Render a shared GodotMaker role definition for a selected runtime."""
-    if agent != AGENT_OPENCODE:
-        return text
+OPENCODE_AGENT_PERMISSION_POLICIES: dict[str, dict[str, object]] = {
+    # OpenCode uses one `edit` permission for write, edit, and apply_patch.
+    # These reviewer-style agents must not mutate project files.
+    "reviewer": {"edit": "deny"},
+    "verifier": {"edit": "deny"},
+    "gdd-auditor": {"edit": "deny"},
+}
 
-    rendered = _remove_frontmatter_scalar(text, "model", "inherit")
-    rendered = _ensure_frontmatter_scalar(rendered, "mode", "subagent")
+
+def _append_yaml_value(lines: list[str], key: str, value: object) -> None:
+    """Append a small YAML scalar or mapping value."""
+    if isinstance(value, dict):
+        lines.append(f"{key}:")
+        for child_key, child_value in value.items():
+            lines.append(f"  {child_key}: {child_value}")
+        return
+    lines.append(f"{key}: {value}")
+
+
+def render_opencode_agent_role_text(text: str, role_name: str) -> str:
+    """Render a shared role definition as an OpenCode native subagent."""
+    frontmatter, body = _split_frontmatter(text)
+    updated = list(frontmatter or [])
+    if frontmatter is None:
+        body = text
+    updated = _frontmatter_without_key(updated, "model")
+    updated = _frontmatter_without_key(updated, "mode")
+    updated = _frontmatter_without_key(updated, "permission")
+    _append_yaml_value(updated, "mode", "subagent")
+    permission = OPENCODE_AGENT_PERMISSION_POLICIES.get(role_name)
+    if permission:
+        _append_yaml_value(updated, "permission", permission)
+    rendered = "---\n" + "\n".join(updated) + "\n---\n" + body
+
     replacements = {
         ".claude/skills": ".opencode/skills",
         ".claude/agents": ".opencode/agents",
@@ -655,7 +661,11 @@ def publish_agents(repo_root: Path, agents_target: Path,
 
     count = 0
     for file in sorted(src.glob("*.md")):
-        rendered = render_agent_role_text(file.read_text(encoding="utf-8"), agent)
+        source = file.read_text(encoding="utf-8")
+        if agent == AGENT_OPENCODE:
+            rendered = render_opencode_agent_role_text(source, file.stem)
+        else:
+            rendered = source
         (agents_target / file.name).write_text(rendered, encoding="utf-8")
         count += 1
 

--- a/tools/run_verify.py
+++ b/tools/run_verify.py
@@ -44,6 +44,7 @@ from agent_runtime import (
     prefer_console_godot_path,
     read_godot_path,
 )
+from godot_output import classify_godot_headless_output
 
 
 # Same flags as gm-verify/SKILL.md Section 4. `--all` deliberately not
@@ -90,22 +91,14 @@ def _tooling_note(tool: str, crashed_on: str, error: str,
 # 1. Build
 # ---------------------------------------------------------------------------
 
-_BUILD_ERROR_LINE = re.compile(r"^\s*ERROR:\s+(.+)$", re.MULTILINE)
-_GD_LOC = re.compile(r"\s+at:\s+GDScript::\w+\s+\(([^:()]+):(\d+)\)")
-
-
-def _next_error_offset(text: str, start: int) -> int:
-    nxt = _BUILD_ERROR_LINE.search(text, start)
-    return nxt.start() if nxt else len(text)
-
-
 def check_build(godot_path: str, project_dir: Path
                 ) -> tuple[dict, dict | None]:
-    """Run `<godot_path> --headless --quit` and parse ERROR lines."""
+    """Run `<godot_path> --headless --quit` and parse blocking diagnostics."""
     try:
         proc = subprocess.run(
             [godot_path, "--headless", "--path", str(project_dir), "--quit"],
-            capture_output=True, text=True, timeout=BUILD_TIMEOUT,
+            capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=BUILD_TIMEOUT,
         )
     except subprocess.TimeoutExpired:
         return (
@@ -130,16 +123,14 @@ def check_build(godot_path: str, project_dir: Path
         )
 
     combined = (proc.stdout or "") + (proc.stderr or "")
-    errors: list[dict] = []
-    for m in _BUILD_ERROR_LINE.finditer(combined):
-        bound = _next_error_offset(combined, m.end())
-        loc_match = _GD_LOC.search(combined, m.end(), bound)
-        entry: dict = {
-            "file": loc_match.group(1) if loc_match else "",
-            "line": int(loc_match.group(2)) if loc_match else 0,
-            "message": m.group(1).strip(),
-        }
-        errors.append(entry)
+    classified = classify_godot_headless_output(
+        combined,
+        returncode=proc.returncode,
+    )
+    errors = [
+        {"file": item.file, "line": item.line, "message": item.message}
+        for item in classified.blockers
+    ]
 
     result = "fail" if errors else "pass"
     return ({"result": result, "errors": errors}, None)
@@ -328,8 +319,14 @@ def check_unit_tests(godot_path: str, project_dir: Path
             "--report-directory", str(report_path),
         ]
         try:
-            proc = subprocess.run(cmd, capture_output=True, text=True,
-                                  timeout=UNIT_TIMEOUT)
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=UNIT_TIMEOUT,
+            )
         except subprocess.TimeoutExpired:
             return (
                 {"result": "error", "passed": 0, "failed": 0, "failures": []},
@@ -458,8 +455,14 @@ def check_static(project_dir: Path) -> tuple[dict, dict | None]:
 
     cmd = [sys.executable, str(check_project), str(project_dir)] + STATIC_CHECK_FLAGS
     try:
-        proc = subprocess.run(cmd, capture_output=True, text=True,
-                              timeout=STATIC_TIMEOUT)
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=STATIC_TIMEOUT,
+        )
     except subprocess.TimeoutExpired:
         return (
             {"result": "error", "issues": []},

--- a/tools/run_verify.py
+++ b/tools/run_verify.py
@@ -483,6 +483,24 @@ def check_static(project_dir: Path) -> tuple[dict, dict | None]:
         else:
             issues.append({"check": "static_check", "detail": detail})
 
+    if proc.returncode != 0 and not issues:
+        excerpt = combined.strip()
+        if len(excerpt) > 800:
+            excerpt = excerpt[:797] + "..."
+        if not excerpt:
+            excerpt = "no stdout/stderr output"
+        return (
+            {"result": "error", "issues": []},
+            _tooling_note(
+                tool="check_project",
+                crashed_on=str(project_dir),
+                error=(
+                    f"check_project.py exited with code {proc.returncode} "
+                    f"without [FAIL] output: {excerpt}"
+                ),
+            ),
+        )
+
     result = "fail" if issues else "pass"
     return ({"result": result, "issues": issues}, None)
 


### PR DESCRIPTION
﻿## Summary

Add OpenCode as a GodotMaker agent runtime and document the current OpenCode-specific runtime limitations.

## Motivation

OpenCode can run GodotMaker stages through providers such as DeepSeek, but its runtime surface is not identical to Claude Code or Codex. This PR adds the OpenCode publish target and records the known limitations that affect project state discovery, hook parity, and child-session permissions.

## Changes

- [x] Add the OpenCode runtime publish surface, including `.opencode` skills, agents, runtime references, templates, config, MCP setup, and hook adapter wiring.
- [x] Add OpenCode-aware environment checks, project configuration docs, and provider setup docs for agent runtimes plus image/VQA selectors.
- [x] Add OpenCode hook adapter behavior for root-stage lifecycle gates while documenting degraded child-session hook parity.
- [x] Add OpenCode runtime guidance for dot-directory state files so agents do not trust missing Glob results for known `.godotmaker/*` and `.opencode/*` metadata paths.
- [x] Keep release notes in `docs/update/next.md` updated for the OpenCode runtime work.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
  - `python -m pytest tests/tools/test_publish.py tests/tools/test_check_env.py tests/agent_runtimes/test_opencode_hooks_plugin.py -q` (`147 passed`)
- [x] Gitleaks passes or no secret-bearing files were touched
  - `gitleaks detect --source . --config .gitleaks.toml` (`no leaks found`)
- [x] Manual testing completed, if applicable
  - Republished an OpenCode test project and confirmed `.opencode/references/runtime-mapping.md` contains the dot-directory file-check guidance.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

No migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
