### PR TITLE
fix: preserve OpenAI image aspect ratios

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -45,6 +45,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
   tooling errors instead of static-check passes.
 - Fixed the API-backed OpenAI image provider so supported reference images are
   all passed to the generation call instead of silently using only the first one.
+- Fixed the API-backed OpenAI image provider so 16:9 and 9:16 source requests
+  preserve their requested aspect ratio instead of falling back to 3:2/2:3.
 - Fixed OpenCode session-idle Stop hook handling so Stop hook block decisions
   are sent back to the active session instead of terminating the worker process.
 - Fixed OpenCode runtime guidance for dot-directory state files so agents do

--- a/tests/tools/test_asset_source_generate.py
+++ b/tests/tools/test_asset_source_generate.py
@@ -160,6 +160,20 @@ def test_openai_uses_all_reference_images_for_edit(tmp_path, monkeypatch):
     assert (tmp_path / spec["source_path"]).exists()
 
 
+@pytest.mark.parametrize(
+    ("aspect_ratio", "expected_size"),
+    [
+        ("16:9", "1536x864"),
+        ("9:16", "864x1536"),
+        ("3:2", "1536x1024"),
+    ],
+)
+def test_openai_size_preserves_supported_aspect_ratios(aspect_ratio, expected_size):
+    size, _cost = source_generate._openai_size("1K", aspect_ratio)
+
+    assert size == expected_size
+
+
 def test_openai_rejects_more_than_sixteen_reference_images(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     spec = source_generate.load_spec(

--- a/tools/asset_source_generate.py
+++ b/tools/asset_source_generate.py
@@ -211,12 +211,28 @@ def _openai_size(size: str, aspect_ratio: str) -> tuple[str, int]:
         return "1024x1024", OPENAI_COSTS["1:1"]
     try:
         left, right = aspect_ratio.split(":", 1)
-        landscape = float(left) >= float(right)
-    except ValueError:
-        landscape = True
-    if landscape:
-        return "1536x1024", OPENAI_COSTS["landscape"]
-    return "1024x1536", OPENAI_COSTS["portrait"]
+        width_ratio = float(left)
+        height_ratio = float(right)
+    except ValueError as exc:
+        raise SourceGenerateError(f"Invalid OpenAI aspect ratio: {aspect_ratio}") from exc
+    if width_ratio <= 0 or height_ratio <= 0:
+        raise SourceGenerateError(f"Invalid OpenAI aspect ratio: {aspect_ratio}")
+
+    ratio = width_ratio / height_ratio
+    if ratio > 3 or ratio < 1 / 3:
+        raise SourceGenerateError("OpenAI aspect ratio must be between 1:3 and 3:1")
+
+    def align16(value: float) -> int:
+        return max(16, int(round(value / 16)) * 16)
+
+    if ratio >= 1:
+        width = 1536
+        height = align16(width / ratio)
+        return f"{width}x{height}", OPENAI_COSTS["landscape"]
+
+    height = 1536
+    width = align16(height * ratio)
+    return f"{width}x{height}", OPENAI_COSTS["portrait"]
 
 
 def _save_openai_b64(response, output: Path):


### PR DESCRIPTION
﻿## Summary

Fix OpenAI image source generation so wide and tall requested aspect ratios keep their requested shape.

## Motivation

`/gm-asset` screen-reference generation can request `16:9` or `9:16` source images. The OpenAI provider previously mapped every non-square landscape request to `1536x1024` and every portrait request to `1024x1536`, which turned `16:9` into `3:2` and caused the asset finalize gate to reject the generated source image.

## Changes

- [x] Compute OpenAI `gpt-image-2` output sizes from the requested aspect ratio instead of using fixed landscape/portrait buckets.
- [x] Keep generated dimensions divisible by 16 and reject invalid ratios outside the OpenAI-supported `1:3` to `3:1` range.
- [x] Add pytest coverage for `16:9`, `9:16`, and existing `3:2` mapping.
- [x] Add a release-note entry to `docs/update/next.md`.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

```text
python -m pytest tests/tools/test_asset_source_generate.py -q
11 passed in 0.26s
```

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

No migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
