### PR TITLE
[codex] Clarify CLI runtime requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ python tools/check_env.py
 | Tool | Why |
 |---|---|
 | [Godot 4.5+](https://godotengine.org) | Runs the generated project |
-| [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex/), or [OpenCode](https://opencode.ai/) | Agent runtime |
+| [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex/), or [OpenCode](https://opencode.ai/) | Command-line agent runtime for CLI-driven runs; desktop chat apps are not sufficient |
 | Node.js 22+ | Runs `godotmaker-cli` and Godot MCP tooling |
 | Python 3.10+ | Runs GodotMaker helper scripts |
 | Git 2.30+ | Enables local history and agent worktrees |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,7 +100,7 @@ python tools/check_env.py
 | 工具 | 用途 |
 |---|---|
 | [Godot 4.5+](https://godotengine.org) | 运行生成出的项目 |
-| [Claude Code](https://claude.ai/code)、[Codex](https://openai.com/codex/) 或 [OpenCode](https://opencode.ai/) | Agent runtime |
+| [Claude Code](https://claude.ai/code)、[Codex](https://openai.com/codex/) 或 [OpenCode](https://opencode.ai/) | CLI 驱动运行所需的命令行 Agent runtime；桌面聊天应用不够 |
 | Node.js 22+ | 运行 `godotmaker-cli` 和 Godot MCP 工具 |
 | Python 3.10+ | 运行 GodotMaker 辅助脚本 |
 | Git 2.30+ | 提供本地历史和 Agent worktree |

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -20,6 +20,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Changed
 
 - Clarified README and docs landing-page boundaries for current game types, art-pipeline limits, and long-running prototype expectations.
+- Clarified that README agent runtime requirements refer to CLI-based runners.
 
 ## Fixed
 


### PR DESCRIPTION
﻿## Summary

Clarifies that the agent runtime listed in the README requirements must be the command-line runner used by `godotmaker-cli`, not a desktop chat app.

## Motivation

Users can confuse Claude Code or Codex desktop-style apps with the terminal runtimes GodotMaker needs for CLI-driven automated runs.

## Changes

- [x] Updated `README.md` requirements wording for agent runtimes.
- [x] Updated `README.zh-CN.md` with matching Chinese wording.
- [x] Added a `docs/update/next.md` release-note entry.

## Testing

- [ ] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

Docs-only README wording change; no code tests were run.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

Not applicable; no migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR

ECS metadata is not applicable to this docs-only change.
