### PR TITLE
fix: tolerate lone Unicode surrogates in agent trace writes

### DIFF
--- a/hooks/log_agent_tool.py
+++ b/hooks/log_agent_tool.py
@@ -113,7 +113,15 @@ def _atomic_write(path: str, content: str, ctx: str) -> None:
         return
 
     try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
+        # errors="backslashreplace": Agent prompts / tool responses can carry
+        # lone Unicode surrogates (e.g. a byte that got surrogate-escaped
+        # upstream survives json.loads -> json.dumps(ensure_ascii=False) as a
+        # raw \udcXX char). A strict UTF-8 encoder raises UnicodeEncodeError on
+        # those, which used to silently drop the whole trace file. Escaping the
+        # un-encodable chars keeps the file valid UTF-8 and readable; for the
+        # input.json path the escape is exactly a JSON \uXXXX sequence, so the
+        # file still round-trips through json.loads.
+        with os.fdopen(fd, "w", encoding="utf-8", errors="backslashreplace") as f:
             f.write(content)
         _log(ctx, "write+close ok", "bytes_written=", len(content))
     except Exception as e:  # noqa: BLE001 — log then unlink, never block

--- a/tests/hooks/test_log_agent_tool.py
+++ b/tests/hooks/test_log_agent_tool.py
@@ -202,6 +202,26 @@ class TestAtomicityAndPairing:
         leftovers = [n for n in os.listdir(TRACES) if n.startswith(".tmp_")]
         assert leftovers == []
 
+    def test_lone_surrogate_content_still_written(self, project_dir):
+        # A lone Unicode surrogate (e.g. a byte that got surrogate-escaped
+        # upstream and survived json.loads) makes a strict UTF-8 encoder raise
+        # UnicodeEncodeError. That used to silently drop the whole trace file.
+        # The write must succeed (backslashreplace) and leave no 0-byte stub,
+        # and the input.json must still be JSON-parseable.
+        _, code, _ = run_hook(HOOK, {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Agent",
+            "tool_use_id": "toolu_surrogate",
+            "tool_input": {"prompt": "bad byte here: \udce9 done"},
+        })
+        assert code == 0
+        path = _input_path("toolu_surrogate")
+        assert os.path.exists(path)
+        assert os.path.getsize(path) > 0
+        # Valid UTF-8 on disk (strict read must not raise) and still JSON.
+        loaded = json.loads(open(path, encoding="utf-8").read())
+        assert "bad byte here" in loaded["prompt"]
+
     def test_path_traversal_in_tool_use_id_is_neutralized(self, project_dir):
         # tool_use_id is opaque and Anthropic-controlled in practice, but
         # treat it as untrusted: a `../` should never escape the traces


### PR DESCRIPTION
## Summary

`_atomic_write` in `hooks/log_agent_tool.py` opened trace files with a strict UTF-8 encoder, so any Agent prompt or tool response carrying a lone Unicode surrogate raised `UnicodeEncodeError` and silently dropped the whole trace file.

## Motivation

Historical symptom: trace directories with many 0-byte `.tmp_*` files and zero successful trace files. Root cause traced to `_atomic_write` catching the `UnicodeEncodeError` in a broad `except Exception`, deleting the temp file, and returning without ever surfacing the failure — the hook itself still exits 0.

Lone surrogates reach the hook legitimately (not corrupted input): JS-side UTF-16 truncation of a surrogate pair, `surrogateescape`-decoded invalid bytes (e.g. non-UTF-8 console output on Windows), or an upstream producer's own `\udXXX` JSON escape. `json.loads` -> `json.dumps(ensure_ascii=False)` preserves the raw `\udcXX` character, and the strict `utf-8` encoder then rejects it on write.

## Changes

- [x] `_atomic_write` now opens the file with `errors="backslashreplace"` instead of the default strict handler
- [x] Add regression test `test_lone_surrogate_content_still_written` (fails without the fix; passes with it, and confirms `input.json` still round-trips through `json.loads`)

## Testing

- [x] New or updated tests pass (`pytest`)
- [ ] Gitleaks passes or no secret-bearing files were touched — not run in this environment
- [ ] Manual testing completed, if applicable

`python -m pytest tests/hooks/ -q` → 258 passed (verified independently by a second reviewer as well).

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — n/a, Python hook only
- [x] No hardcoded secrets or API keys
- [ ] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR — **not done**; left for reviewer/maintainer to add a changelog line before merge, since this PR only packages already-completed worker output

## Why `backslashreplace` over `U+FFFD`

Both produce valid, JSON-parseable UTF-8. `backslashreplace` was chosen because these trace files exist specifically for post-hoc debugging of unusual input — collapsing every bad char to the same `U+FFFD` replacement character would erase the exact evidence (which code unit, how many distinct occurrences) needed to diagnose *why* a run produced a lone surrogate in the first place. If these files ever become user-facing display output rather than diagnostic traces, `U+FFFD` would be the better default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
