### PR TITLE
docs: add changelog entry for surrogate trace fix

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -24,4 +24,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Fixed agent tool-dispatch trace capture so prompts or responses containing invalid Unicode surrogates are recorded instead of being silently dropped.
+
 ## Removed


### PR DESCRIPTION
## Summary

Add the `docs/update/next.md` changelog entry that the merged #73 fix ("tolerate lone Unicode surrogates in agent trace writes") omitted.

## Motivation

#73 was merged without its required changelog entry, which CONTRIBUTING.md step 6 makes mandatory for every PR. This follow-up completes that obligation so the next release's notes cover the fix. No code behavior changes.

Relates to #73.

## Changes

- [x] Add a `## Fixed` bullet to `docs/update/next.md` describing the surrogate-safe trace capture, following the one-sentence, user-facing-intent house style used by the archived `vX.Y.Z.md` notes.

## Testing

- [ ] New or updated tests pass — N/A, docs-only change (the fix's regression test already landed with #73)
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed — N/A, docs-only change

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed

## Checklist

- [x] Code follows project conventions
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
