### PR TITLE
fix(tools): redirect headless Godot logs out of user://logs

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -25,5 +25,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - Fixed agent tool-dispatch trace capture so prompts or responses containing invalid Unicode surrogates are recorded instead of being silently dropped.
+- Redirected headless Godot's log into `.godotmaker/logs/` (keeping the five most recent per check) so verify no longer fails when a sandbox cannot create Godot's default `user://logs` directory.
 
 ## Removed

--- a/tests/tools/test_check_project.py
+++ b/tests/tools/test_check_project.py
@@ -335,6 +335,34 @@ class TestBuildCheck:
         assert "no blocking diagnostics" in stdout
         assert "shutdown notes" in stdout
 
+    def test_headless_build_redirects_log_into_godotmaker_logs(self, project_dir):
+        _seed_scaffolded_project(project_dir)
+        os.makedirs(os.path.join(project_dir, ".godotmaker"), exist_ok=True)
+        argv_file = os.path.join(project_dir, "godot_argv.txt")
+        if os.name == "nt":
+            godot = os.path.join(project_dir, "record-godot.cmd")
+            with open(godot, "w", encoding="utf-8") as f:
+                f.write(f'@echo off\r\necho %* > "{argv_file}"\r\nexit /B 0\r\n')
+        else:
+            godot = os.path.join(project_dir, "record-godot")
+            with open(godot, "w", encoding="utf-8") as f:
+                f.write(
+                    '#!/bin/sh\n'
+                    f'printf "%s\\n" "$@" > "{argv_file}"\n'
+                    'exit 0\n'
+                )
+            os.chmod(godot, 0o755)
+        _write_godot_config(project_dir, godot)
+
+        stdout, code = run_check(project_dir, "--build")
+        assert code == 0, stdout
+
+        with open(argv_file, encoding="utf-8") as f:
+            recorded = f.read()
+        assert "--log-file" in recorded
+        assert ".godotmaker" in recorded
+        assert "godot-static-" in recorded
+
     def test_headless_display_and_objectdb_noise_does_not_block_headless_parse(
         self, project_dir
     ):

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -706,6 +706,7 @@ SELECTIVE_ENTRIES = [
     ".godotmaker/state.json",
     ".godotmaker/metrics.jsonl",
     ".godotmaker/metrics_current.jsonl",
+    ".godotmaker/logs/",
     "reports/",
     "__pycache__/",
     "*.pyc",

--- a/tests/tools/test_run_verify.py
+++ b/tests/tools/test_run_verify.py
@@ -268,6 +268,18 @@ def test_check_build_missing_binary_returns_escalate():
     assert note["crashed_on"] == "nope-godot"
 
 
+def test_check_build_redirects_log_into_godotmaker_logs(project_dir: Path):
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stdout="Done.\n")
+        run_verify.check_build("/usr/bin/godot", project_dir)
+    cmd = run.call_args.args[0]
+    assert "--log-file" in cmd
+    log_path = Path(cmd[cmd.index("--log-file") + 1])
+    assert log_path.parent == project_dir / ".godotmaker" / "logs"
+    assert log_path.name.startswith("godot-build-")
+    assert log_path.suffix == ".log"
+
+
 # ---------- unit tests ----------
 
 def test_check_unit_tests_pass_with_cases_summary():
@@ -293,6 +305,18 @@ def test_check_unit_tests_uses_official_gdunit_cmdtool_args():
     assert "--report-directory" in cmd
     assert "--run-tests" not in cmd
     assert "--test-case" not in cmd
+
+
+def test_check_unit_tests_redirects_log_into_godotmaker_logs(project_dir: Path):
+    output = "1 test case | 0 errors | 0 failures (1 suite, exit 0)\n"
+    with patch.object(run_verify.subprocess, "run") as run:
+        run.return_value = _make_proc(stdout=output)
+        run_verify.check_unit_tests("/usr/bin/godot", project_dir)
+    cmd = run.call_args.args[0]
+    assert "--log-file" in cmd
+    log_path = Path(cmd[cmd.index("--log-file") + 1])
+    assert log_path.parent == project_dir / ".godotmaker" / "logs"
+    assert log_path.name.startswith("godot-gdunit-")
 
 
 def test_check_unit_tests_prefers_xml_top_level_over_first_suite_summary():
@@ -828,3 +852,29 @@ def test_main_subprocess_invocation_real(project_dir: Path):
     # either pass or fail/error here — the assertion that matters is that
     # the script ran end-to-end and produced a schema-valid JSON.
     assert validate_report(parsed) == []
+
+
+# ---------- godot log-file retention ----------
+
+def test_godot_log_file_keeps_five_newest_per_kind(project_dir: Path):
+    logs = project_dir / ".godotmaker" / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    seeded = []
+    for i in range(6):
+        p = logs / f"godot-build-seed{i}.log"
+        p.write_text("x")
+        os.utime(p, (1000 + i, 1000 + i))  # ascending mtime: seed5 newest
+        seeded.append(p)
+    # A different kind must survive build-kind pruning.
+    untouched = logs / "godot-gdunit-seed.log"
+    untouched.write_text("x")
+
+    new_path = Path(run_verify.godot_log_file(project_dir, "build"))
+    new_path.write_text("new")  # the caller (godot) writes the returned path
+
+    build_logs = list(logs.glob("godot-build-*.log"))
+    assert len(build_logs) == 5  # 4 newest seeds + the new one
+    assert not seeded[0].exists()
+    assert not seeded[1].exists()
+    assert seeded[5].exists()
+    assert untouched.exists()

--- a/tools/agent_runtime.py
+++ b/tools/agent_runtime.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 from pathlib import Path
 import sys
 
@@ -172,6 +173,61 @@ def prefer_console_godot_path(godot_path: str | None) -> str | None:
     except OSError:
         return godot_path
     return godot_path
+
+
+# Godot's `--log-file` disables the engine's built-in log rotation
+# (godotengine/godot PR #87373), so we manage retention here and keep the
+# newest MAX_GODOT_LOG_FILES per kind — mirroring Godot's own
+# `debug/file_logging/max_log_files` default of 5.
+MAX_GODOT_LOG_FILES = 5
+
+
+def _log_timestamp() -> str:
+    return dt.datetime.now(tz=dt.timezone.utc).strftime("%Y-%m-%dT%H.%M.%S")
+
+
+def _prune_godot_logs(logs_dir: Path, kind: str, *, keep: int) -> None:
+    """Delete the oldest `godot-<kind>-*.log` files so that once the caller
+    writes a new one, at most `keep` remain. Best-effort; never raises."""
+    try:
+        existing = sorted(
+            logs_dir.glob(f"godot-{kind}-*.log"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+    except OSError:
+        return
+    for stale in existing[max(keep - 1, 0):]:
+        try:
+            stale.unlink()
+        except OSError:
+            pass
+
+
+def godot_log_file(
+    project_dir: Path,
+    kind: str,
+    *,
+    keep: int = MAX_GODOT_LOG_FILES,
+) -> str:
+    """Return an absolute `--log-file` path under `<project>/.godotmaker/logs/`.
+
+    Redirecting Godot's headless log out of the default `user://logs/...`
+    lets verify run under sandboxes (e.g. Codex CLI) that cannot create the
+    engine's user-data directory. Older logs of the same `kind` are pruned to
+    the newest `keep`; `kind` (build / gdunit / static) keeps the concurrent
+    headless calls from clobbering each other.
+    """
+    logs_dir = project_dir / ".godotmaker" / "logs"
+    try:
+        # parents=False on purpose: only create `logs/` inside an existing
+        # `.godotmaker/` project. Outside one (e.g. unit-test stub paths) this
+        # raises FileNotFoundError, which we swallow so no stray dirs appear.
+        logs_dir.mkdir(exist_ok=True)
+    except OSError:
+        pass
+    _prune_godot_logs(logs_dir, kind, keep=keep)
+    return str(logs_dir / f"godot-{kind}-{_log_timestamp()}.log")
 
 
 if __name__ == "__main__":

--- a/tools/check_project.py
+++ b/tools/check_project.py
@@ -22,6 +22,7 @@ import sys
 from pathlib import Path
 
 from agent_runtime import (
+    godot_log_file,
     godotmaker_yaml,
     prefer_console_godot_path,
     read_godot_path,
@@ -98,7 +99,8 @@ def _run_headless_godot(godot_path: str, project_dir: Path
     single function instead of subprocess.run directly.
     """
     proc = subprocess.run(
-        [godot_path, "--headless", "--path", str(project_dir), "--quit"],
+        [godot_path, "--headless", "--path", str(project_dir),
+         "--log-file", godot_log_file(project_dir, "static"), "--quit"],
         capture_output=True, text=True, encoding="utf-8",
         errors="replace", timeout=60,
     )

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -1190,6 +1190,7 @@ def ensure_gitignore(target: Path, agent: str = AGENT_CLAUDE_CODE):
         ".godotmaker/metrics_current.jsonl",
         ".godotmaker/traces/",
         ".godotmaker/applied_migrations.json",
+        ".godotmaker/logs/",
         "reports/",
         "__pycache__/",
         "*.pyc",

--- a/tools/run_verify.py
+++ b/tools/run_verify.py
@@ -40,6 +40,7 @@ from pathlib import Path
 from typing import Any
 
 from agent_runtime import (
+    godot_log_file,
     godotmaker_yaml,
     prefer_console_godot_path,
     read_godot_path,
@@ -94,9 +95,11 @@ def _tooling_note(tool: str, crashed_on: str, error: str,
 def check_build(godot_path: str, project_dir: Path
                 ) -> tuple[dict, dict | None]:
     """Run `<godot_path> --headless --quit` and parse blocking diagnostics."""
+    log_file = godot_log_file(project_dir, "build")
     try:
         proc = subprocess.run(
-            [godot_path, "--headless", "--path", str(project_dir), "--quit"],
+            [godot_path, "--headless", "--path", str(project_dir),
+             "--log-file", log_file, "--quit"],
             capture_output=True, text=True, encoding="utf-8",
             errors="replace", timeout=BUILD_TIMEOUT,
         )
@@ -313,6 +316,7 @@ def check_unit_tests(godot_path: str, project_dir: Path
         cmd = [
             godot_path, "--headless",
             "--path", str(project_dir),
+            "--log-file", godot_log_file(project_dir, "gdunit"),
             "-s", "res://addons/gdUnit4/bin/GdUnitCmdTool.gd",
             "--ignoreHeadlessMode",
             "--add", "res://test/",


### PR DESCRIPTION
## Summary

Redirect headless Godot's log output out of `user://logs/` and into a workspace-local `.godotmaker/logs/` directory, so `verify`/`fixgap` no longer fails when the runner's sandbox cannot create Godot's default user-data log directory.

## Motivation

Under a restricted-write sandbox (e.g. codex CLI's default `workspace-write` mode), Godot's default file logging tries to write to `user://logs/godot<timestamp>.log`, which maps to an OS user-data directory outside the workspace. The write is rejected with `ERROR: Failed to open 'user://logs/...log'`. `tools/godot_output.py` treats any `ERROR:` line as a blocking diagnostic, so `check_build` and `check_project.py --build` are marked FAIL, and `check_unit_tests` can't produce a parseable gdUnit4 report either. Verify then reports FAIL with an `escalate` tooling note, and `gm-fixgap` correctly halts per its escalate-to-user contract (Step 1b) instead of continuing — which surfaces to the user as "fixgap ran but the error keeps coming back."

This is not unique to this project: Godot headless writing to `user://` under a restricted sandbox/CI is a known class of issue (see godotengine/godot#118354, #62430, #77508; MikeSchulze/gdUnit4#487). The Godot CLI's own `--log-file <path>` flag is the documented fix for the logging half of this.

## Changes

- [x] Add shared helper `tools/agent_runtime.py::godot_log_file(project_dir, kind)` — returns an absolute path under `<project>/.godotmaker/logs/godot-<kind>-<timestamp>.log`, creates the directory, and prunes older files so only the 5 most recent per `kind` are kept (aligned with Godot's own `debug/file_logging/max_log_files` default, since `--log-file` disables Godot's built-in rotation).
- [x] Pass `--log-file <path>` at the three headless Godot call sites: `tools/run_verify.py::check_build` (`kind=build`), `tools/run_verify.py::check_unit_tests` (`kind=gdunit`), `tools/check_project.py::_run_headless_godot` (`kind=static`).
- [x] Add `.godotmaker/logs/` to the selective `.gitignore` entries written by `tools/publish.py::ensure_gitignore()`, so these headless log files don't show up as untracked files in generated game projects.
- [x] Update `docs/update/next.md` with a Fixed entry.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
  - `tests/tools/test_run_verify.py` (+3): asserts the build/gdunit commands include `--log-file` and that pruning keeps 5 files per kind
  - `tests/tools/test_check_project.py` (+1): real-subprocess argv capture confirming `--log-file` lands under `.godotmaker/logs/`
  - `tests/tools/test_publish.py` (+1): `.godotmaker/logs/` is written into `.gitignore`'s selective entries
  - Full suite: `python -m pytest` → 1072 passed
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable — runtime behavior (does this actually eliminate the `user://logs` error under a real Mac + codex restricted sandbox) has not been verified on real hardware; only argument-passing and pruning logic are covered by tests. Flagged as residual risk for reviewers.

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed (this only changes internal tool invocation and gitignore contents for newly-generated `.godotmaker/logs/` files; no existing config keys, file layouts, or target-project state are altered)

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — N/A, no ECS systems touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR

## Out of scope (tracked separately)

This PR only redirects the Godot log file. It intentionally does not:
- Change `tools/godot_output.py`'s classification of engine/environment IO errors as blockers (a separate hardening PR)
- Redirect other potential `user://` writes (e.g. shader cache)
