### PR TITLE
fix(scaffold): disable Godot's default engine file logging for new and existing projects

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -27,5 +27,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Improved multi-frame runtime asset handling so generated actors and FX are built and reviewed for animation playback and lifecycle behavior instead of static sheet or first-frame use.
 - Fixed agent tool-dispatch trace capture so prompts or responses containing invalid Unicode surrogates are recorded instead of being silently dropped.
 - Redirected headless Godot's log into `.godotmaker/logs/` (keeping the five most recent per check) so verify no longer fails when a sandbox cannot create Godot's default `user://logs` directory.
+- Scaffolded projects now disable Godot's default engine file log so an unattended run that floods errors can no longer fill the system drive with an unbounded `user://logs/godot.log`.
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -27,6 +27,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Improved multi-frame runtime asset handling so generated actors and FX are built and reviewed for animation playback and lifecycle behavior instead of static sheet or first-frame use.
 - Fixed agent tool-dispatch trace capture so prompts or responses containing invalid Unicode surrogates are recorded instead of being silently dropped.
 - Redirected headless Godot's log into `.godotmaker/logs/` (keeping the five most recent per check) so verify no longer fails when a sandbox cannot create Godot's default `user://logs` directory.
-- Scaffolded projects now disable Godot's default engine file log so an unattended run that floods errors can no longer fill the system drive with an unbounded `user://logs/godot.log`.
+- New and existing projects now disable Godot's default engine file log (existing projects are updated by an upgrade migration) so an unattended run that floods errors can no longer fill the system drive with an unbounded `user://logs/godot.log`.
 
 ## Removed

--- a/migrations/20260708145839_disable_engine_file_logging.py
+++ b/migrations/20260708145839_disable_engine_file_logging.py
@@ -1,0 +1,72 @@
+"""Disable Godot's default engine file logging in existing projects.
+
+The scaffold `project.godot` template now sets
+`[debug] file_logging/enable_file_logging=false` so a generated game does not
+write Godot's default `user://logs/godot.log` — which lives on the system drive
+and has no per-file size cap. An unattended E2E run that re-raises a GDScript
+error every frame could otherwise grow that log without bound and fill the disk.
+
+`project.godot` is target-project state written once at scaffold time (scaffold
+is lifetime-once), so re-publishing the framework does not touch it. Existing
+projects therefore need this migration to gain the setting.
+
+Policy: only *add* the key when it is absent. If a project already sets
+`file_logging/enable_file_logging` to either value, that is an explicit choice
+and is preserved — we never flip a value the user (or a prior scaffold) wrote.
+"""
+from pathlib import Path
+
+_KEY = "file_logging/enable_file_logging"
+_LINE = f"{_KEY}=false"
+
+
+def _has_key(text: str) -> bool:
+    """True if the file already sets the key (any value, any spacing).
+
+    The key only belongs under `[debug]`, so a whole-file scan is
+    unambiguous — it cannot collide with a same-named key elsewhere.
+    """
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith(_KEY) and "=" in stripped:
+            return True
+    return False
+
+
+def migrate(target: Path) -> None:
+    """target is the absolute path to the game project root.
+
+    Idempotent: the key-presence check makes a re-run a no-op, and an
+    explicit existing value is preserved rather than overwritten.
+    """
+    project_godot = target / "project.godot"
+    if not project_godot.exists():
+        print("  [skip] project.godot not found")
+        return
+
+    text = project_godot.read_text(encoding="utf-8")
+
+    if _has_key(text):
+        print(f"  [skip] {_KEY} already set; preserving existing choice")
+        return
+
+    newline = "\r\n" if "\r\n" in text else "\n"
+    lines = text.splitlines(keepends=True)
+
+    debug_idx = next(
+        (i for i, ln in enumerate(lines) if ln.strip() == "[debug]"), None
+    )
+    if debug_idx is not None:
+        # `[debug]` exists but lacks the key — insert it right after the
+        # section header so it lands inside that section.
+        lines.insert(debug_idx + 1, _LINE + newline)
+        new_text = "".join(lines)
+        print(f"  [done] added {_KEY} to existing [debug] section")
+    else:
+        # No `[debug]` section — append one at the end. Section order is
+        # not significant to Godot's ConfigFile parser.
+        sep = "" if (text == "" or text.endswith(newline)) else newline
+        new_text = f"{text}{sep}{newline}[debug]{newline}{newline}{_LINE}{newline}"
+        print("  [done] added [debug] section with default file logging disabled")
+
+    project_godot.write_text(new_text, encoding="utf-8")

--- a/skills/core/project-scaffold/references/project_settings.md
+++ b/skills/core/project-scaffold/references/project_settings.md
@@ -29,6 +29,19 @@ window/stretch/mode="canvas_items"
 renderer/rendering_method="gl_compatibility"
 ```
 
+### [debug]
+
+```ini
+file_logging/enable_file_logging=false
+```
+
+Always include this section. It turns off Godot's default engine file log
+(`user://logs/godot.log`, on the system drive), which has no per-file size cap
+and can grow without bound during unattended pipeline / E2E runs where a
+GDScript error is re-raised every frame. Diagnostics still reach the tooling
+via stdout and the E2E log capture; verify redirects its own headless log with
+an explicit `--log-file` (which overrides this setting).
+
 ### [physics]
 
 ```ini

--- a/skills/core/project-scaffold/templates/project.godot.tmpl
+++ b/skills/core/project-scaffold/templates/project.godot.tmpl
@@ -15,6 +15,17 @@ config/features=PackedStringArray("4.4")
 
 AutomationServer="*res://addons/godot_e2e/automation_server.gd"
 
+[debug]
+
+; Disable Godot's default file logging. Unattended pipeline / E2E runs can
+; re-raise a GDScript error every frame with no human to stop them, and the
+; engine log has no per-file size cap, so the default user://logs/godot.log
+; (on the system drive) can grow without bound and fill the disk. Runtime
+; diagnostics still reach the tooling via stdout and the E2E log capture, and
+; verify passes an explicit --log-file (which overrides this setting), so
+; turning off the default file log is safe here.
+file_logging/enable_file_logging=false
+
 [display]
 
 window/size/viewport_width={{viewport_width}}

--- a/tests/test_scaffold_project_godot.py
+++ b/tests/test_scaffold_project_godot.py
@@ -1,0 +1,28 @@
+"""The scaffolded project.godot template must disable Godot's default engine
+file logging.
+
+Unattended pipeline / E2E runs can re-raise a GDScript error every frame with
+no human to stop them, and Godot's engine log has no per-file size cap, so the
+default `user://logs/godot.log` (on the system drive) can grow without bound and
+fill the disk. Disabling it at the project level covers every launch of the
+generated project — pure-skill, cli, build, verify, and the external E2E
+launcher alike — without depending on how Godot is invoked.
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE = REPO_ROOT / "skills/core/project-scaffold/templates/project.godot.tmpl"
+SETTINGS_DOC = REPO_ROOT / "skills/core/project-scaffold/references/project_settings.md"
+
+
+def test_project_godot_template_disables_default_file_logging():
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "[debug]" in text
+    assert "file_logging/enable_file_logging=false" in text
+
+
+def test_project_settings_reference_documents_debug_file_logging():
+    text = SETTINGS_DOC.read_text(encoding="utf-8")
+    assert "### [debug]" in text
+    assert "file_logging/enable_file_logging=false" in text

--- a/tests/tools/test_migration_disable_engine_file_logging.py
+++ b/tests/tools/test_migration_disable_engine_file_logging.py
@@ -1,0 +1,127 @@
+"""Tests for migrations/20260708145839_disable_engine_file_logging.py.
+
+The migration injects `[debug] file_logging/enable_file_logging=false` into an
+existing project's `project.godot`, so projects scaffolded before the template
+change stop writing Godot's uncapped default `user://logs/godot.log` to the
+system drive. Every step is idempotent, and an explicit existing value is
+preserved.
+"""
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "migrations"
+    / "20260708145839_disable_engine_file_logging.py"
+)
+
+
+@pytest.fixture
+def migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "disable_engine_file_logging", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _debug_section(text: str) -> str:
+    """Return the body of the [debug] section (up to the next header)."""
+    lines = text.splitlines()
+    out: list[str] = []
+    in_debug = False
+    for line in lines:
+        if line.strip() == "[debug]":
+            in_debug = True
+            continue
+        if in_debug and line.strip().startswith("[") and line.strip().endswith("]"):
+            break
+        if in_debug:
+            out.append(line)
+    return "\n".join(out)
+
+
+_BASE = (
+    'config_version=5\n\n'
+    '[application]\n\n'
+    'config/name="Test"\n'
+    'run/main_scene="res://scenes/main.tscn"\n\n'
+    '[rendering]\n\n'
+    'renderer/rendering_method="gl_compatibility"\n'
+)
+
+
+def test_adds_debug_section_when_absent(migration_module, tmp_path):
+    (tmp_path / "project.godot").write_text(_BASE, encoding="utf-8")
+
+    migration_module.migrate(tmp_path)
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert text.count("[debug]") == 1
+    assert "file_logging/enable_file_logging=false" in _debug_section(text)
+    # Untouched sections survive.
+    assert "[application]" in text
+    assert 'renderer/rendering_method="gl_compatibility"' in text
+
+
+def test_adds_key_to_existing_debug_section(migration_module, tmp_path):
+    (tmp_path / "project.godot").write_text(
+        _BASE + "\n[debug]\n\nsettings/profiler/max_functions=16384\n",
+        encoding="utf-8",
+    )
+
+    migration_module.migrate(tmp_path)
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert text.count("[debug]") == 1  # no duplicate section
+    debug = _debug_section(text)
+    assert "file_logging/enable_file_logging=false" in debug
+    assert "settings/profiler/max_functions=16384" in debug  # sibling key kept
+
+
+def test_idempotent_on_rerun(migration_module, tmp_path):
+    (tmp_path / "project.godot").write_text(_BASE, encoding="utf-8")
+
+    migration_module.migrate(tmp_path)
+    first = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    migration_module.migrate(tmp_path)
+    second = (tmp_path / "project.godot").read_text(encoding="utf-8")
+
+    assert first == second
+    assert second.count("file_logging/enable_file_logging") == 1
+
+
+def test_preserves_explicit_true(migration_module, tmp_path):
+    (tmp_path / "project.godot").write_text(
+        _BASE + "\n[debug]\n\nfile_logging/enable_file_logging=true\n",
+        encoding="utf-8",
+    )
+
+    migration_module.migrate(tmp_path)
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert "file_logging/enable_file_logging=true" in text
+    assert "enable_file_logging=false" not in text
+    assert text.count("file_logging/enable_file_logging") == 1
+
+
+def test_preserves_comments(migration_module, tmp_path):
+    seeded = "; Engine configuration file.\n; hand-written note\n" + _BASE
+    (tmp_path / "project.godot").write_text(seeded, encoding="utf-8")
+
+    migration_module.migrate(tmp_path)
+
+    text = (tmp_path / "project.godot").read_text(encoding="utf-8")
+    assert "; Engine configuration file." in text
+    assert "; hand-written note" in text
+    assert "file_logging/enable_file_logging=false" in text
+
+
+def test_missing_project_godot_is_noop(migration_module, tmp_path):
+    # No project.godot at all — must not raise and must not create one.
+    migration_module.migrate(tmp_path)
+    assert not (tmp_path / "project.godot").exists()


### PR DESCRIPTION
## Summary

Disable Godot's default engine file log (`user://logs/godot.log`) for both newly scaffolded and already-existing GodotMaker projects, so an unattended run that floods runtime errors can no longer fill the system drive.

## Motivation

`user://logs/godot.log` lives on the system drive (`%APPDATA%` on Windows) and has no per-file size cap — `debug/file_logging/max_log_files` only caps file *count*, not size. In an unattended pipeline / long-running E2E, a generated game can re-raise a GDScript runtime error every frame with nobody around to stop it, and that log grows unbounded until it fills the disk.

This hits **every** consumer of a generated project (pure-skill usage, CLI, or any other launcher), because the sink is the Godot engine itself, not any one wrapper. `#76` already redirected the framework's own headless *verify* logs via `--log-file`, but the long-running E2E path (the actual flood scenario) launches Godot through an external launcher we don't control and can't pass `--log-file` through. The only lever that works regardless of how Godot is invoked is the project setting itself, so the fix has to live at the project level — and, per review on this PR, has to cover projects that were scaffolded before this change too, not just new ones.

## Changes

- [x] Add `[debug] file_logging/enable_file_logging=false` to the scaffold `project.godot` template so every new project disables the default log sink from creation.
- [x] Add idempotent migration `migrations/20260708145839_disable_engine_file_logging.py` that injects the same key into existing projects' `project.godot` on upgrade — only when the key is absent, so an explicit existing value (true or false) is preserved rather than overwritten.
- [x] Update `skills/core/project-scaffold/references/project_settings.md` to document the new `[debug]` section.
- [x] Add `docs/update/next.md` entry.

## Testing

- [x] New or updated tests pass: `tests/test_scaffold_project_godot.py` (template assertion) and `tests/tools/test_migration_disable_engine_file_logging.py` (6 cases: new `[debug]` section, key added to existing section, idempotent re-run, explicit `true` preserved, comments preserved, missing `project.godot` is a no-op). Full suite: `python -m pytest tests/` → 1081 passed.
- [x] Gitleaks passes (CI `Secret Scan` green; no secret-bearing files touched).
- [ ] Manual testing completed — not performed beyond the automated suite above.

## Benchmark Verification

- [x] Not performance-sensitive.

## Version Compatibility

- [x] **Yes** - migration script added to `migrations/` (see `migrations/20260708145839_disable_engine_file_logging.py`).

### Migration Upgrade Gate

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>` — **not done**. Coverage so far is unit tests against synthetic `project.godot` fixtures in a `tmp_path`, not an end-to-end `publish.py` run against a real pinned project.
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"` — **not verified** (no real-project upgrade run yet).
- [ ] Post-upgrade on-disk state was inspected and matches expectations — only verified indirectly via unit tests, not a real upgraded project.
- [ ] Re-running `tools/publish.py` produces no further migration changes — idempotency is covered by a unit test (`test_idempotent_on_rerun`), but not via an actual `publish.py` re-run.
- [ ] Result attached or summarized below — **outstanding**; this gate should be completed before merge.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — N/A, no ECS systems touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
