### PR TITLE
fix: bind single-element region_atlas nodes to their named region

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -60,6 +60,7 @@ You are STRICTLY PROHIBITED from:
    - Implementation uses final asset paths listed in the snapshot
    - `grid_sheet` usage reads the listed action metadata JSON
    - `region_atlas` usage reads the listed atlas metadata JSON
+   - `region_atlas` single-element nodes reference their named region via AtlasTexture/region, not the whole atlas sheet
    - No source image, curation candidate, prompt file, or scene reference is used as a runtime asset
    - No listed final asset is replaced with placeholder art, procedural shapes, or freshly drawn stand-ins
 
@@ -81,6 +82,11 @@ When `Asset Runtime Snapshot` is present, asset usage review must also check:
   to only the first frame.
 - Animated temporary FX have an end-of-life path such as animation finished,
   timer, tween completion, or explicit state clear.
+- `region_atlas` single-element nodes (button, icon, prop, single FX sprite)
+  bind their named region via AtlasTexture/region, not the whole atlas image.
+- A whole `region_atlas` or `grid_sheet` image is not assigned as one visible
+  sprite where the brief names a single region or frame. Whole-atlas misuse is
+  itself a review issue.
 
 ## Brief Format (What You Receive)
 
@@ -132,6 +138,7 @@ When `Asset Runtime Snapshot` is present, asset usage review must also check:
 - [ ] Runtime metadata is used for grid sheets and atlases: PASS/FAIL/N/A
 - [ ] Multi-frame grid sheets are animated instead of static sheet/first-frame use: PASS/FAIL/N/A
 - [ ] Temporary animated FX clear after playback or state completion: PASS/FAIL/N/A
+- [ ] Region atlases bind single named regions instead of the whole atlas image: PASS/FAIL/N/A
 - [ ] No generation source or curation candidate is used at runtime: PASS/FAIL/N/A
 - [ ] No final asset is replaced by placeholder or procedural art: PASS/FAIL/N/A
 

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -115,8 +115,9 @@ If you need to modify a file not in your deliverables, report this in your Notes
   action/state switches named in the brief.
 - For temporary projectile, impact, pickup, slash, aura, or feedback FX, wire
   the effect lifecycle so it disappears or clears after playback.
-- For `region_atlas`, read the listed atlas metadata JSON and wire named
-  regions from it.
+- For `region_atlas`, read the listed atlas metadata JSON and resolve the
+  matching region by name from it. Use the region named in the brief when given;
+  otherwise match the element to its region by name.
 - A node that shows one element (a single button, icon, prop, or FX sprite)
   from a `region_atlas` must reference its named region via `AtlasTexture` with
   the region `rect` from the metadata (or an equivalent region binding). Do not

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -117,6 +117,13 @@ If you need to modify a file not in your deliverables, report this in your Notes
   the effect lifecycle so it disappears or clears after playback.
 - For `region_atlas`, read the listed atlas metadata JSON and wire named
   regions from it.
+- A node that shows one element (a single button, icon, prop, or FX sprite)
+  from a `region_atlas` must reference its named region via `AtlasTexture` with
+  the region `rect` from the metadata (or an equivalent region binding). Do not
+  assign the whole atlas image as a `Sprite2D`/`TextureRect` texture where a
+  single region is required.
+- Do not use a whole `region_atlas` or `grid_sheet` image as one visible sprite
+  when the brief names a single region or frame to show.
 - Do not use `.godotmaker/asset-generation/sources/`, curation candidates,
   prompt files, or scene references as runtime assets.
 - Do not replace listed final assets with placeholders, procedural shapes, or

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -25,6 +25,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - Improved multi-frame runtime asset handling so generated actors and FX are built and reviewed for animation playback and lifecycle behavior instead of static sheet or first-frame use.
+- Fixed atlas asset usage so a generated button, icon, prop, or effect is built and reviewed to show its own image instead of the whole packed sheet it was cut from.
 - Fixed agent tool-dispatch trace capture so prompts or responses containing invalid Unicode surrogates are recorded instead of being silently dropped.
 - Redirected headless Godot's log into `.godotmaker/logs/` (keeping the five most recent per check) so verify no longer fails when a sandbox cannot create Godot's default `user://logs` directory.
 

--- a/skills/core/_shared/reviewer-dispatch.md
+++ b/skills/core/_shared/reviewer-dispatch.md
@@ -37,8 +37,8 @@ Agent({
 used by the implementation.
 For `grid_sheet` with frame_count > 1, include the action metadata path,
 expected runtime animation behavior, and temporary-FX teardown requirement.
-For `region_atlas`, include the atlas metadata path, region names, and the
-expected named region for each single-element node.}
+For `region_atlas`, include the atlas metadata path; name the expected region
+only when the element-to-region match is not obvious from the binding.}
 ```
 
 ## Handling the Reviewer's Report

--- a/skills/core/_shared/reviewer-dispatch.md
+++ b/skills/core/_shared/reviewer-dispatch.md
@@ -36,7 +36,9 @@ Agent({
 {Final asset paths, runtime_artifact values, frame_count, and metadata paths
 used by the implementation.
 For `grid_sheet` with frame_count > 1, include the action metadata path,
-expected runtime animation behavior, and temporary-FX teardown requirement.}
+expected runtime animation behavior, and temporary-FX teardown requirement.
+For `region_atlas`, include the atlas metadata path, region names, and the
+expected named region for each single-element node.}
 ```
 
 ## Handling the Reviewer's Report

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -79,8 +79,9 @@ prompt files, or scene references as runtime assets.
 For `grid_sheet` with frame_count > 1, include the action metadata path,
 frame_paths, fps/loop when present, and the expected runtime state or FX
 lifecycle that should play it.
-For `region_atlas`, include the atlas metadata path, the region names/count,
-and which named region each node or binding must show.
+For `region_atlas`, include the atlas metadata path and let the worker resolve
+the region and its rect from that metadata by name. Name the target region only
+when the element-to-region match is not obvious from the binding.
 If a required final asset or metadata file is missing, report PARTIAL or
 FAILED with the missing path.}
 
@@ -145,9 +146,10 @@ presentation" or static feedback.
 slash, aura, or feedback effects must state how the effect starts and how it
 disappears or clears.
 22. **Region atlases are single regions.** If the snapshot lists a
-`region_atlas`, name which region each node must show and require selecting
-that region via AtlasTexture/region. Never assign the whole atlas image as one
-texture where a single element is required.
+`region_atlas`, require selecting the element's named region from the atlas
+metadata via AtlasTexture/region. Name the target region only when the match is
+not obvious from the binding. Never assign the whole atlas image as one texture
+where a single element is required.
 23. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
 
 ## Worker Utility Convention

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -42,6 +42,7 @@ Agent({
 - [ ] e2e-testable interface: public methods / signals / simulate_* helpers for affected systems/scenes/UI, with unit tests covering each one
 - [ ] If runtime assets include multi-frame `grid_sheet` entries: wire animation playback from metadata, not a static sheet or first frame
 - [ ] If runtime assets include temporary animated FX: implement end-of-life behavior (animation finished, timer, tween completion, or equivalent state clear)
+- [ ] If runtime assets include `region_atlas` entries: bind each single-element node to its named region via AtlasTexture/region, not the whole atlas image
 - [ ] Run headless-build and confirm compilation
 - [ ] Run unit tests and include pass/fail output
 - [ ] If `Visual Self-Check` is present: capture screenshot(s), run visual-qa, include output
@@ -78,6 +79,8 @@ prompt files, or scene references as runtime assets.
 For `grid_sheet` with frame_count > 1, include the action metadata path,
 frame_paths, fps/loop when present, and the expected runtime state or FX
 lifecycle that should play it.
+For `region_atlas`, include the atlas metadata path, the region names/count,
+and which named region each node or binding must show.
 If a required final asset or metadata file is missing, report PARTIAL or
 FAILED with the missing path.}
 
@@ -141,7 +144,11 @@ presentation" or static feedback.
 21. **Temporary FX need lifecycle.** Animated projectile, impact, pickup,
 slash, aura, or feedback effects must state how the effect starts and how it
 disappears or clears.
-22. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
+22. **Region atlases are single regions.** If the snapshot lists a
+`region_atlas`, name which region each node must show and require selecting
+that region via AtlasTexture/region. Never assign the whole atlas image as one
+texture where a single element is required.
+23. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
 
 ## Worker Utility Convention
 

--- a/skills/core/gm-evaluate/SKILL.md
+++ b/skills/core/gm-evaluate/SKILL.md
@@ -156,6 +156,14 @@ All of these must pass for `result == "approve"`. Failure of any is a `critical_
    readability, layout, and motion/animation requirements. For deterministic
    setup screenshots, add `Visible state only; do not infer prior play history.`.
 
+   **Atlas misuse check.** When a scene's `Asset bindings` reference a
+   `region_atlas` (or a single element sourced from a `grid_sheet`), add to the
+   question whether each element shows only its intended region/sprite and not
+   the whole atlas or sheet. A visible full atlas or sheet where a single
+   button, icon, prop, or FX sprite is expected is a `critical_issue`; set this
+   scene's `visual_checks.<scene>.result` to `"fail"` and note the misused
+   binding in `visual_checks.<scene>.notes`.
+
    **VQA log path.** Ask `visual-qa` to write its debug log to `e2e/screenshots/vqa.log`.
 
    ```

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -290,15 +290,20 @@ def test_region_atlas_single_region_contract():
     reviewer = _read("agents/reviewer.md")
     evaluate = _read("skills/core/gm-evaluate/SKILL.md")
 
-    # Worker must select a single named region, not the whole atlas image.
+    # Worker resolves the region by name from metadata, not the whole atlas image.
+    assert "matching region by name from it" in worker
+    assert "Use the region named in the brief when given" in worker
     assert "must reference its named region via `AtlasTexture`" in worker
     assert "Do not use a whole `region_atlas` or `grid_sheet` image as one visible sprite" in worker
 
-    # Dispatch snapshots feed region info to worker and reviewer.
+    # Dispatch passes only the metadata path; region names come from metadata,
+    # and the target region is named only when the match is not obvious.
     assert "bind each single-element node to its named region via AtlasTexture/region" in worker_dispatch
     assert "Region atlases are single regions." in worker_dispatch
-    assert "which named region each node or binding must show" in worker_dispatch
-    assert "expected named region for each single-element node" in reviewer_dispatch
+    assert "the region and its rect from that metadata by name" in worker_dispatch
+    assert "the element-to-region match is not obvious" in worker_dispatch
+    assert "region names/count" not in worker_dispatch
+    assert "the element-to-region match is not obvious" in reviewer_dispatch
 
     # Reviewer flags whole-atlas misuse as an issue.
     assert "Region atlases bind single named regions instead of the whole atlas image" in reviewer

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -281,3 +281,30 @@ def test_gdd_templates_do_not_add_weak_dynamic_visual_checks():
     assert "animation/lifecycle" not in scenes
     assert "multi-frame actors/FX" not in scenes
     assert "dynamic-mode test" not in scenes
+
+
+def test_region_atlas_single_region_contract():
+    worker = _read("agents/worker.md")
+    worker_dispatch = _read("skills/core/_shared/worker-dispatch.md")
+    reviewer_dispatch = _read("skills/core/_shared/reviewer-dispatch.md")
+    reviewer = _read("agents/reviewer.md")
+    evaluate = _read("skills/core/gm-evaluate/SKILL.md")
+
+    # Worker must select a single named region, not the whole atlas image.
+    assert "must reference its named region via `AtlasTexture`" in worker
+    assert "Do not use a whole `region_atlas` or `grid_sheet` image as one visible sprite" in worker
+
+    # Dispatch snapshots feed region info to worker and reviewer.
+    assert "bind each single-element node to its named region via AtlasTexture/region" in worker_dispatch
+    assert "Region atlases are single regions." in worker_dispatch
+    assert "which named region each node or binding must show" in worker_dispatch
+    assert "expected named region for each single-element node" in reviewer_dispatch
+
+    # Reviewer flags whole-atlas misuse as an issue.
+    assert "Region atlases bind single named regions instead of the whole atlas image" in reviewer
+    assert "Whole-atlas misuse is" in reviewer
+
+    # Evaluate covers whole-image-as-atlas/sub-image misuse via the VQA question.
+    assert "**Atlas misuse check.**" in evaluate
+    assert "the whole atlas or sheet." in evaluate
+    assert "is a `critical_issue`" in evaluate


### PR DESCRIPTION
## Summary

Extends the WOR-21 asset-runtime contract to `region_atlas` assets: a single-element node (button, icon, prop, effect sprite) must bind to its named `AtlasTexture` region instead of showing the whole packed atlas image.

## Motivation

Testing kept surfacing cases where a UI button used the entire button atlas, or an effect used the entire FX atlas, instead of the single named region. The atlas manifest and cut regions were correct — the gap was in the worker/reviewer/evaluate contracts, which only said "read atlas metadata" without requiring a single-region selection. This mirrors the `grid_sheet` contract fix landed in #75 (WOR-21), applied to the `region_atlas` side.

## Changes

- [x] `agents/worker.md` — single-element `region_atlas` nodes must use `AtlasTexture` + the metadata region `rect`; the whole `region_atlas`/`grid_sheet` image must not be used as one visible sprite. Worker resolves the matching region by name from the atlas metadata; uses the brief's named region when given, otherwise matches the element to its region by name.
- [x] `skills/core/_shared/worker-dispatch.md` — Deliverables gains a region_atlas binding item; Asset Runtime Snapshot carries only the atlas metadata path (worker resolves region + rect by name from it); a target region is named in the brief only when the element-to-region match isn't obvious. New dispatch rule 22 ("Region atlases are single regions").
- [x] `agents/reviewer.md` — Asset Usage Review gains a "single-element node binds to a named region, not the whole image" check; whole-atlas misuse is itself a review finding.
- [x] `skills/core/_shared/reviewer-dispatch.md` — Snapshot carries the same region_atlas metadata path; names the expected region only when the match isn't obvious from the binding.
- [x] `skills/core/gm-evaluate/SKILL.md` — adds an "Atlas misuse check" to the VQA question set: when a scene binds a `region_atlas` (or single-element `grid_sheet` usage), ask whether the element shows only its target region rather than the whole sheet; a whole-image-in-place-of-a-single-element is a `critical_issue`/`fail`. This is statically verifiable from a screenshot, not a dynamic/lifecycle check.
- [x] `docs/update/next.md` — user-facing Fixed entry.
- [x] `tests/test_asset_runtime_contract_docs.py` — `test_region_atlas_single_region_contract` locks the contract strings above, including that dispatch no longer enumerates `region names/count`.

No post-hoc scanner was added; the fix stays at the contract/prompt layer, consistent with #75. Region info flows by name through existing atlas metadata rather than being enumerated in dispatch snapshots, keeping build/fixgap manager context small while still allowing an explicit region name as a fallback when the element-to-region match is ambiguous.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable

```text
python -m pytest tests/test_asset_runtime_contract_docs.py -q
15 passed
```

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
