### PR TITLE
Document CLI pipeline model configuration

### DIFF
--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -10,6 +10,20 @@
 # fields.
 agent: claude-code
 
+# Optional godotmaker-cli pipeline model override.
+# The GodotMaker framework preserves this block but does not consume it;
+# godotmaker-cli owns the supported model IDs and reads these keys.
+# Leave this commented to use the selected runtime's CLI default.
+#
+# pipeline:
+#   model: <codex-model-id>
+#
+# To split build and evaluation model choices:
+#
+# pipeline:
+#   buildModel: <build-model-id>
+#   evalModel: <eval-model-id>
+
 # Visual quality assessment model.
 # Supported values:
 # - native: active agent runtime image inspection

--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -12,17 +12,11 @@ agent: claude-code
 
 # Optional godotmaker-cli pipeline model override.
 # The GodotMaker framework preserves this block but does not consume it;
-# godotmaker-cli owns the supported model IDs and reads these keys.
+# godotmaker-cli owns the supported model IDs and reads this key.
 # Leave this commented to use the selected runtime's CLI default.
 #
 # pipeline:
-#   model: <codex-model-id>
-#
-# To split build and evaluation model choices:
-#
-# pipeline:
-#   buildModel: <build-model-id>
-#   evalModel: <eval-model-id>
+#   model: <agent-model-id>
 
 # Visual quality assessment model.
 # Supported values:

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -19,6 +19,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Changed
 
+- Project config templates and docs now show where godotmaker-cli pipeline model overrides belong while leaving concrete model IDs to the CLI documentation (#81) - @Codex Worker
+
 ## Fixed
 
 ## Removed

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -19,7 +19,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Changed
 
-- Project config templates and docs now show where godotmaker-cli pipeline model overrides belong while leaving concrete model IDs to the CLI documentation (#81) - @Codex Worker
+- Project config templates and docs now show where the single godotmaker-cli pipeline model override belongs while leaving concrete model IDs to the CLI documentation (#81).
 
 ## Fixed
 

--- a/docs/wiki/06-configuration/project-config.md
+++ b/docs/wiki/06-configuration/project-config.md
@@ -10,6 +10,10 @@ Framework developers and manual-mode users can still create the same file with `
 
 ## Common fields
 
+**`pipeline.model`** - optional `godotmaker-cli` model override for automated build/evaluate stages. The GodotMaker framework preserves this value in `.godotmaker/config.yaml` but does not consume it directly; use the current model IDs documented by `godotmaker-cli` / GodotMakerApp.
+
+**`pipeline.buildModel`** and **`pipeline.evalModel`** - optional split overrides when build and evaluation should use different models. Choose both values from the current `godotmaker-cli` model documentation.
+
 **`agent`** — selected coding-agent runtime, such as `claude-code`, `codex`, or `opencode`.
 
 **`worker_model`** — which Claude model writes game code. Defaults to `sonnet`; set it to `opus` for games that need heavier implementation reasoning.
@@ -32,6 +36,10 @@ The default config looks like this:
 # Deployed to .godotmaker/config.yaml by publish script
 
 agent: claude-code
+
+# Optional godotmaker-cli pipeline model override.
+# pipeline:
+#   model: <codex-model-id>
 
 vqa_model: native
 vqa_fallback_model: native
@@ -122,6 +130,24 @@ To use OpenAI for API-backed image generation:
 
 ```yaml
 asset_image_model: openai:gpt-image-2
+```
+
+To override the Codex model used for automated pipeline stages, use the concrete
+model ID from the current `godotmaker-cli` / GodotMakerApp documentation:
+
+```yaml
+agent: codex
+pipeline:
+  model: <codex-model-id>
+```
+
+To use different Codex models for build and evaluation:
+
+```yaml
+agent: codex
+pipeline:
+  buildModel: <build-model-id>
+  evalModel: <eval-model-id>
 ```
 
 The next `/gm-*` command picks up the new value. A command already running will not see changes until the next session or stage invocation.

--- a/docs/wiki/06-configuration/project-config.md
+++ b/docs/wiki/06-configuration/project-config.md
@@ -10,9 +10,7 @@ Framework developers and manual-mode users can still create the same file with `
 
 ## Common fields
 
-**`pipeline.model`** - optional `godotmaker-cli` model override for automated build/evaluate stages. The GodotMaker framework preserves this value in `.godotmaker/config.yaml` but does not consume it directly; use the current model IDs documented by `godotmaker-cli` / GodotMakerApp.
-
-**`pipeline.buildModel`** and **`pipeline.evalModel`** - optional split overrides when build and evaluation should use different models. Choose both values from the current `godotmaker-cli` model documentation.
+**`pipeline.model`** - optional `godotmaker-cli` model override for automated build/evaluate stages. The GodotMaker framework preserves this value in `.godotmaker/config.yaml` but does not consume it directly; use a model ID supported by the selected agent runtime, as documented by `godotmaker-cli` / GodotMakerApp.
 
 **`agent`** — selected coding-agent runtime, such as `claude-code`, `codex`, or `opencode`.
 
@@ -39,7 +37,7 @@ agent: claude-code
 
 # Optional godotmaker-cli pipeline model override.
 # pipeline:
-#   model: <codex-model-id>
+#   model: <agent-model-id>
 
 vqa_model: native
 vqa_fallback_model: native
@@ -132,22 +130,14 @@ To use OpenAI for API-backed image generation:
 asset_image_model: openai:gpt-image-2
 ```
 
-To override the Codex model used for automated pipeline stages, use the concrete
-model ID from the current `godotmaker-cli` / GodotMakerApp documentation:
+To override the selected agent model used for automated pipeline stages, use a
+concrete model ID from the current `godotmaker-cli` / GodotMakerApp
+documentation:
 
 ```yaml
 agent: codex
 pipeline:
-  model: <codex-model-id>
-```
-
-To use different Codex models for build and evaluation:
-
-```yaml
-agent: codex
-pipeline:
-  buildModel: <build-model-id>
-  evalModel: <eval-model-id>
+  model: <agent-model-id>
 ```
 
 The next `/gm-*` command picks up the new value. A command already running will not see changes until the next session or stage invocation.

--- a/docs/zh/wiki/06-configuration/project-config.md
+++ b/docs/zh/wiki/06-configuration/project-config.md
@@ -8,9 +8,7 @@
 
 ## 常用字段
 
-**`pipeline.model`** — 可选的 `godotmaker-cli` 模型覆盖项，用于自动 build/evaluate 阶段。GodotMaker 框架会保留 `.godotmaker/config.yaml` 里的这个值，但不会直接消费它；请使用 `godotmaker-cli` / GodotMakerApp 文档中当前支持的模型 ID。
-
-**`pipeline.buildModel`** 和 **`pipeline.evalModel`** — 当 build 和 evaluation 需要使用不同模型时，可分别配置这两个覆盖项。两个值都应从当前 `godotmaker-cli` 模型文档中选择。
+**`pipeline.model`** — 可选的 `godotmaker-cli` 模型覆盖项，用于自动 build/evaluate 阶段。GodotMaker 框架会保留 `.godotmaker/config.yaml` 里的这个值，但不会直接消费它；请使用所选 agent runtime 支持的模型 ID，具体以 `godotmaker-cli` / GodotMakerApp 文档为准。
 
 **`agent`** — 当前项目选择的编码智能体运行时，例如 `claude-code`、`codex` 或 `opencode`。
 
@@ -34,7 +32,7 @@ agent: claude-code
 
 # 可选的 godotmaker-cli pipeline 模型覆盖项。
 # pipeline:
-#   model: <codex-model-id>
+#   model: <agent-model-id>
 
 vqa_model: native
 vqa_fallback_model: native
@@ -124,22 +122,13 @@ godotmaker-cli --agent codex
 godotmaker-cli --agent opencode
 ```
 
-覆盖自动 pipeline 阶段使用的 Codex 模型时，请使用当前 `godotmaker-cli` /
+覆盖自动 pipeline 阶段使用的所选 agent 模型时，请使用当前 `godotmaker-cli` /
 GodotMakerApp 文档中的具体模型 ID：
 
 ```yaml
 agent: codex
 pipeline:
-  model: <codex-model-id>
-```
-
-如果 build 和 evaluation 需要使用不同 Codex 模型：
-
-```yaml
-agent: codex
-pipeline:
-  buildModel: <build-model-id>
-  evalModel: <eval-model-id>
+  model: <agent-model-id>
 ```
 
 下一次运行 `/gm-*` 命令时会读取新配置。已经运行中的命令不会自动感知修改，需要下一次会话或阶段调用才会生效。

--- a/docs/zh/wiki/06-configuration/project-config.md
+++ b/docs/zh/wiki/06-configuration/project-config.md
@@ -8,6 +8,10 @@
 
 ## 常用字段
 
+**`pipeline.model`** — 可选的 `godotmaker-cli` 模型覆盖项，用于自动 build/evaluate 阶段。GodotMaker 框架会保留 `.godotmaker/config.yaml` 里的这个值，但不会直接消费它；请使用 `godotmaker-cli` / GodotMakerApp 文档中当前支持的模型 ID。
+
+**`pipeline.buildModel`** 和 **`pipeline.evalModel`** — 当 build 和 evaluation 需要使用不同模型时，可分别配置这两个覆盖项。两个值都应从当前 `godotmaker-cli` 模型文档中选择。
+
 **`agent`** — 当前项目选择的编码智能体运行时，例如 `claude-code`、`codex` 或 `opencode`。
 
 **`worker_model`** — 编写游戏代码的 Claude 模型。默认是 `sonnet`；需要更强实现推理的游戏可改为 `opus`。
@@ -27,6 +31,10 @@
 
 ```yaml
 agent: claude-code
+
+# 可选的 godotmaker-cli pipeline 模型覆盖项。
+# pipeline:
+#   model: <codex-model-id>
 
 vqa_model: native
 vqa_fallback_model: native
@@ -114,6 +122,24 @@ agent: codex
 godotmaker-cli --agent claude-code
 godotmaker-cli --agent codex
 godotmaker-cli --agent opencode
+```
+
+覆盖自动 pipeline 阶段使用的 Codex 模型时，请使用当前 `godotmaker-cli` /
+GodotMakerApp 文档中的具体模型 ID：
+
+```yaml
+agent: codex
+pipeline:
+  model: <codex-model-id>
+```
+
+如果 build 和 evaluation 需要使用不同 Codex 模型：
+
+```yaml
+agent: codex
+pipeline:
+  buildModel: <build-model-id>
+  evalModel: <eval-model-id>
 ```
 
 下一次运行 `/gm-*` 命令时会读取新配置。已经运行中的命令不会自动感知修改，需要下一次会话或阶段调用才会生效。

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -63,3 +63,16 @@ def test_skill_referenced_defaults_match_config_default():
                 f"'{default}', but config.yaml.default has '{key}: {actual}'"
             )
     assert not mismatches, "Skill default hints disagree with config:\n" + "\n".join(mismatches)
+
+
+def test_config_template_documents_cli_pipeline_model_override():
+    """The project config template must show where godotmaker-cli model
+    overrides belong without pinning downstream-owned model variants."""
+    text = CONFIG_DEFAULT.read_text(encoding="utf-8")
+    assert "godotmaker-cli pipeline model override" in text
+    assert "godotmaker-cli owns the supported model IDs" in text
+    assert "pipeline:" in text
+    assert "model: <codex-model-id>" in text
+    assert "buildModel: <build-model-id>" in text
+    assert "evalModel: <eval-model-id>" in text
+    assert "gpt-5.6" not in text

--- a/tests/test_config_consistency.py
+++ b/tests/test_config_consistency.py
@@ -72,7 +72,7 @@ def test_config_template_documents_cli_pipeline_model_override():
     assert "godotmaker-cli pipeline model override" in text
     assert "godotmaker-cli owns the supported model IDs" in text
     assert "pipeline:" in text
-    assert "model: <codex-model-id>" in text
-    assert "buildModel: <build-model-id>" in text
-    assert "evalModel: <eval-model-id>" in text
+    assert "model: <agent-model-id>" in text
+    assert "buildModel:" not in text
+    assert "evalModel:" not in text
     assert "gpt-5.6" not in text


### PR DESCRIPTION
﻿## Summary

Document the CLI pipeline model configuration entry and keep the framework template focused on the config surface it owns.

## Motivation

The project needed a clear answer for where the Codex 5.6 model setting lives and how the framework template should describe it without hardcoding downstream model IDs.

## Changes

- [x] Add a `pipeline` example to the project config template
- [x] Update the configuration docs to explain that the framework preserves the block but does not consume it
- [x] Remove hardcoded downstream model IDs from the framework-side test

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

Verified locally:
- `pytest tests/test_config_consistency.py`
- `git diff --check`

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
