### PR TITLE
Add reasoning effort config example

### DIFF
--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -18,6 +18,13 @@ agent: claude-code
 # pipeline:
 #   model: <agent-model-id>
 
+# Optional reasoning level override for the selected coding-agent runtime.
+# Leave this commented to inherit the agent/user default. Common tested values
+# include low, medium, high, and xhigh; provider-specific values may also work
+# if the selected CLI accepts them.
+#
+# reasoning_effort: high
+
 # Visual quality assessment model.
 # Supported values:
 # - native: active agent runtime image inspection

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -20,6 +20,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Changed
 
 - Project config templates and docs now show where the single godotmaker-cli pipeline model override belongs while leaving concrete model IDs to the CLI documentation (#81).
+- Added a commented `reasoning_effort` example to the default project config template for GodotMakerApp-driven pipelines.
 
 ## Fixed
 

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -661,6 +661,7 @@ class TestCreateProjectConfig:
         assert "vqa_model:" in content
         assert "vqa_fallback_model:" in content
         assert "asset_image_model:" in content
+        assert "reasoning_effort:" in content
         assert "worker_model:" in content
         assert "asset_producer_model:" in content
         assert "agent:" in content


### PR DESCRIPTION
﻿## Summary

- Add a commented `reasoning_effort` example to `config/config.yaml.default`.
- Assert that newly published project configs expose the commented field in publish tests.
- Add a release-note entry for the config template update.

## Motivation

GodotMakerApp now supports forwarding project-level `reasoning_effort` values to selected coding-agent CLIs. New GodotMaker project templates should show the opt-in config key without changing default behavior for existing users or newly published projects.

## Changes

- [x] Add a commented `reasoning_effort` example to `config/config.yaml.default`.
- [x] Update publish tests to assert the generated config includes the commented example.
- [x] Add a release-note entry in `docs/update/next.md`.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant): `python -m pytest tests/tools/test_publish.py -k "default_config_template_is_valid_yaml or creates_config_with_defaults"`
- [x] Gitleaks passes or no secret-bearing files were touched: CI Secret Scan passed.
- [x] Manual testing completed, if applicable: not applicable; this is a config template and publish-test update.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

No migration script was added or modified, so the migration upgrade gate is not applicable.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable: not applicable; no ECS systems changed.
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
