### PR TITLE
docs: add concrete README demo labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@
 <p align="center"><em>Games built with GodotMaker (click to view):</em></p>
 
 <p align="center">
-  <a href="docs/assets/demo_01.gif">Game 1</a> &nbsp;·&nbsp;
-  <a href="docs/assets/demo_02.gif">Game 2</a> &nbsp;·&nbsp;
-  <a href="docs/assets/demo_03.gif">Game 3</a>
+  <a href="docs/assets/demo_01.gif">Vertical bullet-hell shooter</a> &nbsp;·&nbsp;
+  <a href="docs/assets/demo_02.gif">Vampire Survivors-like</a> &nbsp;·&nbsp;
+  <a href="docs/assets/demo_03.gif">Roguelike deckbuilder</a>
 </p>
 
 ## Why I Built This

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -32,9 +32,9 @@
 <p align="center"><em>用 GodotMaker 制作的游戏（点击查看）：</em></p>
 
 <p align="center">
-  <a href="docs/assets/demo_01.gif">游戏 1</a> &nbsp;·&nbsp;
-  <a href="docs/assets/demo_02.gif">游戏 2</a> &nbsp;·&nbsp;
-  <a href="docs/assets/demo_03.gif">游戏 3</a>
+  <a href="docs/assets/demo_01.gif">竖版弹幕射击</a> &nbsp;·&nbsp;
+  <a href="docs/assets/demo_02.gif">吸血鬼幸存者</a> &nbsp;·&nbsp;
+  <a href="docs/assets/demo_03.gif">肉鸽卡牌</a>
 </p>
 
 ## 为什么做这个

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -21,6 +21,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - Project config templates and docs now show where the single godotmaker-cli pipeline model override belongs while leaving concrete model IDs to the CLI documentation (#81).
 - Added a commented `reasoning_effort` example to the default project config template for GodotMakerApp-driven pipelines.
+- Clarified the README demo GIF labels with concrete game-type names.
 
 ## Fixed
 


### PR DESCRIPTION
﻿## Summary

Rename the README demo GIF links from generic numbered labels to concrete game-type labels.

## Motivation

The existing demo links already point to three gameplay GIFs, but `Game 1`, `Game 2`, and `Game 3` are too vague for readers scanning the README. Concrete genre labels make the examples easier to understand without changing the demo assets.

## Changes

- [x] Rename the English demo GIF labels to `Vertical bullet-hell shooter`, `Vampire Survivors-like`, and `Roguelike deckbuilder`.
- [x] Rename the Chinese demo GIF labels to `竖版弹幕射击`, `吸血鬼幸存者`, and `肉鸽卡牌`.
- [x] Add a `docs/update/next.md` entry for the README demo label change.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
  - Docs-only change; no pytest or gdUnit4 run.
  - `git diff --check origin/main...HEAD`
- [x] Gitleaks passes or no secret-bearing files were touched
  - `gitleaks detect --source . --config .gitleaks.toml` passed with no leaks found.
- [x] Manual testing completed, if applicable
  - Reviewed the diff to confirm existing GIF links are preserved and only link text changed.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
