### PR TITLE
fix(gm-accept): always write accept role marker on idempotent re-entry

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -25,4 +25,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- gm-accept now writes the `accept` role marker on every invocation, even when `.godotmaker/current_role` already contains it, so an idempotent re-entry still performs the required FIRST ACTION write instead of substituting a read (#93).
+
 ## Removed

--- a/skills/core/gm-accept/SKILL.md
+++ b/skills/core/gm-accept/SKILL.md
@@ -15,7 +15,7 @@ You are presenting the **current tag's** completed work to the user for acceptan
 
 ## Session Setup
 
-**FIRST ACTION — before anything else:** Write `accept` to `.godotmaker/current_role`.
+**FIRST ACTION — before anything else:** Write `accept` to `.godotmaker/current_role`. Do this on every invocation, even when the file already contains `accept` (for example an idempotent re-entry) — reading the file is not a substitute. The write must actually happen and must be your first action.
 
 ## Resume Check
 


### PR DESCRIPTION
## Summary

Clarify that gm-accept must write the `accept` role marker on every invocation, including an idempotent re-entry where the file already contains `accept`.

## Motivation

An idempotent native run correctly routed to `/gm-finalize` after reading the state, but skipped the required FIRST ACTION workspace write because the existing content matched. This made the role-lock ordering contract unobservable.

## Changes

- [x] Clarify the gm-accept FIRST ACTION requirement in `skills/core/gm-accept/SKILL.md`.
- [x] Add a changelog entry in `docs/update/next.md`.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) (not applicable; wording-only Skill-contract change).
- [x] Gitleaks passes or no secret-bearing files were touched (Secret Scan check passed).
- [x] Manual testing completed, if applicable (not applicable; documentation and Skill wording only).

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable: no runtime or performance-sensitive code changed.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>` (not applicable; no migration).
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"` (not applicable; no migration).
- [ ] Post-upgrade on-disk state was inspected and matches expectations (not applicable; no migration).
- [ ] Re-running `tools/publish.py` produces no further migration changes (not applicable; no migration).
- [ ] Result attached or summarized below (not applicable; no migration).

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable; no ECS system changed)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
