### PR TITLE
fix(asset): read generated-asset runtime handoff from generated manifest

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -82,7 +82,7 @@ The lead agent provides your brief with these fields. REQUIRED fields are always
 {Known pitfalls from reviewer skills}
 
 ### Asset Runtime Snapshot                               [REQUIRED for visual tasks]
-{Final runtime asset paths from ASSETS.md or assets/manifest.json.
+{Final runtime asset paths from ASSETS.md or .godotmaker/asset-generation/manifest.json.
 Include metadata paths for grid sheets and region atlases.}
 
 ### Visual Self-Check                                  [OPTIONAL]

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -21,4 +21,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Point generated-asset runtime handoff (gm-build, gm-fixgap, worker dispatch, worker agent) at `.godotmaker/asset-generation/manifest.json` instead of the analyst's `assets/manifest.json` (#97)
+
 ## Removed

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -69,7 +69,7 @@ Agent({
 - DO NOT write files outside the project tree (system temp dirs, home directory, etc.). If you genuinely need a scratch file, create it under `.godotmaker/scratch/` (mkdir -p the directory if missing) and delete it before reporting DONE. Claude Code's own scratchpad system is gated behind a feature flag we cannot rely on, so this rule is what guarantees clean tear-down.
 
 ### Asset Runtime Snapshot                               [REQUIRED for visual tasks]
-{Copy the matching ready entries from assets/manifest.json and ASSETS.md.
+{Copy the matching ready entries from .godotmaker/asset-generation/manifest.json and ASSETS.md.
 Include: asset_id, final_path, runtime_artifact, runtime_role, target size,
 frame_count, and metadata path for `grid_sheet` or `region_atlas`.
 Use cwd-relative final paths and metadata paths.
@@ -91,7 +91,7 @@ FAILED with the missing path.}
  Include: asset row/path, runtime size, visual role, readability requirement,
  animation/lifecycle requirement when present, anchor/derivative source, and
  final runtime asset path.
- Use existing final paths from ASSETS.md or assets/manifest.json.
+ Use existing final paths from ASSETS.md or .godotmaker/asset-generation/manifest.json.
  Do not use source sheets, curation candidates, prompt files, or scene
  references as runtime assets unless ASSETS.md explicitly lists that path as
  the final asset.

--- a/skills/core/gm-build/SKILL.md
+++ b/skills/core/gm-build/SKILL.md
@@ -44,7 +44,7 @@ Apply the resume gates in this order:
 Then read context:
 - `PLAN.md` → current tag's `**Tag:**` header + Tag Mechanics + Inherited Mechanics + Playable Unit + pending/in_progress/completed tasks (anything not `verified`)
 - `STRUCTURE.md` → architecture and build order (current tag scope: previous tags' systems already exist on disk and may be touched only when PLAN.md explicitly lists a refactor task for them)
-- `ASSETS.md` and `assets/manifest.json` → final runtime asset paths, `runtime_artifact`, and runtime metadata paths for visual tasks
+- `ASSETS.md` and `.godotmaker/asset-generation/manifest.json` → final runtime asset paths, `runtime_artifact`, and runtime metadata paths for visual tasks
 - `MEMORY.md` index + sub-files (cross-tag accumulating notebook) → avoid repeating known mistakes
 - `docs/tags/<prev_tag>/STRUCTURE.md` (only if PLAN.md has Inherited Mechanics or refactor tasks touching prior systems) → know what already exists before adding/refactoring
 

--- a/skills/core/gm-fixgap/SKILL.md
+++ b/skills/core/gm-fixgap/SKILL.md
@@ -39,7 +39,7 @@ Then read context:
 - `.godotmaker/verify_report.json` → mechanical-layer failures from the most recent verify
 - `PLAN.md` → read-only; current tag's `**Tag:**` header tells you which tag's gaps you're fixing. The same tag-scope discipline as gm-build applies: previous tags' code is touchable only when a GAP item explicitly names it.
 - `STRUCTURE.md` → architecture (fixes need to respect existing system boundaries)
-- `ASSETS.md` and `assets/manifest.json` → final runtime asset paths, `runtime_artifact`, and runtime metadata paths for visual tasks
+- `ASSETS.md` and `.godotmaker/asset-generation/manifest.json` → final runtime asset paths, `runtime_artifact`, and runtime metadata paths for visual tasks
 - `MEMORY.md` index + sub-files → past decisions and known gotchas
 
 ## Hard Rules

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -221,13 +221,17 @@ def test_build_and_fixgap_handoff_runtime_assets_to_workers():
     worker = _read("agents/worker.md")
 
     for doc in (build, fixgap):
-        assert "`ASSETS.md` and `assets/manifest.json`" in doc
+        assert "`ASSETS.md` and `.godotmaker/asset-generation/manifest.json`" in doc
         assert "Asset Runtime Snapshot" in doc
 
     assert "### Asset Runtime Snapshot" in worker_dispatch
     assert "Use final runtime assets only." in worker_dispatch
     assert "`grid_sheet` or `region_atlas`" in worker_dispatch
     assert "Do not use `.godotmaker/asset-generation/sources/`" in worker_dispatch
+    # Generated-asset runtime handoff reads the generated manifest, never the
+    # analyst's user-provided-asset classification manifest.
+    assert ".godotmaker/asset-generation/manifest.json" in worker_dispatch
+    assert ".godotmaker/asset-generation/manifest.json" in worker
     assert "## Runtime Asset Rules" in worker
     assert "For `grid_sheet`, read the listed action metadata JSON" in worker
     assert "For `region_atlas`, read the listed atlas metadata JSON" in worker
@@ -281,6 +285,48 @@ def test_gdd_templates_do_not_add_weak_dynamic_visual_checks():
     assert "animation/lifecycle" not in scenes
     assert "multi-frame actors/FX" not in scenes
     assert "dynamic-mode test" not in scenes
+
+
+def test_generated_and_analyst_manifests_have_distinct_responsibilities():
+    """The two manifests must never be confused.
+
+    `.godotmaker/asset-generation/manifest.json` holds the generated-asset
+    runtime handoff data (runtime_artifact, final paths, metadata). It is the
+    only runtime source read by gm-build / gm-fixgap / worker dispatch.
+
+    `assets/manifest.json` holds the analyst's classification of user-provided
+    assets and keeps that responsibility unchanged.
+    """
+    build = _read("skills/core/gm-build/SKILL.md")
+    fixgap = _read("skills/core/gm-fixgap/SKILL.md")
+    worker_dispatch = _read("skills/core/_shared/worker-dispatch.md")
+    worker = _read("agents/worker.md")
+
+    # Runtime handoff docs point at the generated manifest, not the analyst one.
+    runtime_docs = {
+        "gm-build/SKILL.md": build,
+        "gm-fixgap/SKILL.md": fixgap,
+        "worker-dispatch.md": worker_dispatch,
+        "worker.md": worker,
+    }
+    for name, doc in runtime_docs.items():
+        assert (
+            ".godotmaker/asset-generation/manifest.json" in doc
+        ), f"{name} must read generated runtime data from the generated manifest"
+
+    # Regression guard: runtime handoff docs must not name the analyst's
+    # user-asset manifest (`assets/manifest.json`) as a runtime source.
+    for name, doc in runtime_docs.items():
+        assert "assets/manifest.json" not in doc, (
+            f"{name} must not name the analyst manifest as a runtime source"
+        )
+
+    # The analyst manifest keeps its distinct user-asset classification role.
+    analyst = _read("agents/analyst.md")
+    analyst_dispatch = _read("skills/core/_shared/analyst-dispatch.md")
+    assert "assets/manifest.json" in analyst
+    assert "user-provided" in analyst_dispatch or "user-provided" in analyst
+    assert "assets/manifest.json" in analyst_dispatch
 
 
 def test_region_atlas_single_region_contract():


### PR DESCRIPTION
## Summary

Fix the generated-asset manifest data-source reference error: `gm-build`,
`gm-fixgap`, the worker dispatch protocol, and the worker agent now read
runtime asset handoff data (final paths, `runtime_artifact`, metadata) from
`.godotmaker/asset-generation/manifest.json` instead of the analyst's
`assets/manifest.json`.

## Motivation

`assets/manifest.json` classifies user-provided assets (written by the
analyst) and has a different schema/responsibility from the generated-asset
handoff manifest at `.godotmaker/asset-generation/manifest.json` (written by
`gm-asset`'s `asset_generation_manifest_update.py`). Several contract docs
incorrectly described the generated-asset runtime data as coming from
`assets/manifest.json`, causing downstream stages to read the wrong file.

Related Multica issue: WOR-187.

## Changes

- [x] `skills/core/gm-build/SKILL.md`, `skills/core/gm-fixgap/SKILL.md`: context-read references point at the generated-asset manifest
- [x] `skills/core/_shared/worker-dispatch.md`: `Asset Runtime Snapshot` and `Visual Asset Contract` point at the generated-asset manifest
- [x] `agents/worker.md`: `Asset Runtime Snapshot` points at the generated-asset manifest
- [x] `tests/test_asset_runtime_contract_docs.py`: corrected the handoff assertion, added `test_generated_and_analyst_manifests_have_distinct_responsibilities` (fails if the runtime-source reference regresses to `assets/manifest.json`)
- [x] `docs/update/next.md`: changelog entry added

`assets/manifest.json`'s analyst/user-asset-classification role, schema, and
usage (analyst agent/dispatch, GDD/decomposer manifest-path context, TOC)
are unchanged. Out of scope (tracked separately, WOR-188/189): a
`manifest_entry` resolver, `ASSETS.md` pointer format changes, Asset Runtime
Snapshot auto-generation, and SpriteFrames/AtlasTexture/Theme compilers.
This is a v1.0.0 breaking contract change — no migration, compat reader, or
dual-read fallback was added, by design.

## Testing

- [x] New or updated tests pass (`pytest`) — `tests/test_asset_runtime_contract_docs.py`: 16 passed; full suite `python -m pytest tests/`: 1084 passed
- [x] Gitleaks passes or no secret-bearing files were touched — CI `Secret Scan` check green
- [ ] Manual testing completed, if applicable — N/A, documentation/contract-only change

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed

This PR only changes contract *documentation* (which manifest path each doc
points to) and a contract test; it does not change any manifest schema,
runtime file layout, or config key, so no target-project migration applies.

### Migration Upgrade Gate

N/A — no migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — N/A, no ECS systems touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
