### PR TITLE
feat(assets): define standalone asset-skill contract

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,7 +17,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
-- Add the standalone asset-skill invocation and result contract under `skills/assets/_shared/`, with declarative JSON schemas, valid samples, a dependency-free checker, and fail-closed tests (WOR-196) — @worker_claude_opus_4_8
+- Added a standalone asset-skill invocation and result contract under `skills/assets/_shared/` with declarative JSON schemas, valid samples, a dependency-free checker, and fail-closed tests (#98).
 
 ## Changed
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,6 +17,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
+- Add the standalone asset-skill invocation and result contract under `skills/assets/_shared/`, with declarative JSON schemas, valid samples, a dependency-free checker, and fail-closed tests (WOR-196) — @worker_claude_opus_4_8
+
 ## Changed
 
 ## Fixed

--- a/skills/assets/_shared/asset-skill-contract.md
+++ b/skills/assets/_shared/asset-skill-contract.md
@@ -37,8 +37,17 @@ a leaked pipeline field fails closed.
 
 The JSON Schema files are the canonical declarative contract. The checker is a
 dependency-free implementation of the identical rules so validation can run at
-runtime (schema/L0) inside a game project without a `jsonschema` dependency. A
-parity test keeps the two in sync.
+runtime (schema/L0) inside a game project without a `jsonschema` dependency. The
+two are semantically equivalent — a document is accepted by the JSON Schema if
+and only if it is accepted by the checker. A bidirectional parity test enforces
+this on a shared battery of valid and invalid documents.
+
+Two rules go beyond plain field structure, and both enforcers encode them:
+
+- every required string is non-empty after trimming whitespace (a whitespace-only
+  value is rejected);
+- a runtime output `path` must be `res://` followed by a relative resource path,
+  so bare `res://` and `res:///` are rejected.
 
 `_shared/` holds cross-skill contract material only. It has no `SKILL.md` and is
 not independently triggerable.
@@ -108,7 +117,7 @@ output into its own stable entry with one primary `godot_artifact`.
 | Field | Required | Type | Rule |
 |---|---|---|---|
 | `role` | yes | string | `runtime` or `reference` |
-| `path` | yes | string | Non-empty; a `runtime` path must be a loadable `res://` path |
+| `path` | yes | string | Non-empty; a `runtime` path must be `res://` followed by a relative resource path (bare `res://` / `res:///` are rejected) |
 | `godot_type` | runtime only | string | Godot ClassDB type, `^[A-Z][A-Za-z0-9]+$` (open, not a closed enum) |
 | `name` | no | string | Optional logical label to disambiguate multiple outputs |
 

--- a/skills/assets/_shared/asset-skill-contract.md
+++ b/skills/assets/_shared/asset-skill-contract.md
@@ -40,7 +40,9 @@ dependency-free implementation of the identical rules so validation can run at
 runtime (schema/L0) inside a game project without a `jsonschema` dependency. The
 two are semantically equivalent — a document is accepted by the JSON Schema if
 and only if it is accepted by the checker. A bidirectional parity test enforces
-this on a shared battery of valid and invalid documents.
+this on a shared battery of valid and invalid documents. The checker fails
+closed: any malformed input — including a wrong JSON type on an enum field —
+becomes a single `AssetContractError`, never an uncaught exception.
 
 These rules go beyond plain field structure, and both enforcers encode them:
 

--- a/skills/assets/_shared/asset-skill-contract.md
+++ b/skills/assets/_shared/asset-skill-contract.md
@@ -1,0 +1,146 @@
+# Asset Skill Contract
+
+The single source of truth for how any first-class asset skill is invoked and
+what it returns. Every asset skill under `skills/assets/<family>/` accepts an
+**asset request** and returns an **asset result** that matches this contract,
+regardless of who calls it.
+
+A user may invoke an asset skill directly. `/gm-asset` invokes the same skill in
+exactly the same way and then registers the returned result into project
+manifests and stage state. There is no separate "gm mode" inside an asset skill.
+
+## Independence
+
+An asset skill knows nothing about the project pipeline. Neither the request nor
+the result may carry, and the skill must not read:
+
+- `/gm-asset` or any pipeline orchestration;
+- tags, stage state, or `ROADMAP.md`;
+- `ASSETS.md`;
+- `assets/manifest.json` or `.godotmaker/asset-generation/manifest.json`;
+- manifest registration, stable entries, or worker dispatch.
+
+Registration concepts — `tag`, `stage`, `manifest_entry`, `godot_artifact`,
+`source_layout`, `processing_status` — belong to `/gm-asset` and the stable-entry
+schema, never to this contract. The schemas set `additionalProperties: false`, so
+a leaked pipeline field fails closed.
+
+## Files
+
+| File | Role |
+|---|---|
+| `schema/asset-skill-request.schema.json` | Canonical declarative schema for the request |
+| `schema/asset-skill-result.schema.json` | Canonical declarative schema for the result |
+| `samples/request/*.json` | Valid request examples |
+| `samples/result/*.json` | Valid result examples |
+| `tools/asset_skill_contract_check.py` | Dependency-free enforcement of the same rules (runtime L0 + CI) |
+
+The JSON Schema files are the canonical declarative contract. The checker is a
+dependency-free implementation of the identical rules so validation can run at
+runtime (schema/L0) inside a game project without a `jsonschema` dependency. A
+parity test keeps the two in sync.
+
+`_shared/` holds cross-skill contract material only. It has no `SKILL.md` and is
+not independently triggerable.
+
+## Request
+
+```json
+{
+  "asset_type": "character-bundle",
+  "asset_id": "player",
+  "brief": "A small pixel-art knight with idle and run actions, side view.",
+  "references": [
+    { "role": "canonical", "path": "res://references/player_canonical.png" }
+  ],
+  "provider": "native",
+  "spec": {}
+}
+```
+
+| Field | Required | Type | Rule |
+|---|---|---|---|
+| `asset_type` | yes | string | One of the known production families (see below) |
+| `asset_id` | yes | string | Stable logical id, `^[a-z0-9][a-z0-9_-]*$` |
+| `brief` | yes | string | Non-empty natural-language description of the asset to produce |
+| `references` | no | array | Visible reference images; each `{ role, path }` |
+| `provider` | no | string | Image provider hint: `native`, `codex`, `gemini`, `openai` |
+| `spec` | no | object | Family-specific structured parameters; inner shape owned by each family skill |
+
+`references[].role` is one of `canonical`, `style`, `screen`. `references[].path`
+is a non-empty string.
+
+## Result
+
+```json
+{
+  "asset_type": "character-bundle",
+  "outputs": [
+    {
+      "role": "runtime",
+      "name": "player",
+      "path": "res://assets/generated/character-bundle/player/player.tres",
+      "godot_type": "SpriteFrames"
+    }
+  ],
+  "sources": [
+    {
+      "path": "res://assets/generated/character-bundle/player/player.png",
+      "layout": "grid_sheet"
+    }
+  ],
+  "previews": [],
+  "validation": { "passed": true }
+}
+```
+
+The result stably contains `asset_type`, `outputs`, `sources`, `previews`, and
+`validation`. All five keys are always present; `sources` and `previews` may be
+empty arrays.
+
+### outputs
+
+`outputs` has at least one entry. One invocation may return multiple logical
+outputs (for example a `Theme` plus a `StyleBoxTexture`, or several actors);
+each is a separate entry, and `/gm-asset` registration turns each `runtime`
+output into its own stable entry with one primary `godot_artifact`.
+
+| Field | Required | Type | Rule |
+|---|---|---|---|
+| `role` | yes | string | `runtime` or `reference` |
+| `path` | yes | string | Non-empty; a `runtime` path must be a loadable `res://` path |
+| `godot_type` | runtime only | string | Godot ClassDB type, `^[A-Z][A-Za-z0-9]+$` (open, not a closed enum) |
+| `name` | no | string | Optional logical label to disambiguate multiple outputs |
+
+- `runtime` outputs are worker-consumable native Godot resources. `godot_type` is
+  a Godot ClassDB type name (`SpriteFrames`, `AtlasTexture`, `Theme`,
+  `StyleBoxTexture`, `TileSet`, `Texture2D`, …); it is validated for shape, not
+  against a closed list.
+- `reference` outputs are visual references such as a screen reference. They are
+  not handed to workers as runtime game assets and do not require a `godot_type`.
+
+### sources
+
+Raw generated or claimed source images the outputs were compiled from. Each
+entry is `{ path, layout? }`. `layout` describes pixel organization and is one of
+`single`, `grid_sheet`, `region_atlas`, `action_frames`, `theme_recipe`,
+`tile_atlas`. `sources` may be empty (for example a reference-only result).
+
+### previews
+
+Optional preview or inspection images, each `{ path, label? }`. Previews are for
+human or later curation review, never a runtime handoff. `previews` may be empty.
+
+### validation
+
+`{ passed: bool, levels?, notes? }`. `levels` is an optional map of `L0`–`L4`
+booleans. When `passed` is `true` and `levels` is present, every provided level
+must be `true` — a passed result may not report a failed level.
+
+## Production families
+
+`asset_type` is one of:
+
+`background-map`, `character-bundle`, `fx-bundle`, `ui-kit`, `card-kit`,
+`compact-prop-pack`, `platform-strip`, `scene-prop-set`, `screen-reference`,
+`tileset`.

--- a/skills/assets/_shared/asset-skill-contract.md
+++ b/skills/assets/_shared/asset-skill-contract.md
@@ -42,12 +42,15 @@ two are semantically equivalent — a document is accepted by the JSON Schema if
 and only if it is accepted by the checker. A bidirectional parity test enforces
 this on a shared battery of valid and invalid documents.
 
-Two rules go beyond plain field structure, and both enforcers encode them:
+These rules go beyond plain field structure, and both enforcers encode them:
 
 - every required string is non-empty after trimming whitespace (a whitespace-only
   value is rejected);
-- a runtime output `path` must be `res://` followed by a relative resource path,
-  so bare `res://` and `res:///` are rejected.
+- an optional field is either omitted or a value of its declared type — an
+  explicit `null` is a wrong-typed value and is rejected, not treated as absent;
+- a runtime output `path` must be `res://` followed by a relative resource path
+  of one or more non-empty segments, and no segment may be `.` or `..`. Bare
+  `res://`, `res:///`, `res://.`, and `res://../outside.tres` are all rejected.
 
 `_shared/` holds cross-skill contract material only. It has no `SKILL.md` and is
 not independently triggerable.
@@ -117,7 +120,7 @@ output into its own stable entry with one primary `godot_artifact`.
 | Field | Required | Type | Rule |
 |---|---|---|---|
 | `role` | yes | string | `runtime` or `reference` |
-| `path` | yes | string | Non-empty; a `runtime` path must be `res://` followed by a relative resource path (bare `res://` / `res:///` are rejected) |
+| `path` | yes | string | Non-empty; a `runtime` path must be `res://` followed by a relative resource path with no `.`/`..` segment (bare `res://`, `res:///`, `res://.`, `res://../x` are rejected) |
 | `godot_type` | runtime only | string | Godot ClassDB type, `^[A-Z][A-Za-z0-9]+$` (open, not a closed enum) |
 | `name` | no | string | Optional logical label to disambiguate multiple outputs |
 

--- a/skills/assets/_shared/samples/request/character-bundle.json
+++ b/skills/assets/_shared/samples/request/character-bundle.json
@@ -1,0 +1,14 @@
+{
+  "asset_type": "character-bundle",
+  "asset_id": "player",
+  "brief": "A small pixel-art knight with idle and run actions, side view, transparent background.",
+  "references": [
+    { "role": "canonical", "path": "res://references/player_canonical.png" },
+    { "role": "style", "path": "res://references/style_seed.png" }
+  ],
+  "provider": "native",
+  "spec": {
+    "actions": ["idle", "run"],
+    "fps": 8
+  }
+}

--- a/skills/assets/_shared/samples/request/screen-reference.json
+++ b/skills/assets/_shared/samples/request/screen-reference.json
@@ -1,0 +1,5 @@
+{
+  "asset_type": "screen-reference",
+  "asset_id": "main_menu",
+  "brief": "A cozy fantasy main-menu screen reference: title banner, three stacked buttons, parchment panel."
+}

--- a/skills/assets/_shared/samples/result/character-bundle.json
+++ b/skills/assets/_shared/samples/result/character-bundle.json
@@ -1,0 +1,24 @@
+{
+  "asset_type": "character-bundle",
+  "outputs": [
+    {
+      "role": "runtime",
+      "name": "player",
+      "path": "res://assets/generated/character-bundle/player/player.tres",
+      "godot_type": "SpriteFrames"
+    }
+  ],
+  "sources": [
+    {
+      "path": "res://assets/generated/character-bundle/player/player.png",
+      "layout": "grid_sheet"
+    }
+  ],
+  "previews": [
+    { "path": "res://assets/generated/character-bundle/player/preview_idle.png", "label": "idle" }
+  ],
+  "validation": {
+    "passed": true,
+    "levels": { "L0": true, "L1": true, "L2": true, "L3": true, "L4": true }
+  }
+}

--- a/skills/assets/_shared/samples/result/screen-reference.json
+++ b/skills/assets/_shared/samples/result/screen-reference.json
@@ -1,0 +1,16 @@
+{
+  "asset_type": "screen-reference",
+  "outputs": [
+    {
+      "role": "reference",
+      "name": "main_menu",
+      "path": "references/scene_main_menu.png"
+    }
+  ],
+  "sources": [],
+  "previews": [],
+  "validation": {
+    "passed": true,
+    "levels": { "L0": true, "L1": true }
+  }
+}

--- a/skills/assets/_shared/samples/result/tileset.json
+++ b/skills/assets/_shared/samples/result/tileset.json
@@ -1,0 +1,20 @@
+{
+  "asset_type": "tileset",
+  "outputs": [
+    {
+      "role": "runtime",
+      "path": "res://assets/generated/tileset/grassland/grassland.tres",
+      "godot_type": "TileSet"
+    }
+  ],
+  "sources": [
+    {
+      "path": "res://assets/generated/tileset/grassland/grassland_atlas.png",
+      "layout": "tile_atlas"
+    }
+  ],
+  "previews": [],
+  "validation": {
+    "passed": true
+  }
+}

--- a/skills/assets/_shared/samples/result/ui-kit-multi-output.json
+++ b/skills/assets/_shared/samples/result/ui-kit-multi-output.json
@@ -1,0 +1,27 @@
+{
+  "asset_type": "ui-kit",
+  "outputs": [
+    {
+      "role": "runtime",
+      "name": "main_theme",
+      "path": "res://assets/generated/ui-kit/main/main_theme.tres",
+      "godot_type": "Theme"
+    },
+    {
+      "role": "runtime",
+      "name": "panel_stylebox",
+      "path": "res://assets/generated/ui-kit/main/panel_stylebox.tres",
+      "godot_type": "StyleBoxTexture"
+    }
+  ],
+  "sources": [
+    { "path": "res://assets/generated/ui-kit/main/theme_recipe.json", "layout": "theme_recipe" },
+    { "path": "res://assets/generated/ui-kit/main/panel_atlas.png", "layout": "region_atlas" }
+  ],
+  "previews": [
+    { "path": "res://assets/generated/ui-kit/main/preview.png" }
+  ],
+  "validation": {
+    "passed": true
+  }
+}

--- a/skills/assets/_shared/schema/asset-skill-request.schema.json
+++ b/skills/assets/_shared/schema/asset-skill-request.schema.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/RandallLiuXin/GodotMaker/skills/assets/_shared/schema/asset-skill-request.schema.json",
+  "title": "Asset Skill Request",
+  "description": "Unified invocation contract for any first-class asset skill. Carries no pipeline, tag, stage, or manifest state.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["asset_type", "asset_id", "brief"],
+  "properties": {
+    "asset_type": {
+      "type": "string",
+      "enum": [
+        "background-map",
+        "character-bundle",
+        "fx-bundle",
+        "ui-kit",
+        "card-kit",
+        "compact-prop-pack",
+        "platform-strip",
+        "scene-prop-set",
+        "screen-reference",
+        "tileset"
+      ]
+    },
+    "asset_id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9_-]*$"
+    },
+    "brief": {
+      "type": "string",
+      "minLength": 1
+    },
+    "references": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["role", "path"],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": ["canonical", "style", "screen"]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "provider": {
+      "type": "string",
+      "enum": ["native", "codex", "gemini", "openai"]
+    },
+    "spec": {
+      "type": "object"
+    }
+  }
+}

--- a/skills/assets/_shared/schema/asset-skill-request.schema.json
+++ b/skills/assets/_shared/schema/asset-skill-request.schema.json
@@ -28,7 +28,7 @@
     },
     "brief": {
       "type": "string",
-      "minLength": 1
+      "pattern": "\\S"
     },
     "references": {
       "type": "array",
@@ -43,7 +43,7 @@
           },
           "path": {
             "type": "string",
-            "minLength": 1
+            "pattern": "\\S"
           }
         }
       }

--- a/skills/assets/_shared/schema/asset-skill-result.schema.json
+++ b/skills/assets/_shared/schema/asset-skill-result.schema.json
@@ -36,7 +36,7 @@
           },
           "path": {
             "type": "string",
-            "minLength": 1
+            "pattern": "\\S"
           },
           "godot_type": {
             "type": "string",
@@ -44,7 +44,7 @@
           },
           "name": {
             "type": "string",
-            "minLength": 1
+            "pattern": "\\S"
           }
         },
         "allOf": [
@@ -55,7 +55,7 @@
             "then": {
               "required": ["godot_type"],
               "properties": {
-                "path": { "pattern": "^res://" }
+                "path": { "pattern": "^res://[^/\\s]\\S*$" }
               }
             }
           }
@@ -71,7 +71,7 @@
         "properties": {
           "path": {
             "type": "string",
-            "minLength": 1
+            "pattern": "\\S"
           },
           "layout": {
             "type": "string",
@@ -96,11 +96,11 @@
         "properties": {
           "path": {
             "type": "string",
-            "minLength": 1
+            "pattern": "\\S"
           },
           "label": {
             "type": "string",
-            "minLength": 1
+            "pattern": "\\S"
           }
         }
       }
@@ -127,7 +127,28 @@
         "notes": {
           "type": "string"
         }
-      }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": { "passed": { "const": true } },
+            "required": ["passed"]
+          },
+          "then": {
+            "properties": {
+              "levels": {
+                "properties": {
+                  "L0": { "const": true },
+                  "L1": { "const": true },
+                  "L2": { "const": true },
+                  "L3": { "const": true },
+                  "L4": { "const": true }
+                }
+              }
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/skills/assets/_shared/schema/asset-skill-result.schema.json
+++ b/skills/assets/_shared/schema/asset-skill-result.schema.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/RandallLiuXin/GodotMaker/skills/assets/_shared/schema/asset-skill-result.schema.json",
+  "title": "Asset Skill Result",
+  "description": "Unified result contract returned by any first-class asset skill. Carries no pipeline, tag, stage, or registration state.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["asset_type", "outputs", "sources", "previews", "validation"],
+  "properties": {
+    "asset_type": {
+      "type": "string",
+      "enum": [
+        "background-map",
+        "character-bundle",
+        "fx-bundle",
+        "ui-kit",
+        "card-kit",
+        "compact-prop-pack",
+        "platform-strip",
+        "scene-prop-set",
+        "screen-reference",
+        "tileset"
+      ]
+    },
+    "outputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["role", "path"],
+        "properties": {
+          "role": {
+            "type": "string",
+            "enum": ["runtime", "reference"]
+          },
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "godot_type": {
+            "type": "string",
+            "pattern": "^[A-Z][A-Za-z0-9]+$"
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": { "role": { "const": "runtime" } }
+            },
+            "then": {
+              "required": ["godot_type"],
+              "properties": {
+                "path": { "pattern": "^res://" }
+              }
+            }
+          }
+        ]
+      }
+    },
+    "sources": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "layout": {
+            "type": "string",
+            "enum": [
+              "single",
+              "grid_sheet",
+              "region_atlas",
+              "action_frames",
+              "theme_recipe",
+              "tile_atlas"
+            ]
+          }
+        }
+      }
+    },
+    "previews": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path"],
+        "properties": {
+          "path": {
+            "type": "string",
+            "minLength": 1
+          },
+          "label": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "validation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["passed"],
+      "properties": {
+        "passed": {
+          "type": "boolean"
+        },
+        "levels": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "L0": { "type": "boolean" },
+            "L1": { "type": "boolean" },
+            "L2": { "type": "boolean" },
+            "L3": { "type": "boolean" },
+            "L4": { "type": "boolean" }
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/skills/assets/_shared/schema/asset-skill-result.schema.json
+++ b/skills/assets/_shared/schema/asset-skill-result.schema.json
@@ -55,7 +55,7 @@
             "then": {
               "required": ["godot_type"],
               "properties": {
-                "path": { "pattern": "^res://[^/\\s]\\S*$" }
+                "path": { "pattern": "^res://(?!\\.\\.?(?:/|$))[^/\\s]+(?:/(?!\\.\\.?(?:/|$))[^/\\s]+)*$" }
               }
             }
           }

--- a/tests/test_asset_skill_contract_docs.py
+++ b/tests/test_asset_skill_contract_docs.py
@@ -196,6 +196,11 @@ def _result_parity_cases():
         ("bad-godot_type", _with(base, lambda d: d["outputs"][0].update(godot_type="spriteFrames")), False),
         ("bad-role", _with(base, lambda d: d["outputs"][0].update(role="preview")), False),
         ("bad-source-layout", _with(base, lambda d: d["sources"][0].update(layout="mosaic")), False),
+        # --- invalid: non-scalar values on enum fields (must not crash) ---
+        ("role-list", _with(base, lambda d: d["outputs"][0].update(role=[])), False),
+        ("role-dict", _with(base, lambda d: d["outputs"][0].update(role={})), False),
+        ("layout-list", _with(base, lambda d: d["sources"][0].update(layout=[])), False),
+        ("layout-dict", _with(base, lambda d: d["sources"][0].update(layout={})), False),
         ("unknown-output-key", _with(base, lambda d: d["outputs"][0].update(z=1)), False),
         ("unknown-top-key", _with(base, lambda d: d.update(extra=1)), False),
         ("forbidden-tag", _with(base, lambda d: d.update(tag="v0.1.0")), False),
@@ -245,6 +250,13 @@ def _request_parity_cases():
         ("null-references", _with(base, lambda d: d.update(references=None)), False),
         ("null-provider", _with(base, lambda d: d.update(provider=None)), False),
         ("null-spec", _with(base, lambda d: d.update(spec=None)), False),
+        ("provider-list", _with(base, lambda d: d.update(provider=[])), False),
+        ("provider-dict", _with(base, lambda d: d.update(provider={})), False),
+        (
+            "reference-role-list",
+            _with(base, lambda d: d.update(references=[{"role": [], "path": "x"}])),
+            False,
+        ),
     ]
 
 

--- a/tests/test_asset_skill_contract_docs.py
+++ b/tests/test_asset_skill_contract_docs.py
@@ -1,0 +1,113 @@
+"""Structural and parity checks for the standalone asset-skill contract.
+
+The declarative JSON Schema under `skills/assets/_shared/schema/` is the
+canonical contract. `tools/asset_skill_contract_check.py` is a dependency-free
+implementation of the same rules. These tests assert the two agree and that the
+`_shared/` contract material is shaped correctly.
+"""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
+SCHEMA_DIR = SHARED_DIR / "schema"
+SAMPLES_DIR = SHARED_DIR / "samples"
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from asset_skill_contract_check import (  # noqa: E402
+    ASSET_TYPES,
+    OUTPUT_ROLES,
+    PROVIDERS,
+    REFERENCE_ROLES,
+    SOURCE_LAYOUTS,
+    VALIDATION_LEVELS,
+)
+
+
+def _read_json(path: Path):
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def test_shared_has_no_skill_md():
+    # _shared holds cross-skill contract material and is not triggerable.
+    assert not (SHARED_DIR / "SKILL.md").exists()
+
+
+def test_contract_doc_documents_the_result_keys():
+    doc = (SHARED_DIR / "asset-skill-contract.md").read_text(encoding="utf-8")
+    for key in ("asset_type", "outputs", "sources", "previews", "validation"):
+        assert key in doc
+    for field in ("role", "path", "godot_type"):
+        assert field in doc
+    assert "There is no separate \"gm mode\"" in doc
+    assert "additionalProperties" in doc
+    # Independence: the doc names the pipeline state a skill must not read.
+    for forbidden in ("ASSETS.md", "manifest", "tag", "stage state"):
+        assert forbidden in doc
+
+
+def test_schema_files_are_valid_json_with_no_additional_properties():
+    request_schema = _read_json(SCHEMA_DIR / "asset-skill-request.schema.json")
+    result_schema = _read_json(SCHEMA_DIR / "asset-skill-result.schema.json")
+    assert request_schema["additionalProperties"] is False
+    assert result_schema["additionalProperties"] is False
+    assert result_schema["required"] == [
+        "asset_type",
+        "outputs",
+        "sources",
+        "previews",
+        "validation",
+    ]
+    assert result_schema["properties"]["outputs"]["minItems"] == 1
+
+
+def test_schema_enums_match_validator_constants():
+    request_schema = _read_json(SCHEMA_DIR / "asset-skill-request.schema.json")
+    result_schema = _read_json(SCHEMA_DIR / "asset-skill-result.schema.json")
+    props = request_schema["properties"]
+    rprops = result_schema["properties"]
+
+    assert set(props["asset_type"]["enum"]) == ASSET_TYPES
+    assert set(rprops["asset_type"]["enum"]) == ASSET_TYPES
+    assert set(props["references"]["items"]["properties"]["role"]["enum"]) == REFERENCE_ROLES
+    assert set(props["provider"]["enum"]) == PROVIDERS
+    assert set(rprops["outputs"]["items"]["properties"]["role"]["enum"]) == OUTPUT_ROLES
+    assert set(rprops["sources"]["items"]["properties"]["layout"]["enum"]) == SOURCE_LAYOUTS
+    assert set(rprops["validation"]["properties"]["levels"]["properties"]) == VALIDATION_LEVELS
+
+
+def test_samples_validate_against_declarative_schema():
+    jsonschema = pytest.importorskip("jsonschema")
+    request_schema = _read_json(SCHEMA_DIR / "asset-skill-request.schema.json")
+    result_schema = _read_json(SCHEMA_DIR / "asset-skill-result.schema.json")
+
+    for sample in sorted((SAMPLES_DIR / "request").glob("*.json")):
+        jsonschema.validate(_read_json(sample), request_schema)
+    for sample in sorted((SAMPLES_DIR / "result").glob("*.json")):
+        jsonschema.validate(_read_json(sample), result_schema)
+
+
+def test_declarative_schema_rejects_representative_invalids():
+    jsonschema = pytest.importorskip("jsonschema")
+    result_schema = _read_json(SCHEMA_DIR / "asset-skill-result.schema.json")
+
+    base = _read_json(SAMPLES_DIR / "result" / "character-bundle.json")
+
+    invalids = [
+        {**base, "outputs": []},
+        {**base, "extra": 1},
+        {**base, "runtime_artifact": "single"},
+        {
+            **base,
+            "outputs": [
+                {"role": "runtime", "path": "assets/x.tres", "godot_type": "Texture2D"}
+            ],
+        },
+        {**base, "outputs": [{"role": "runtime", "path": "res://x.tres"}]},
+    ]
+    for invalid in invalids:
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(invalid, result_schema)

--- a/tests/test_asset_skill_contract_docs.py
+++ b/tests/test_asset_skill_contract_docs.py
@@ -90,24 +90,156 @@ def test_samples_validate_against_declarative_schema():
         jsonschema.validate(_read_json(sample), result_schema)
 
 
-def test_declarative_schema_rejects_representative_invalids():
-    jsonschema = pytest.importorskip("jsonschema")
-    result_schema = _read_json(SCHEMA_DIR / "asset-skill-result.schema.json")
+def _result_base():
+    return {
+        "asset_type": "character-bundle",
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": "player",
+                "path": "res://assets/generated/character-bundle/player/player.tres",
+                "godot_type": "SpriteFrames",
+            }
+        ],
+        "sources": [{"path": "res://assets/generated/x.png", "layout": "grid_sheet"}],
+        "previews": [{"path": "res://assets/generated/x.png", "label": "idle"}],
+        "validation": {"passed": True},
+    }
 
-    base = _read_json(SAMPLES_DIR / "result" / "character-bundle.json")
 
-    invalids = [
-        {**base, "outputs": []},
-        {**base, "extra": 1},
-        {**base, "runtime_artifact": "single"},
-        {
-            **base,
-            "outputs": [
-                {"role": "runtime", "path": "assets/x.tres", "godot_type": "Texture2D"}
-            ],
-        },
-        {**base, "outputs": [{"role": "runtime", "path": "res://x.tres"}]},
+def _with(base, mutate):
+    doc = json.loads(json.dumps(base))
+    mutate(doc)
+    return doc
+
+
+# (label, doc, expected_valid). The declarative schema and the checker must
+# reach the SAME verdict on every row — both directions, valid and invalid.
+def _result_parity_cases():
+    base = _result_base()
+    ref_only = {
+        "asset_type": "screen-reference",
+        "outputs": [{"role": "reference", "path": "references/scene_main.png"}],
+        "sources": [],
+        "previews": [],
+        "validation": {"passed": True, "levels": {"L0": True, "L1": True}},
+    }
+    return [
+        ("valid-base", base, True),
+        ("valid-reference-only", ref_only, True),
+        (
+            "valid-all-levels-true",
+            _with(base, lambda d: d["validation"].update(
+                levels={"L0": True, "L1": True, "L2": True, "L3": True, "L4": True}
+            )),
+            True,
+        ),
+        (
+            "valid-levels-subset-true",
+            _with(base, lambda d: d["validation"].update(levels={"L0": True})),
+            True,
+        ),
+        (
+            "valid-passed-false-level-false",
+            _with(base, lambda d: d.update(
+                validation={"passed": False, "levels": {"L0": False}}
+            )),
+            True,
+        ),
+        (
+            "valid-multi-runtime",
+            _with(base, lambda d: d["outputs"].append(
+                {"role": "runtime", "path": "res://a/b.tres", "godot_type": "Texture2D"}
+            )),
+            True,
+        ),
+        # --- invalid: the two P1 drift/weakness cases the reviewer flagged ---
+        (
+            "passed-true-level-false",
+            _with(base, lambda d: d.update(
+                validation={"passed": True, "levels": {"L0": False}}
+            )),
+            False,
+        ),
+        ("bare-res", _with(base, lambda d: d["outputs"][0].update(path="res://")), False),
+        ("triple-slash-res", _with(base, lambda d: d["outputs"][0].update(path="res:///")), False),
+        # --- invalid: whitespace-only strings ---
+        ("whitespace-output-path", _with(base, lambda d: d["outputs"][0].update(path="  ")), False),
+        ("whitespace-output-name", _with(base, lambda d: d["outputs"][0].update(name="  ")), False),
+        ("whitespace-source-path", _with(base, lambda d: d["sources"][0].update(path="  ")), False),
+        ("whitespace-preview-label", _with(base, lambda d: d["previews"][0].update(label="  ")), False),
+        # --- invalid: structural / enum / forbidden ---
+        ("empty-outputs", _with(base, lambda d: d.update(outputs=[])), False),
+        ("non-res-runtime", _with(base, lambda d: d["outputs"][0].update(path="assets/x.tres")), False),
+        ("missing-godot_type", _with(base, lambda d: d["outputs"][0].pop("godot_type")), False),
+        ("bad-godot_type", _with(base, lambda d: d["outputs"][0].update(godot_type="spriteFrames")), False),
+        ("bad-role", _with(base, lambda d: d["outputs"][0].update(role="preview")), False),
+        ("bad-source-layout", _with(base, lambda d: d["sources"][0].update(layout="mosaic")), False),
+        ("unknown-output-key", _with(base, lambda d: d["outputs"][0].update(z=1)), False),
+        ("unknown-top-key", _with(base, lambda d: d.update(extra=1)), False),
+        ("forbidden-tag", _with(base, lambda d: d.update(tag="v0.1.0")), False),
+        ("forbidden-runtime_artifact", _with(base, lambda d: d.update(runtime_artifact="single")), False),
+        ("unknown-asset_type", _with(base, lambda d: d.update(asset_type="sprite")), False),
     ]
-    for invalid in invalids:
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(invalid, result_schema)
+
+
+@pytest.mark.parametrize(
+    "doc,expected", [(c[1], c[2]) for c in _result_parity_cases()],
+    ids=[c[0] for c in _result_parity_cases()],
+)
+def test_result_schema_and_checker_agree(doc, expected):
+    jsonschema = pytest.importorskip("jsonschema")
+    from asset_skill_contract_check import AssetContractError, check_result
+
+    result_schema = _read_json(SCHEMA_DIR / "asset-skill-result.schema.json")
+    schema_valid = jsonschema.Draft202012Validator(result_schema).is_valid(doc)
+
+    try:
+        check_result(doc)
+        checker_valid = True
+    except AssetContractError:
+        checker_valid = False
+
+    assert schema_valid == expected, f"schema verdict {schema_valid} != expected {expected}"
+    assert checker_valid == expected, f"checker verdict {checker_valid} != expected {expected}"
+
+
+def _request_parity_cases():
+    base = {
+        "asset_type": "character-bundle",
+        "asset_id": "player",
+        "brief": "A knight.",
+        "references": [{"role": "canonical", "path": "res://references/p.png"}],
+    }
+    return [
+        ("valid-base", base, True),
+        ("whitespace-brief", _with(base, lambda d: d.update(brief="   ")), False),
+        (
+            "whitespace-reference-path",
+            _with(base, lambda d: d.update(references=[{"role": "style", "path": "  "}])),
+            False,
+        ),
+        ("forbidden-tag", _with(base, lambda d: d.update(tag="v0.1.0")), False),
+        ("unknown-asset_type", _with(base, lambda d: d.update(asset_type="sprite")), False),
+    ]
+
+
+@pytest.mark.parametrize(
+    "doc,expected", [(c[1], c[2]) for c in _request_parity_cases()],
+    ids=[c[0] for c in _request_parity_cases()],
+)
+def test_request_schema_and_checker_agree(doc, expected):
+    jsonschema = pytest.importorskip("jsonschema")
+    from asset_skill_contract_check import AssetContractError, check_request
+
+    request_schema = _read_json(SCHEMA_DIR / "asset-skill-request.schema.json")
+    schema_valid = jsonschema.Draft202012Validator(request_schema).is_valid(doc)
+
+    try:
+        check_request(doc)
+        checker_valid = True
+    except AssetContractError:
+        checker_valid = False
+
+    assert schema_valid == expected
+    assert checker_valid == expected

--- a/tests/test_asset_skill_contract_docs.py
+++ b/tests/test_asset_skill_contract_docs.py
@@ -168,6 +168,27 @@ def _result_parity_cases():
         ("whitespace-output-name", _with(base, lambda d: d["outputs"][0].update(name="  ")), False),
         ("whitespace-source-path", _with(base, lambda d: d["sources"][0].update(path="  ")), False),
         ("whitespace-preview-label", _with(base, lambda d: d["previews"][0].update(label="  ")), False),
+        # --- invalid: explicit null on optional fields ---
+        ("null-output-name", _with(base, lambda d: d["outputs"][0].update(name=None)), False),
+        (
+            "null-reference-godot_type",
+            _with(base, lambda d: d["outputs"].__setitem__(
+                0, {"role": "reference", "path": "references/x.png", "godot_type": None}
+            )),
+            False,
+        ),
+        ("null-source-layout", _with(base, lambda d: d["sources"][0].update(layout=None)), False),
+        ("null-preview-label", _with(base, lambda d: d["previews"][0].update(label=None)), False),
+        ("null-levels", _with(base, lambda d: d.update(validation={"passed": True, "levels": None})), False),
+        ("null-notes", _with(base, lambda d: d.update(validation={"passed": True, "notes": None})), False),
+        # --- invalid: dot / traversal path segments ---
+        ("path-dot", _with(base, lambda d: d["outputs"][0].update(path="res://.")), False),
+        ("path-dotdot", _with(base, lambda d: d["outputs"][0].update(path="res://..")), False),
+        ("path-traversal", _with(base, lambda d: d["outputs"][0].update(path="res://../outside.tres")), False),
+        ("path-mid-traversal", _with(base, lambda d: d["outputs"][0].update(path="res://a/../b.tres")), False),
+        # --- valid: legitimate dotted names ---
+        ("valid-dotted-filename", _with(base, lambda d: d["outputs"][0].update(path="res://a/b.name.tres")), True),
+        ("valid-hidden-dir", _with(base, lambda d: d["outputs"][0].update(path="res://.hidden/x.tres")), True),
         # --- invalid: structural / enum / forbidden ---
         ("empty-outputs", _with(base, lambda d: d.update(outputs=[])), False),
         ("non-res-runtime", _with(base, lambda d: d["outputs"][0].update(path="assets/x.tres")), False),
@@ -221,6 +242,9 @@ def _request_parity_cases():
         ),
         ("forbidden-tag", _with(base, lambda d: d.update(tag="v0.1.0")), False),
         ("unknown-asset_type", _with(base, lambda d: d.update(asset_type="sprite")), False),
+        ("null-references", _with(base, lambda d: d.update(references=None)), False),
+        ("null-provider", _with(base, lambda d: d.update(provider=None)), False),
+        ("null-spec", _with(base, lambda d: d.update(spec=None)), False),
     ]
 
 

--- a/tests/tools/test_asset_skill_contract_check.py
+++ b/tests/tools/test_asset_skill_contract_check.py
@@ -182,6 +182,16 @@ def test_validation_levels_all_true_with_passed():
             id="reference-bad-role",
         ),
         pytest.param(
+            lambda r: r.update(references=[{"role": [], "path": "x"}]),
+            id="reference-role-list",
+        ),
+        pytest.param(
+            lambda r: r.update(references=[{"role": {}, "path": "x"}]),
+            id="reference-role-dict",
+        ),
+        pytest.param(lambda r: r.update(provider=[]), id="provider-list"),
+        pytest.param(lambda r: r.update(provider={}), id="provider-dict"),
+        pytest.param(
             lambda r: r.update(references=[{"role": "canonical", "path": "x", "z": 1}]),
             id="reference-extra-key",
         ),
@@ -296,6 +306,10 @@ def test_request_rejects_non_dict():
         pytest.param(
             lambda r: r["outputs"][0].update(role="preview"), id="output-bad-role"
         ),
+        pytest.param(lambda r: r["outputs"][0].update(role=[]), id="output-role-list"),
+        pytest.param(lambda r: r["outputs"][0].update(role={}), id="output-role-dict"),
+        pytest.param(lambda r: r["sources"][0].update(layout=[]), id="source-layout-list"),
+        pytest.param(lambda r: r["sources"][0].update(layout={}), id="source-layout-dict"),
         pytest.param(
             lambda r: r["outputs"][0].update(godot_artifact={"type": "x"}),
             id="output-forbidden-godot_artifact",
@@ -395,6 +409,20 @@ def test_cli_rejects_invalid_result(tmp_path):
     proc = _run_cli(path, "--kind", "result")
     assert proc.returncode == 1
     assert json.loads(proc.stdout)["ok"] is False
+
+
+@pytest.mark.parametrize("bad_role", [[], {}], ids=["list", "dict"])
+def test_cli_fails_closed_on_non_scalar_enum(tmp_path, bad_role):
+    # A non-scalar enum value must become {"ok": false}, never an uncaught
+    # TypeError traceback that crashes the L0/CI process.
+    data = valid_result()
+    data["outputs"][0]["role"] = bad_role
+    path = tmp_path / "result.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    proc = _run_cli(path, "--kind", "result")
+    assert proc.returncode == 1
+    assert json.loads(proc.stdout)["ok"] is False
+    assert "Traceback" not in proc.stderr
 
 
 def test_valid_samples_are_independent_copies():

--- a/tests/tools/test_asset_skill_contract_check.py
+++ b/tests/tools/test_asset_skill_contract_check.py
@@ -1,0 +1,327 @@
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOLS_DIR = REPO_ROOT / "tools"
+SAMPLES_DIR = REPO_ROOT / "skills" / "assets" / "_shared" / "samples"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_skill_contract_check import (  # noqa: E402
+    AssetContractError,
+    check_document,
+    check_request,
+    check_result,
+)
+
+
+def valid_request():
+    return {
+        "asset_type": "character-bundle",
+        "asset_id": "player",
+        "brief": "A small pixel-art knight with idle and run actions.",
+        "references": [
+            {"role": "canonical", "path": "res://references/player_canonical.png"}
+        ],
+        "provider": "native",
+        "spec": {"actions": ["idle", "run"]},
+    }
+
+
+def valid_result():
+    return {
+        "asset_type": "character-bundle",
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": "player",
+                "path": "res://assets/generated/character-bundle/player/player.tres",
+                "godot_type": "SpriteFrames",
+            }
+        ],
+        "sources": [
+            {
+                "path": "res://assets/generated/character-bundle/player/player.png",
+                "layout": "grid_sheet",
+            }
+        ],
+        "previews": [{"path": "res://assets/generated/character-bundle/player/p.png"}],
+        "validation": {"passed": True},
+    }
+
+
+# ---------------------------------------------------------------------------
+# On-disk sample files are all valid.
+
+
+@pytest.mark.parametrize(
+    "sample", sorted((SAMPLES_DIR / "request").glob("*.json")), ids=lambda p: p.name
+)
+def test_request_samples_are_valid(sample):
+    data = json.loads(sample.read_text(encoding="utf-8"))
+    result = check_request(data)
+    assert result["ok"] is True
+    assert result["kind"] == "request"
+
+
+@pytest.mark.parametrize(
+    "sample", sorted((SAMPLES_DIR / "result").glob("*.json")), ids=lambda p: p.name
+)
+def test_result_samples_are_valid(sample):
+    data = json.loads(sample.read_text(encoding="utf-8"))
+    result = check_result(data)
+    assert result["ok"] is True
+    assert result["kind"] == "result"
+
+
+def test_samples_exist():
+    assert list((SAMPLES_DIR / "request").glob("*.json"))
+    assert list((SAMPLES_DIR / "result").glob("*.json"))
+
+
+# ---------------------------------------------------------------------------
+# Positive contract behaviors.
+
+
+def test_kind_is_inferred_from_shape():
+    assert check_document(valid_result())["kind"] == "result"
+    assert check_document(valid_request())["kind"] == "request"
+
+
+def test_multiple_runtime_outputs_are_counted():
+    data = valid_result()
+    data["outputs"].append(
+        {
+            "role": "runtime",
+            "path": "res://assets/generated/character-bundle/player/shadow.tres",
+            "godot_type": "Texture2D",
+        }
+    )
+    result = check_result(data)
+    assert result["output_count"] == 2
+    assert result["runtime_output_count"] == 2
+
+
+def test_reference_output_needs_no_godot_type_and_allows_project_path():
+    data = valid_result()
+    data["asset_type"] = "screen-reference"
+    data["outputs"] = [{"role": "reference", "path": "references/scene_main.png"}]
+    data["sources"] = []
+    result = check_result(data)
+    assert result["runtime_output_count"] == 0
+
+
+def test_empty_sources_and_previews_are_allowed():
+    data = valid_result()
+    data["sources"] = []
+    data["previews"] = []
+    assert check_result(data)["ok"] is True
+
+
+def test_validation_levels_all_true_with_passed():
+    data = valid_result()
+    data["validation"] = {
+        "passed": True,
+        "levels": {"L0": True, "L1": True, "L2": True, "L3": True, "L4": True},
+    }
+    assert check_result(data)["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: request.
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda r: r.pop("asset_type"), id="missing-asset_type"),
+        pytest.param(lambda r: r.pop("asset_id"), id="missing-asset_id"),
+        pytest.param(lambda r: r.pop("brief"), id="missing-brief"),
+        pytest.param(lambda r: r.update(asset_type="sprite"), id="unknown-asset_type"),
+        pytest.param(lambda r: r.update(asset_id="Player"), id="asset_id-uppercase"),
+        pytest.param(lambda r: r.update(asset_id="-bad"), id="asset_id-leading-dash"),
+        pytest.param(lambda r: r.update(brief="   "), id="blank-brief"),
+        pytest.param(lambda r: r.update(references={}), id="references-not-list"),
+        pytest.param(
+            lambda r: r.update(references=[{"path": "x"}]), id="reference-missing-role"
+        ),
+        pytest.param(
+            lambda r: r.update(references=[{"role": "canonical"}]),
+            id="reference-missing-path",
+        ),
+        pytest.param(
+            lambda r: r.update(references=[{"role": "hero", "path": "x"}]),
+            id="reference-bad-role",
+        ),
+        pytest.param(
+            lambda r: r.update(references=[{"role": "canonical", "path": "x", "z": 1}]),
+            id="reference-extra-key",
+        ),
+        pytest.param(lambda r: r.update(provider="dalle"), id="bad-provider"),
+        pytest.param(lambda r: r.update(spec=[]), id="spec-not-object"),
+        pytest.param(lambda r: r.update(tag="v0.1.0"), id="forbidden-tag"),
+        pytest.param(lambda r: r.update(stage=1), id="forbidden-stage"),
+        pytest.param(
+            lambda r: r.update(manifest_entry="x"), id="forbidden-manifest_entry"
+        ),
+        pytest.param(lambda r: r.update(gm_mode="build"), id="forbidden-gm_mode"),
+        pytest.param(lambda r: r.update(surprise=1), id="unknown-key"),
+    ],
+)
+def test_request_fails_closed(mutate):
+    data = valid_request()
+    mutate(data)
+    with pytest.raises(AssetContractError):
+        check_request(data)
+
+
+def test_request_rejects_non_dict():
+    with pytest.raises(AssetContractError):
+        check_request(["not", "a", "dict"])
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: result.
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        pytest.param(lambda r: r.pop("asset_type"), id="missing-asset_type"),
+        pytest.param(lambda r: r.pop("outputs"), id="missing-outputs"),
+        pytest.param(lambda r: r.pop("sources"), id="missing-sources"),
+        pytest.param(lambda r: r.pop("previews"), id="missing-previews"),
+        pytest.param(lambda r: r.pop("validation"), id="missing-validation"),
+        pytest.param(lambda r: r.update(asset_type="sprite"), id="unknown-asset_type"),
+        pytest.param(lambda r: r.update(outputs=[]), id="empty-outputs"),
+        pytest.param(lambda r: r.update(outputs={}), id="outputs-not-list"),
+        pytest.param(
+            lambda r: r["outputs"][0].pop("role"), id="output-missing-role"
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].pop("path"), id="output-missing-path"
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].pop("godot_type"),
+            id="runtime-output-missing-godot_type",
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(path="assets/player.tres"),
+            id="runtime-output-non-res-path",
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(godot_type="spriteFrames"),
+            id="runtime-output-bad-godot_type",
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(role="preview"), id="output-bad-role"
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(godot_artifact={"type": "x"}),
+            id="output-forbidden-godot_artifact",
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(extra=1), id="output-unknown-key"
+        ),
+        pytest.param(
+            lambda r: r["sources"][0].update(layout="mosaic"), id="source-bad-layout"
+        ),
+        pytest.param(
+            lambda r: r["sources"][0].pop("path"), id="source-missing-path"
+        ),
+        pytest.param(
+            lambda r: r["sources"][0].update(extra=1), id="source-unknown-key"
+        ),
+        pytest.param(
+            lambda r: r["previews"][0].update(label="   "), id="preview-blank-label"
+        ),
+        pytest.param(
+            lambda r: r.update(validation={}), id="validation-missing-passed"
+        ),
+        pytest.param(
+            lambda r: r.update(validation={"passed": "yes"}),
+            id="validation-passed-not-bool",
+        ),
+        pytest.param(
+            lambda r: r.update(
+                validation={"passed": True, "levels": {"L9": True}}
+            ),
+            id="validation-unknown-level",
+        ),
+        pytest.param(
+            lambda r: r.update(
+                validation={"passed": True, "levels": {"L0": "yes"}}
+            ),
+            id="validation-level-not-bool",
+        ),
+        pytest.param(
+            lambda r: r.update(
+                validation={"passed": True, "levels": {"L0": True, "L3": False}}
+            ),
+            id="passed-true-with-failed-level",
+        ),
+        pytest.param(
+            lambda r: r.update(runtime_artifact="single"),
+            id="forbidden-runtime_artifact",
+        ),
+        pytest.param(
+            lambda r: r.update(source_layout="grid_sheet"),
+            id="forbidden-source_layout",
+        ),
+        pytest.param(
+            lambda r: r.update(manifest_entry="x"), id="forbidden-manifest_entry"
+        ),
+        pytest.param(lambda r: r.update(tag="v0.1.0"), id="forbidden-tag"),
+        pytest.param(lambda r: r.update(mystery=1), id="unknown-key"),
+    ],
+)
+def test_result_fails_closed(mutate):
+    data = valid_result()
+    mutate(data)
+    with pytest.raises(AssetContractError):
+        check_result(data)
+
+
+def test_result_rejects_non_dict():
+    with pytest.raises(AssetContractError):
+        check_result("nope")
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+
+
+def _run_cli(path: Path, *args):
+    return subprocess.run(
+        [sys.executable, str(TOOLS_DIR / "asset_skill_contract_check.py"), str(path), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_accepts_valid_result(tmp_path):
+    path = tmp_path / "result.json"
+    path.write_text(json.dumps(valid_result()), encoding="utf-8")
+    proc = _run_cli(path)
+    assert proc.returncode == 0
+    assert json.loads(proc.stdout)["ok"] is True
+
+
+def test_cli_rejects_invalid_result(tmp_path):
+    data = valid_result()
+    data["outputs"] = []
+    path = tmp_path / "result.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    proc = _run_cli(path, "--kind", "result")
+    assert proc.returncode == 1
+    assert json.loads(proc.stdout)["ok"] is False
+
+
+def test_valid_samples_are_independent_copies():
+    # Guard against shared-reference mutation bugs in the test helpers.
+    assert valid_result() is not valid_result()
+    assert copy.deepcopy(valid_request()) == valid_request()

--- a/tests/tools/test_asset_skill_contract_check.py
+++ b/tests/tools/test_asset_skill_contract_check.py
@@ -214,6 +214,26 @@ def test_request_rejects_non_dict():
             id="runtime-output-non-res-path",
         ),
         pytest.param(
+            lambda r: r["outputs"][0].update(path="res://"),
+            id="runtime-output-bare-res",
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(path="res:///"),
+            id="runtime-output-res-triple-slash",
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(path="   "),
+            id="output-whitespace-path",
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(name="   "),
+            id="output-whitespace-name",
+        ),
+        pytest.param(
+            lambda r: r["sources"][0].update(path="   "),
+            id="source-whitespace-path",
+        ),
+        pytest.param(
             lambda r: r["outputs"][0].update(godot_type="spriteFrames"),
             id="runtime-output-bad-godot_type",
         ),

--- a/tests/tools/test_asset_skill_contract_check.py
+++ b/tests/tools/test_asset_skill_contract_check.py
@@ -122,6 +122,30 @@ def test_empty_sources_and_previews_are_allowed():
     assert check_result(data)["ok"] is True
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "res://assets/x.tres",
+        "res://a/b.name.tres",
+        "res://.hidden/x.tres",
+        "res://..foo/bar.tres",
+    ],
+)
+def test_runtime_paths_with_dotted_names_are_valid(path):
+    data = valid_result()
+    data["outputs"][0]["path"] = path
+    assert check_result(data)["ok"] is True
+
+
+def test_omitted_optional_fields_are_valid():
+    data = valid_result()
+    data["outputs"][0].pop("name", None)
+    data["sources"][0].pop("layout", None)
+    data["previews"] = [{"path": "res://a/b.png"}]
+    data["validation"] = {"passed": True}
+    assert check_result(data)["ok"] is True
+
+
 def test_validation_levels_all_true_with_passed():
     data = valid_result()
     data["validation"] = {
@@ -162,7 +186,10 @@ def test_validation_levels_all_true_with_passed():
             id="reference-extra-key",
         ),
         pytest.param(lambda r: r.update(provider="dalle"), id="bad-provider"),
+        pytest.param(lambda r: r.update(provider=None), id="provider-null"),
+        pytest.param(lambda r: r.update(references=None), id="references-null"),
         pytest.param(lambda r: r.update(spec=[]), id="spec-not-object"),
+        pytest.param(lambda r: r.update(spec=None), id="spec-null"),
         pytest.param(lambda r: r.update(tag="v0.1.0"), id="forbidden-tag"),
         pytest.param(lambda r: r.update(stage=1), id="forbidden-stage"),
         pytest.param(
@@ -232,6 +259,35 @@ def test_request_rejects_non_dict():
         pytest.param(
             lambda r: r["sources"][0].update(path="   "),
             id="source-whitespace-path",
+        ),
+        # explicit null on an optional field is a wrong-typed value, not omission
+        pytest.param(lambda r: r["outputs"][0].update(name=None), id="output-name-null"),
+        pytest.param(
+            lambda r: r["outputs"].__setitem__(
+                0, {"role": "reference", "path": "references/x.png", "godot_type": None}
+            ),
+            id="reference-godot_type-null",
+        ),
+        pytest.param(lambda r: r["sources"][0].update(layout=None), id="source-layout-null"),
+        pytest.param(lambda r: r["previews"][0].update(label=None), id="preview-label-null"),
+        pytest.param(
+            lambda r: r.update(validation={"passed": True, "levels": None}),
+            id="validation-levels-null",
+        ),
+        pytest.param(
+            lambda r: r.update(validation={"passed": True, "notes": None}),
+            id="validation-notes-null",
+        ),
+        # dot / traversal segments are not loadable resource paths
+        pytest.param(lambda r: r["outputs"][0].update(path="res://."), id="runtime-path-dot"),
+        pytest.param(lambda r: r["outputs"][0].update(path="res://.."), id="runtime-path-dotdot"),
+        pytest.param(
+            lambda r: r["outputs"][0].update(path="res://../outside.tres"),
+            id="runtime-path-traversal",
+        ),
+        pytest.param(
+            lambda r: r["outputs"][0].update(path="res://a/../b.tres"),
+            id="runtime-path-mid-traversal",
         ),
         pytest.param(
             lambda r: r["outputs"][0].update(godot_type="spriteFrames"),

--- a/tools/asset_skill_contract_check.py
+++ b/tools/asset_skill_contract_check.py
@@ -44,10 +44,13 @@ VALIDATION_LEVELS = {"L0", "L1", "L2", "L3", "L4"}
 
 ASSET_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 GODOT_TYPE_PATTERN = re.compile(r"^[A-Z][A-Za-z0-9]+$")
-# A loadable res:// resource path: the scheme, then a relative path that starts
-# with a non-slash, non-whitespace character. Rejects bare "res://" and
-# "res:///", which resolve to the project root rather than a resource.
-RES_PATH_PATTERN = re.compile(r"^res://[^/\s]\S*$")
+# A loadable res:// resource path: the scheme, then one or more "/"-separated
+# path segments of non-whitespace, non-slash characters. No segment may be "."
+# or ".." (a lone dot resolves to a directory, and ".." escapes the project
+# root), and there are no empty segments. Rejects bare "res://", "res:///",
+# "res://.", "res://..", and "res://../outside.tres".
+_RES_SEGMENT = r"(?!\.\.?(?:/|$))[^/\s]+"
+RES_PATH_PATTERN = re.compile(rf"^res://{_RES_SEGMENT}(?:/{_RES_SEGMENT})*$")
 
 # Pipeline / registration concepts that must never leak into a skill-neutral
 # request or result. Reported with a targeted message; any other unknown key is
@@ -131,8 +134,10 @@ def check_request(data: Any) -> dict[str, Any]:
     if not _non_empty_string(data.get("brief")):
         issues.append("request.brief must be a non-empty string")
 
-    references = data.get("references")
-    if references is not None:
+    # Optional fields are keyed on presence, not on a non-None value: an explicit
+    # null is a wrong-typed value the schema rejects, not an omission.
+    if "references" in data:
+        references = data["references"]
         if not isinstance(references, list):
             issues.append("request.references must be a list")
         else:
@@ -150,12 +155,10 @@ def check_request(data: Any) -> dict[str, Any]:
                 if not _non_empty_string(ref.get("path")):
                     issues.append(f"{loc}.path must be a non-empty string")
 
-    provider = data.get("provider")
-    if provider is not None and provider not in PROVIDERS:
-        issues.append(f"request.provider is not allowed: {provider}")
+    if "provider" in data and data["provider"] not in PROVIDERS:
+        issues.append(f"request.provider is not allowed: {data['provider']}")
 
-    spec = data.get("spec")
-    if spec is not None and not isinstance(spec, dict):
+    if "spec" in data and not isinstance(data["spec"], dict):
         issues.append("request.spec must be an object")
 
     if issues:
@@ -191,24 +194,17 @@ def _check_output(output: Any, *, index: int, issues: list[str]) -> bool:
             "(res:// followed by a relative resource path) for a runtime output"
         )
 
-    godot_type = output.get("godot_type")
-    if role == "runtime":
-        if not _non_empty_string(godot_type):
+    if role == "runtime" or "godot_type" in output:
+        godot_type = output.get("godot_type")
+        if role == "runtime" and "godot_type" not in output:
             issues.append(f"{loc}.godot_type is required for a runtime output")
-        elif not GODOT_TYPE_PATTERN.match(godot_type):
-            issues.append(
-                f"{loc}.godot_type must be a Godot ClassDB type name "
-                f"({GODOT_TYPE_PATTERN.pattern}): {godot_type}"
-            )
-    elif godot_type is not None:
-        if not _non_empty_string(godot_type) or not GODOT_TYPE_PATTERN.match(godot_type):
+        elif not _non_empty_string(godot_type) or not GODOT_TYPE_PATTERN.match(godot_type):
             issues.append(
                 f"{loc}.godot_type must be a Godot ClassDB type name "
                 f"({GODOT_TYPE_PATTERN.pattern}): {godot_type}"
             )
 
-    name = output.get("name")
-    if name is not None and not _non_empty_string(name):
+    if "name" in output and not _non_empty_string(output["name"]):
         issues.append(f"{loc}.name must be a non-empty string")
 
     return role == "runtime"
@@ -253,8 +249,8 @@ def _check_validation(validation: Any, *, issues: list[str]) -> None:
     if not isinstance(passed, bool):
         issues.append("result.validation.passed must be a boolean")
 
-    levels = validation.get("levels")
-    if levels is not None:
+    if "levels" in validation:
+        levels = validation["levels"]
         if not isinstance(levels, dict):
             issues.append("result.validation.levels must be an object")
         else:
@@ -275,8 +271,7 @@ def _check_validation(validation: Any, *, issues: list[str]) -> None:
                         + ", ".join(failed)
                     )
 
-    notes = validation.get("notes")
-    if notes is not None and not isinstance(notes, str):
+    if "notes" in validation and not isinstance(validation["notes"], str):
         issues.append("result.validation.notes must be a string")
 
 
@@ -313,19 +308,19 @@ def check_result(data: Any) -> dict[str, Any]:
     )
     if isinstance(data.get("sources"), list):
         for index, source in enumerate(data["sources"]):
-            if isinstance(source, dict):
-                layout = source.get("layout")
-                if layout is not None and layout not in SOURCE_LAYOUTS:
-                    issues.append(f"result.sources[{index}].layout is not allowed: {layout}")
+            if isinstance(source, dict) and "layout" in source:
+                if source["layout"] not in SOURCE_LAYOUTS:
+                    issues.append(
+                        f"result.sources[{index}].layout is not allowed: {source['layout']}"
+                    )
 
     _check_file_list(
         data.get("previews"), field="previews", allowed={"path", "label"}, issues=issues
     )
     if isinstance(data.get("previews"), list):
         for index, preview in enumerate(data["previews"]):
-            if isinstance(preview, dict):
-                label = preview.get("label")
-                if label is not None and not _non_empty_string(label):
+            if isinstance(preview, dict) and "label" in preview:
+                if not _non_empty_string(preview["label"]):
                     issues.append(f"result.previews[{index}].label must be a non-empty string")
 
     _check_validation(data.get("validation"), issues=issues)

--- a/tools/asset_skill_contract_check.py
+++ b/tools/asset_skill_contract_check.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Validate the standalone asset-skill request and result contract.
+
+This is a dependency-free implementation of the rules declared in
+`skills/assets/_shared/schema/asset-skill-request.schema.json` and
+`skills/assets/_shared/schema/asset-skill-result.schema.json`, so schema/L0
+validation can run at runtime inside a game project without a `jsonschema`
+dependency. A parity test keeps this checker in sync with those schemas.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+ASSET_TYPES = {
+    "background-map",
+    "character-bundle",
+    "fx-bundle",
+    "ui-kit",
+    "card-kit",
+    "compact-prop-pack",
+    "platform-strip",
+    "scene-prop-set",
+    "screen-reference",
+    "tileset",
+}
+
+REFERENCE_ROLES = {"canonical", "style", "screen"}
+PROVIDERS = {"native", "codex", "gemini", "openai"}
+OUTPUT_ROLES = {"runtime", "reference"}
+SOURCE_LAYOUTS = {
+    "single",
+    "grid_sheet",
+    "region_atlas",
+    "action_frames",
+    "theme_recipe",
+    "tile_atlas",
+}
+VALIDATION_LEVELS = {"L0", "L1", "L2", "L3", "L4"}
+
+ASSET_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+GODOT_TYPE_PATTERN = re.compile(r"^[A-Z][A-Za-z0-9]+$")
+RES_PREFIX = "res://"
+
+# Pipeline / registration concepts that must never leak into a skill-neutral
+# request or result. Reported with a targeted message; any other unknown key is
+# still rejected by the generic additional-key check.
+FORBIDDEN_REQUEST_KEYS = {
+    "tag",
+    "stage",
+    "stage_state",
+    "gm_mode",
+    "manifest_entry",
+    "asset_generation",
+}
+FORBIDDEN_RESULT_KEYS = {
+    "tag",
+    "stage",
+    "stage_state",
+    "gm_mode",
+    "manifest_entry",
+    "runtime_artifact",
+    "source_layout",
+    "godot_artifact",
+    "processing_status",
+    "extraction_status",
+}
+
+
+class AssetContractError(Exception):
+    """Raised when an asset-skill request or result is invalid."""
+
+
+def _non_empty_string(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _check_extra_keys(
+    obj: dict[str, Any],
+    allowed: set[str],
+    *,
+    location: str,
+    forbidden: set[str],
+    issues: list[str],
+) -> None:
+    for key in obj:
+        if key in allowed:
+            continue
+        if key in forbidden:
+            issues.append(
+                f"{location}.{key} is a pipeline/registration field and is not "
+                "allowed in the skill-neutral contract"
+            )
+        else:
+            issues.append(f"{location} has unknown field: {key}")
+
+
+def _check_asset_type(value: Any, *, location: str, issues: list[str]) -> None:
+    if not _non_empty_string(value):
+        issues.append(f"{location} must be a non-empty string")
+    elif value not in ASSET_TYPES:
+        issues.append(f"{location} is not an allowed production family: {value}")
+
+
+def check_request(data: Any) -> dict[str, Any]:
+    """Validate an asset-skill request. Raise AssetContractError if invalid."""
+    issues: list[str] = []
+    if not isinstance(data, dict):
+        raise AssetContractError("request must be a JSON object")
+
+    allowed = {"asset_type", "asset_id", "brief", "references", "provider", "spec"}
+    _check_extra_keys(
+        data, allowed, location="request", forbidden=FORBIDDEN_REQUEST_KEYS, issues=issues
+    )
+
+    _check_asset_type(data.get("asset_type"), location="request.asset_type", issues=issues)
+
+    asset_id = data.get("asset_id")
+    if not _non_empty_string(asset_id):
+        issues.append("request.asset_id must be a non-empty string")
+    elif not ASSET_ID_PATTERN.match(asset_id):
+        issues.append(f"request.asset_id must match {ASSET_ID_PATTERN.pattern}: {asset_id}")
+
+    if not _non_empty_string(data.get("brief")):
+        issues.append("request.brief must be a non-empty string")
+
+    references = data.get("references")
+    if references is not None:
+        if not isinstance(references, list):
+            issues.append("request.references must be a list")
+        else:
+            for index, ref in enumerate(references):
+                loc = f"request.references[{index}]"
+                if not isinstance(ref, dict):
+                    issues.append(f"{loc} must be an object")
+                    continue
+                _check_extra_keys(
+                    ref, {"role", "path"}, location=loc, forbidden=set(), issues=issues
+                )
+                role = ref.get("role")
+                if role not in REFERENCE_ROLES:
+                    issues.append(f"{loc}.role is not allowed: {role}")
+                if not _non_empty_string(ref.get("path")):
+                    issues.append(f"{loc}.path must be a non-empty string")
+
+    provider = data.get("provider")
+    if provider is not None and provider not in PROVIDERS:
+        issues.append(f"request.provider is not allowed: {provider}")
+
+    spec = data.get("spec")
+    if spec is not None and not isinstance(spec, dict):
+        issues.append("request.spec must be an object")
+
+    if issues:
+        raise AssetContractError("; ".join(issues))
+
+    return {"ok": True, "kind": "request", "asset_type": data.get("asset_type")}
+
+
+def _check_output(output: Any, *, index: int, issues: list[str]) -> bool:
+    loc = f"result.outputs[{index}]"
+    if not isinstance(output, dict):
+        issues.append(f"{loc} must be an object")
+        return False
+
+    _check_extra_keys(
+        output,
+        {"role", "path", "godot_type", "name"},
+        location=loc,
+        forbidden=FORBIDDEN_RESULT_KEYS,
+        issues=issues,
+    )
+
+    role = output.get("role")
+    if role not in OUTPUT_ROLES:
+        issues.append(f"{loc}.role is not allowed: {role}")
+
+    path = output.get("path")
+    if not _non_empty_string(path):
+        issues.append(f"{loc}.path must be a non-empty string")
+    elif role == "runtime" and not path.startswith(RES_PREFIX):
+        issues.append(f"{loc}.path must be a loadable res:// path for a runtime output")
+
+    godot_type = output.get("godot_type")
+    if role == "runtime":
+        if not _non_empty_string(godot_type):
+            issues.append(f"{loc}.godot_type is required for a runtime output")
+        elif not GODOT_TYPE_PATTERN.match(godot_type):
+            issues.append(
+                f"{loc}.godot_type must be a Godot ClassDB type name "
+                f"({GODOT_TYPE_PATTERN.pattern}): {godot_type}"
+            )
+    elif godot_type is not None:
+        if not _non_empty_string(godot_type) or not GODOT_TYPE_PATTERN.match(godot_type):
+            issues.append(
+                f"{loc}.godot_type must be a Godot ClassDB type name "
+                f"({GODOT_TYPE_PATTERN.pattern}): {godot_type}"
+            )
+
+    name = output.get("name")
+    if name is not None and not _non_empty_string(name):
+        issues.append(f"{loc}.name must be a non-empty string")
+
+    return role == "runtime"
+
+
+def _check_file_list(
+    items: Any,
+    *,
+    field: str,
+    allowed: set[str],
+    issues: list[str],
+) -> None:
+    if not isinstance(items, list):
+        issues.append(f"result.{field} must be a list")
+        return
+    for index, item in enumerate(items):
+        loc = f"result.{field}[{index}]"
+        if not isinstance(item, dict):
+            issues.append(f"{loc} must be an object")
+            continue
+        _check_extra_keys(
+            item, allowed, location=loc, forbidden=FORBIDDEN_RESULT_KEYS, issues=issues
+        )
+        if not _non_empty_string(item.get("path")):
+            issues.append(f"{loc}.path must be a non-empty string")
+
+
+def _check_validation(validation: Any, *, issues: list[str]) -> None:
+    if not isinstance(validation, dict):
+        issues.append("result.validation must be an object")
+        return
+
+    _check_extra_keys(
+        validation,
+        {"passed", "levels", "notes"},
+        location="result.validation",
+        forbidden=FORBIDDEN_RESULT_KEYS,
+        issues=issues,
+    )
+
+    passed = validation.get("passed")
+    if not isinstance(passed, bool):
+        issues.append("result.validation.passed must be a boolean")
+
+    levels = validation.get("levels")
+    if levels is not None:
+        if not isinstance(levels, dict):
+            issues.append("result.validation.levels must be an object")
+        else:
+            for level, value in levels.items():
+                if level not in VALIDATION_LEVELS:
+                    issues.append(f"result.validation.levels has unknown level: {level}")
+                elif not isinstance(value, bool):
+                    issues.append(f"result.validation.levels.{level} must be a boolean")
+            if passed is True:
+                failed = sorted(
+                    level
+                    for level, value in levels.items()
+                    if level in VALIDATION_LEVELS and value is False
+                )
+                if failed:
+                    issues.append(
+                        "result.validation.passed is true but these levels failed: "
+                        + ", ".join(failed)
+                    )
+
+    notes = validation.get("notes")
+    if notes is not None and not isinstance(notes, str):
+        issues.append("result.validation.notes must be a string")
+
+
+def check_result(data: Any) -> dict[str, Any]:
+    """Validate an asset-skill result. Raise AssetContractError if invalid."""
+    issues: list[str] = []
+    if not isinstance(data, dict):
+        raise AssetContractError("result must be a JSON object")
+
+    allowed = {"asset_type", "outputs", "sources", "previews", "validation"}
+    _check_extra_keys(
+        data, allowed, location="result", forbidden=FORBIDDEN_RESULT_KEYS, issues=issues
+    )
+
+    for required in ("asset_type", "outputs", "sources", "previews", "validation"):
+        if required not in data:
+            issues.append(f"result is missing required field: {required}")
+
+    _check_asset_type(data.get("asset_type"), location="result.asset_type", issues=issues)
+
+    runtime_output_count = 0
+    outputs = data.get("outputs")
+    if not isinstance(outputs, list):
+        issues.append("result.outputs must be a list")
+    elif not outputs:
+        issues.append("result.outputs must contain at least one output")
+    else:
+        for index, output in enumerate(outputs):
+            if _check_output(output, index=index, issues=issues):
+                runtime_output_count += 1
+
+    _check_file_list(
+        data.get("sources"), field="sources", allowed={"path", "layout"}, issues=issues
+    )
+    if isinstance(data.get("sources"), list):
+        for index, source in enumerate(data["sources"]):
+            if isinstance(source, dict):
+                layout = source.get("layout")
+                if layout is not None and layout not in SOURCE_LAYOUTS:
+                    issues.append(f"result.sources[{index}].layout is not allowed: {layout}")
+
+    _check_file_list(
+        data.get("previews"), field="previews", allowed={"path", "label"}, issues=issues
+    )
+    if isinstance(data.get("previews"), list):
+        for index, preview in enumerate(data["previews"]):
+            if isinstance(preview, dict):
+                label = preview.get("label")
+                if label is not None and not _non_empty_string(label):
+                    issues.append(f"result.previews[{index}].label must be a non-empty string")
+
+    _check_validation(data.get("validation"), issues=issues)
+
+    if issues:
+        raise AssetContractError("; ".join(issues))
+
+    output_count = len(outputs) if isinstance(outputs, list) else 0
+    return {
+        "ok": True,
+        "kind": "result",
+        "asset_type": data.get("asset_type"),
+        "output_count": output_count,
+        "runtime_output_count": runtime_output_count,
+    }
+
+
+def check_document(data: Any, *, kind: str | None = None) -> dict[str, Any]:
+    """Validate a request or result. Infer the kind when not given."""
+    if kind is None:
+        if isinstance(data, dict) and "outputs" in data:
+            kind = "result"
+        else:
+            kind = "request"
+    if kind == "request":
+        return check_request(data)
+    if kind == "result":
+        return check_result(data)
+    raise AssetContractError(f"unknown document kind: {kind}")
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(description="Validate an asset-skill request or result")
+    parser.add_argument("document", help="Path to the request or result JSON")
+    parser.add_argument(
+        "--kind",
+        choices=["request", "result"],
+        default=None,
+        help="Document kind; inferred from shape when omitted",
+    )
+    args = parser.parse_args()
+
+    try:
+        data = json.loads(Path(args.document).read_text(encoding="utf-8"))
+    except Exception as exc:
+        print(json.dumps({"ok": False, "error": f"invalid JSON: {exc}"}))
+        return 1
+
+    try:
+        result = check_document(data, kind=args.kind)
+    except AssetContractError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tools/asset_skill_contract_check.py
+++ b/tools/asset_skill_contract_check.py
@@ -44,7 +44,10 @@ VALIDATION_LEVELS = {"L0", "L1", "L2", "L3", "L4"}
 
 ASSET_ID_PATTERN = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 GODOT_TYPE_PATTERN = re.compile(r"^[A-Z][A-Za-z0-9]+$")
-RES_PREFIX = "res://"
+# A loadable res:// resource path: the scheme, then a relative path that starts
+# with a non-slash, non-whitespace character. Rejects bare "res://" and
+# "res:///", which resolve to the project root rather than a resource.
+RES_PATH_PATTERN = re.compile(r"^res://[^/\s]\S*$")
 
 # Pipeline / registration concepts that must never leak into a skill-neutral
 # request or result. Reported with a targeted message; any other unknown key is
@@ -182,8 +185,11 @@ def _check_output(output: Any, *, index: int, issues: list[str]) -> bool:
     path = output.get("path")
     if not _non_empty_string(path):
         issues.append(f"{loc}.path must be a non-empty string")
-    elif role == "runtime" and not path.startswith(RES_PREFIX):
-        issues.append(f"{loc}.path must be a loadable res:// path for a runtime output")
+    elif role == "runtime" and not RES_PATH_PATTERN.match(path):
+        issues.append(
+            f"{loc}.path must be a loadable res:// resource path "
+            "(res:// followed by a relative resource path) for a runtime output"
+        )
 
     godot_type = output.get("godot_type")
     if role == "runtime":

--- a/tools/asset_skill_contract_check.py
+++ b/tools/asset_skill_contract_check.py
@@ -150,13 +150,15 @@ def check_request(data: Any) -> dict[str, Any]:
                     ref, {"role", "path"}, location=loc, forbidden=set(), issues=issues
                 )
                 role = ref.get("role")
-                if role not in REFERENCE_ROLES:
-                    issues.append(f"{loc}.role is not allowed: {role}")
+                if not isinstance(role, str) or role not in REFERENCE_ROLES:
+                    issues.append(f"{loc}.role is not allowed: {role!r}")
                 if not _non_empty_string(ref.get("path")):
                     issues.append(f"{loc}.path must be a non-empty string")
 
-    if "provider" in data and data["provider"] not in PROVIDERS:
-        issues.append(f"request.provider is not allowed: {data['provider']}")
+    if "provider" in data and (
+        not isinstance(data["provider"], str) or data["provider"] not in PROVIDERS
+    ):
+        issues.append(f"request.provider is not allowed: {data['provider']!r}")
 
     if "spec" in data and not isinstance(data["spec"], dict):
         issues.append("request.spec must be an object")
@@ -182,8 +184,8 @@ def _check_output(output: Any, *, index: int, issues: list[str]) -> bool:
     )
 
     role = output.get("role")
-    if role not in OUTPUT_ROLES:
-        issues.append(f"{loc}.role is not allowed: {role}")
+    if not isinstance(role, str) or role not in OUTPUT_ROLES:
+        issues.append(f"{loc}.role is not allowed: {role!r}")
 
     path = output.get("path")
     if not _non_empty_string(path):
@@ -309,9 +311,9 @@ def check_result(data: Any) -> dict[str, Any]:
     if isinstance(data.get("sources"), list):
         for index, source in enumerate(data["sources"]):
             if isinstance(source, dict) and "layout" in source:
-                if source["layout"] not in SOURCE_LAYOUTS:
+                if not isinstance(source["layout"], str) or source["layout"] not in SOURCE_LAYOUTS:
                     issues.append(
-                        f"result.sources[{index}].layout is not allowed: {source['layout']}"
+                        f"result.sources[{index}].layout is not allowed: {source['layout']!r}"
                     )
 
     _check_file_list(


### PR DESCRIPTION
## Summary

Defines the unified invocation and result contract for first-class asset skills under `skills/assets/_shared/`, decoupled from `/gm-asset`.

## Motivation

Standalone asset skills currently have no independent contract — they are only reachable through `/gm-asset`. This PR defines a stable request/result contract so a user can call an asset skill directly, while `/gm-asset` invokes the same interface.

## Changes

- [x] `skills/assets/_shared/asset-skill-contract.md` — canonical contract prose (request/result semantics, independence rules, fail-closed rules); `_shared/` has no `SKILL.md`
- [x] `schema/asset-skill-request.schema.json`, `schema/asset-skill-result.schema.json` — declarative JSON Schema (Draft 2020-12), `additionalProperties: false`
- [x] `samples/request/*`, `samples/result/*` — valid samples incl. multiple runtime outputs and reference-only
- [x] `tools/asset_skill_contract_check.py` — dependency-free enforcement of the same rules (schema/L0 + CI), with CLI
- [x] `tests/tools/test_asset_skill_contract_check.py`, `tests/test_asset_skill_contract_docs.py` — fail-closed tests plus a `jsonschema` parity check (skipped when the lib is absent, e.g. CI)

Result stably contains `asset_type`, `outputs`, `sources`, `previews`, `validation`. Each runtime output declares `role`/`path`/`godot_type` (open Godot ClassDB type; runtime `path` must be `res://`). One invocation may return multiple runtime outputs. No `tag`, `ASSETS.md`, stage state, generated manifest, or gm mode is read.

Non-goals honored: no production-family migration, no gm-asset orchestration, no compiler.

## Testing

- [x] New or updated tests pass (`python -m pytest` full → 1155 passed; `ruff 0.15.22 check` → clean)
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable — not applicable (schema/tooling change, no runtime UI)

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed (new files under `skills/assets/_shared/`; no existing behavior, file locations, or config keys changed)

### Migration Upgrade Gate

Not applicable — no migration script added or modified.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — not applicable (no ECS systems touched)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
