### PR TITLE
feat(asset): v1 generated-asset stable entry and root index schema

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,6 +17,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
+- v1 generated-asset stable entry and root index schema: `tools/asset_stable_entry.py` (per-asset `production_family` / `source_layout` / minimal `godot_artifact` / `processing_status` entry written to `.godotmaker/asset-generation/entries/<tag>/<asset_id>.json`) and `tools/asset_generation_index.py` (pointer-only root index). Old `runtime_artifact` schema fails closed and must be regenerated through `/gm-asset`; no migration or compatibility read is provided.
+
 ## Changed
 
 ## Fixed

--- a/tests/tools/test_asset_generation_index.py
+++ b/tests/tools/test_asset_generation_index.py
@@ -83,6 +83,15 @@ def test_invalid_index_rejected(tmp_path, entries, match):
         check_index(path, project_root=tmp_path)
 
 
+def test_extra_root_field_rejected(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(
+        json.dumps({"version": 1, "entries": [], "unexpected": True}), encoding="utf-8"
+    )
+    with pytest.raises(GenerationIndexError, match="unexpected fields: unexpected"):
+        check_index(path, project_root=tmp_path)
+
+
 def test_bad_version_rejected(tmp_path):
     path = tmp_path / "manifest.json"
     path.write_text(json.dumps({"version": 2, "entries": []}), encoding="utf-8")
@@ -154,6 +163,30 @@ def test_update_index_upsert_overwrites(tmp_path):
     update_index(index_path, [entry_file], project_root=tmp_path)
     data = json.loads(index_path.read_text(encoding="utf-8"))
     assert len(data["entries"]) == 1
+
+
+def test_update_index_rejects_corrupt_existing(tmp_path):
+    # A pre-existing index carrying a root-level extra field must not be silently
+    # "repaired" on upsert.
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(
+        json.dumps({"version": 1, "entries": [], "unexpected": True}), encoding="utf-8"
+    )
+    entry_file = write_entry_file(tmp_path, valid_entry())
+    with pytest.raises(GenerationIndexError, match="unexpected fields"):
+        update_index(index_path, [entry_file], project_root=tmp_path)
+
+
+def test_update_index_rejects_non_canonical_entry_path(tmp_path):
+    # Content is valid but the file is not at entries/<tag>/<asset_id>.json, so the
+    # pointer would dangle; the run must fail closed instead of writing it.
+    loose = tmp_path / "input.json"
+    loose.write_text(json.dumps(valid_entry()), encoding="utf-8")
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+    with pytest.raises(GenerationIndexError, match="canonical entry path"):
+        update_index(index_path, [loose], project_root=tmp_path)
+    assert not index_path.exists()
 
 
 def test_update_index_rejects_legacy_existing(tmp_path):

--- a/tests/tools/test_asset_generation_index.py
+++ b/tests/tools/test_asset_generation_index.py
@@ -206,6 +206,30 @@ def test_update_index_rejects_non_canonical_entry_path(tmp_path):
     assert not index_path.exists()
 
 
+def test_unsafe_tag_rejected_end_to_end(tmp_path):
+    # tag="." previously slipped through write -> update -> check and produced a
+    # non-canonical `/./` pointer. Every stage must now reject it.
+    entry = dict(valid_entry(), tag=".")
+    loose = tmp_path / "entry.json"
+    loose.write_text(json.dumps(entry), encoding="utf-8")
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+    with pytest.raises(GenerationIndexError, match="must not be"):
+        update_index(index_path, [loose], project_root=tmp_path)
+    assert not index_path.exists()
+
+    # A hand-written index carrying the non-canonical pointer is rejected too.
+    bad_index = write_index(
+        tmp_path / "manifest.json",
+        [{
+            "asset_id": "player",
+            "tag": ".",
+            "entry_path": ".godotmaker/asset-generation/entries/./player.json",
+        }],
+    )
+    with pytest.raises(GenerationIndexError, match="must not be"):
+        check_index(bad_index, project_root=tmp_path)
+
+
 def test_update_index_rejects_legacy_existing(tmp_path):
     index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
     index_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/tools/test_asset_generation_index.py
+++ b/tests/tools/test_asset_generation_index.py
@@ -92,10 +92,27 @@ def test_extra_root_field_rejected(tmp_path):
         check_index(path, project_root=tmp_path)
 
 
-def test_bad_version_rejected(tmp_path):
+@pytest.mark.parametrize("version", [2, True, False, 1.0, "1", None])
+def test_bad_version_rejected(tmp_path, version):
     path = tmp_path / "manifest.json"
-    path.write_text(json.dumps({"version": 2, "entries": []}), encoding="utf-8")
-    with pytest.raises(GenerationIndexError, match="version must be 1"):
+    path.write_text(json.dumps({"version": version, "entries": []}), encoding="utf-8")
+    with pytest.raises(GenerationIndexError, match="version must be integer 1"):
+        check_index(path, project_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "entry_path",
+    [
+        ".godotmaker\\asset-generation\\entries\\v0.1.0\\player.json",  # backslashes
+        ".godotmaker/asset-generation/entries/v0.1.0//player.json",     # double slash
+        "./.godotmaker/asset-generation/entries/v0.1.0/player.json",    # leading ./
+        ".godotmaker/asset-generation/entries/v0.1.0/./player.json",    # inner ./
+    ],
+)
+def test_non_canonical_entry_path_rejected(tmp_path, entry_path):
+    item = dict(index_item(), entry_path=entry_path)
+    path = write_index(tmp_path / "manifest.json", [item])
+    with pytest.raises(GenerationIndexError, match="entry_path must be"):
         check_index(path, project_root=tmp_path)
 
 

--- a/tests/tools/test_asset_generation_index.py
+++ b/tests/tools/test_asset_generation_index.py
@@ -1,0 +1,212 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_generation_index import (  # noqa: E402
+    GenerationIndexError,
+    check_index,
+    update_index,
+)
+
+INDEX_TOOL = TOOLS_DIR / "asset_generation_index.py"
+
+
+def valid_entry(asset_id="player", tag="v0.1.0"):
+    return {
+        "version": 1,
+        "asset_id": asset_id,
+        "tag": tag,
+        "production_family": "character-bundle",
+        "source_layout": {
+            "type": "grid_sheet",
+            "path": f"res://assets/generated/character-bundle/{asset_id}/{asset_id}.png",
+        },
+        "godot_artifact": {
+            "type": "SpriteFrames",
+            "path": f"res://assets/generated/character-bundle/{asset_id}/{asset_id}.tres",
+        },
+        "processing_status": "ready",
+    }
+
+
+def index_item(asset_id="player", tag="v0.1.0"):
+    return {
+        "asset_id": asset_id,
+        "tag": tag,
+        "entry_path": f".godotmaker/asset-generation/entries/{tag}/{asset_id}.json",
+    }
+
+
+def write_index(path: Path, entries):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"version": 1, "entries": entries}), encoding="utf-8")
+    return path
+
+
+def write_entry_file(root: Path, entry) -> Path:
+    rel = f".godotmaker/asset-generation/entries/{entry['tag']}/{entry['asset_id']}.json"
+    target = root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(entry), encoding="utf-8")
+    return target
+
+
+def test_check_valid_index(tmp_path):
+    path = write_index(tmp_path / "manifest.json", [index_item(), index_item("enemy")])
+    result = check_index(path, project_root=tmp_path)
+    assert result["ok"] is True
+    assert result["entry_count"] == 2
+
+
+@pytest.mark.parametrize(
+    "entries, match",
+    [
+        ([{"asset_id": "player", "tag": "v0.1.0"}], "entry_path"),
+        ([index_item("player"), index_item("player")], "Duplicate asset_id"),
+        (
+            [dict(index_item(), entry_path=".godotmaker/asset-generation/entries/v0.1.0/other.json")],
+            "entry_path must be",
+        ),
+        ([dict(index_item(), production_family="character-bundle")], "unexpected fields"),
+        ([dict(index_item(), asset_id="../evil")], "path separators"),
+    ],
+)
+def test_invalid_index_rejected(tmp_path, entries, match):
+    path = write_index(tmp_path / "manifest.json", entries)
+    with pytest.raises(GenerationIndexError, match=match):
+        check_index(path, project_root=tmp_path)
+
+
+def test_bad_version_rejected(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps({"version": 2, "entries": []}), encoding="utf-8")
+    with pytest.raises(GenerationIndexError, match="version must be 1"):
+        check_index(path, project_root=tmp_path)
+
+
+def test_legacy_manifest_demands_regeneration(tmp_path):
+    path = tmp_path / "manifest.json"
+    path.write_text(
+        json.dumps({"version": 1, "assets": [{"asset_id": "player", "runtime_artifact": "grid_sheet"}]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(GenerationIndexError, match="Regenerate generated assets through /gm-asset"):
+        check_index(path, project_root=tmp_path)
+
+
+def test_legacy_field_in_item_rejected(tmp_path):
+    item = index_item()
+    item["runtime_artifact"] = "grid_sheet"
+    path = write_index(tmp_path / "manifest.json", [item])
+    with pytest.raises(GenerationIndexError, match="Regenerate"):
+        check_index(path, project_root=tmp_path)
+
+
+def test_check_entries_resolves_files(tmp_path):
+    write_entry_file(tmp_path, valid_entry())
+    path = write_index(tmp_path / ".godotmaker/asset-generation/manifest.json", [index_item()])
+    result = check_index(path, project_root=tmp_path, check_entries=True)
+    assert result["entry_checks"] == 1
+
+
+def test_check_entries_missing_file(tmp_path):
+    path = write_index(tmp_path / ".godotmaker/asset-generation/manifest.json", [index_item()])
+    with pytest.raises(GenerationIndexError, match="Entry file not found"):
+        check_index(path, project_root=tmp_path, check_entries=True)
+
+
+def test_check_entries_identity_mismatch(tmp_path):
+    entry = valid_entry()
+    # Write the entry file at the player path but with a mismatched asset_id inside.
+    rel = ".godotmaker/asset-generation/entries/v0.1.0/player.json"
+    target = tmp_path / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    mismatched = dict(entry, asset_id="enemy")
+    target.write_text(json.dumps(mismatched), encoding="utf-8")
+    path = write_index(tmp_path / ".godotmaker/asset-generation/manifest.json", [index_item()])
+    with pytest.raises(GenerationIndexError, match="does not match index item"):
+        check_index(path, project_root=tmp_path, check_entries=True)
+
+
+def test_update_index_writes_pointers_only(tmp_path):
+    entry_file = write_entry_file(tmp_path, valid_entry())
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+    result = update_index(index_path, [entry_file], project_root=tmp_path)
+    assert result["ok"] is True
+    assert result["upserted"] == ["player"]
+
+    data = json.loads(index_path.read_text(encoding="utf-8"))
+    assert data == {"version": 1, "entries": [index_item()]}
+    # The pointer body carries no source_layout / godot_artifact duplication.
+    assert set(data["entries"][0].keys()) == {"asset_id", "tag", "entry_path"}
+
+
+def test_update_index_upsert_overwrites(tmp_path):
+    entry_file = write_entry_file(tmp_path, valid_entry())
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+    update_index(index_path, [entry_file], project_root=tmp_path)
+    update_index(index_path, [entry_file], project_root=tmp_path)
+    data = json.loads(index_path.read_text(encoding="utf-8"))
+    assert len(data["entries"]) == 1
+
+
+def test_update_index_rejects_legacy_existing(tmp_path):
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(json.dumps({"version": 1, "assets": []}), encoding="utf-8")
+    entry_file = write_entry_file(tmp_path, valid_entry())
+    with pytest.raises(GenerationIndexError, match="Regenerate"):
+        update_index(index_path, [entry_file], project_root=tmp_path)
+
+
+def test_update_index_rejects_legacy_entry(tmp_path):
+    entry = valid_entry()
+    entry["runtime_artifact"] = "grid_sheet"
+    rel = ".godotmaker/asset-generation/entries/v0.1.0/player.json"
+    entry_file = tmp_path / rel
+    entry_file.parent.mkdir(parents=True, exist_ok=True)
+    entry_file.write_text(json.dumps(entry), encoding="utf-8")
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+    with pytest.raises(GenerationIndexError, match="Regenerate"):
+        update_index(index_path, [entry_file], project_root=tmp_path)
+
+
+def _run_cli(*args):
+    return subprocess.run(
+        [sys.executable, str(INDEX_TOOL), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_update_and_check(tmp_path):
+    entry_file = write_entry_file(tmp_path, valid_entry())
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+
+    updated = _run_cli(
+        str(index_path),
+        "--project-root",
+        str(tmp_path),
+        "--entry-file",
+        str(entry_file),
+    )
+    assert updated.returncode == 0
+    assert json.loads(updated.stdout)["upserted"] == ["player"]
+
+    checked = _run_cli(str(index_path), "--project-root", str(tmp_path), "--check-entries")
+    assert checked.returncode == 0
+    assert json.loads(checked.stdout)["entry_checks"] == 1
+
+
+def test_cli_rejects_legacy(tmp_path):
+    index_path = tmp_path / "manifest.json"
+    index_path.write_text(json.dumps({"version": 1, "assets": []}), encoding="utf-8")
+    result = _run_cli(str(index_path), "--project-root", str(tmp_path))
+    assert result.returncode == 1
+    assert "Regenerate" in json.loads(result.stdout)["error"]

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -11,6 +11,7 @@ sys.path.insert(0, str(TOOLS_DIR))
 
 from asset_stable_entry import (  # noqa: E402
     StableEntryError,
+    _assert_within_root,
     entry_relative_path,
     validate_entry,
     write_entry,
@@ -122,6 +123,72 @@ def test_legacy_field_nested_in_source_layout():
     entry["source_layout"]["runtime_artifact"] = "grid_sheet"
     with pytest.raises(StableEntryError, match="Regenerate"):
         validate_entry(entry)
+
+
+@pytest.mark.parametrize("version", [True, False, 1.0, "1", None, 2])
+def test_version_must_be_strict_integer(version):
+    entry = valid_entry(version=version)
+    with pytest.raises(StableEntryError, match="version"):
+        validate_entry(entry)
+
+
+@pytest.mark.parametrize(
+    "res_path",
+    [
+        "res://C:/Windows/system.ini",   # drive letter
+        "res://c:/x.png",
+        "res:///tmp/x.png",              # absolute (empty first segment)
+        "res:////server/share/x.png",    # UNC-style double slash
+        "res://a//b.png",                # empty middle segment
+        "res://a/./b.png",               # '.' segment
+        "res://a/../b.png",              # '..' segment
+        "res://..",                      # bare parent
+        "res://a\\b.png",                # backslash
+    ],
+)
+def test_source_layout_path_rejects_escapes(res_path):
+    entry = valid_entry()
+    entry["source_layout"]["path"] = res_path
+    with pytest.raises(StableEntryError):
+        validate_entry(entry)
+
+
+def test_godot_artifact_path_rejects_escapes():
+    entry = valid_entry()
+    entry["godot_artifact"]["path"] = "res://C:/Windows/system.ini"
+    with pytest.raises(StableEntryError, match="drive letter"):
+        validate_entry(entry)
+
+
+def test_check_files_rejects_path_outside_root(tmp_path):
+    # A clean relative res:// path can never escape, but the post-resolve guard
+    # holds even if a symlink or ``project_root`` trick pointed elsewhere.
+    outside = tmp_path.parent / "outside"
+    outside.mkdir()
+    (outside / "leak.png").write_bytes(b"x")
+    root = tmp_path / "proj"
+    root.mkdir()
+    # Symlink a directory inside the root to a sibling outside it.
+    link = root / "assets"
+    try:
+        link.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not permitted on this platform")
+    entry = valid_entry(
+        source_layout={"type": "single", "path": "res://assets/leak.png"},
+    )
+    del entry["godot_artifact"]
+    entry["processing_status"] = "source_ready"
+    with pytest.raises(StableEntryError, match="outside the project root"):
+        validate_entry(entry, project_root=root, check_files=True)
+
+
+def test_assert_within_root_rejects_outside(tmp_path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    _assert_within_root(root, root / "assets" / "x.png", "source_layout.path")
+    with pytest.raises(StableEntryError, match="outside the project root"):
+        _assert_within_root(root, tmp_path / "outside" / "x.png", "source_layout.path")
 
 
 def test_godot_artifact_rejects_extra_keys():

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -124,6 +124,20 @@ def test_legacy_field_nested_in_source_layout():
         validate_entry(entry)
 
 
+def test_godot_artifact_rejects_extra_keys():
+    entry = valid_entry()
+    entry["godot_artifact"]["receipt"] = {"hash": "abc"}
+    with pytest.raises(StableEntryError, match="godot_artifact must only hold type and path"):
+        validate_entry(entry)
+
+
+def test_source_layout_rejects_extra_keys():
+    entry = valid_entry()
+    entry["source_layout"]["grid"] = [4, 4]
+    with pytest.raises(StableEntryError, match="source_layout must only hold type and path"):
+        validate_entry(entry)
+
+
 def test_check_files_requires_present_paths(tmp_path):
     entry = valid_entry()
     with pytest.raises(StableEntryError, match="source_layout.path not found"):

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -1,0 +1,201 @@
+import copy
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_stable_entry import (  # noqa: E402
+    StableEntryError,
+    entry_relative_path,
+    validate_entry,
+    write_entry,
+)
+
+STABLE_ENTRY_TOOL = TOOLS_DIR / "asset_stable_entry.py"
+
+
+def valid_entry(**overrides):
+    entry = {
+        "version": 1,
+        "asset_id": "player",
+        "tag": "v0.1.0",
+        "production_family": "character-bundle",
+        "source_layout": {
+            "type": "grid_sheet",
+            "path": "res://assets/generated/character-bundle/player/player.png",
+        },
+        "godot_artifact": {
+            "type": "SpriteFrames",
+            "path": "res://assets/generated/character-bundle/player/player.tres",
+        },
+        "processing_status": "ready",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def reference_entry(**overrides):
+    entry = {
+        "version": 1,
+        "asset_id": "title_screen",
+        "tag": "v0.1.0",
+        "production_family": "screen-reference",
+        "source_layout": {
+            "type": "reference",
+            "path": "res://assets/references/title_screen.png",
+        },
+        "processing_status": "ready",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def test_validate_ready_entry_ok():
+    assert validate_entry(valid_entry()) == valid_entry()
+
+
+def test_reference_entry_needs_no_artifact():
+    validate_entry(reference_entry())
+
+
+def test_reference_entry_rejects_artifact():
+    entry = reference_entry(
+        godot_artifact={"type": "Texture2D", "path": "res://x.tres"}
+    )
+    with pytest.raises(StableEntryError, match="reference"):
+        validate_entry(entry)
+
+
+def test_artifact_required_for_ready_non_reference():
+    entry = valid_entry()
+    del entry["godot_artifact"]
+    with pytest.raises(StableEntryError, match="godot_artifact is required"):
+        validate_entry(entry)
+
+
+def test_artifact_optional_before_ready():
+    entry = valid_entry(processing_status="source_ready")
+    del entry["godot_artifact"]
+    validate_entry(entry)
+
+
+@pytest.mark.parametrize(
+    "mutate, match",
+    [
+        (lambda e: e.update(version=2), "version"),
+        (lambda e: e.pop("asset_id"), "asset_id"),
+        (lambda e: e.update(asset_id="../evil"), "path separators"),
+        (lambda e: e.update(tag="a/b"), "path separators"),
+        (lambda e: e.update(production_family="not-a-family"), "production_family"),
+        (lambda e: e.update(processing_status="weird"), "processing_status"),
+        (lambda e: e["source_layout"].update(type="bogus"), "source_layout.type"),
+        (lambda e: e["source_layout"].update(path="assets/x.png"), "res://"),
+        (lambda e: e["godot_artifact"].update(type="123bad"), "ClassDB"),
+        (lambda e: e["godot_artifact"].update(path="/abs/x.tres"), "res://"),
+    ],
+)
+def test_invalid_entries_rejected(mutate, match):
+    entry = valid_entry()
+    mutate(entry)
+    with pytest.raises(StableEntryError, match=match):
+        validate_entry(entry)
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["runtime_artifact", "production_shape", "extraction_status", "family", "final_path"],
+)
+def test_legacy_fields_demand_regeneration(field):
+    entry = valid_entry()
+    entry[field] = "grid_sheet"
+    with pytest.raises(StableEntryError, match="Regenerate this asset through /gm-asset"):
+        validate_entry(entry)
+
+
+def test_legacy_field_nested_in_source_layout():
+    entry = valid_entry()
+    entry["source_layout"]["runtime_artifact"] = "grid_sheet"
+    with pytest.raises(StableEntryError, match="Regenerate"):
+        validate_entry(entry)
+
+
+def test_check_files_requires_present_paths(tmp_path):
+    entry = valid_entry()
+    with pytest.raises(StableEntryError, match="source_layout.path not found"):
+        validate_entry(entry, project_root=tmp_path, check_files=True)
+
+    src = tmp_path / "assets/generated/character-bundle/player/player.png"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b"png")
+    with pytest.raises(StableEntryError, match="godot_artifact.path not found"):
+        validate_entry(entry, project_root=tmp_path, check_files=True)
+
+    (tmp_path / "assets/generated/character-bundle/player/player.tres").write_text("res")
+    validate_entry(entry, project_root=tmp_path, check_files=True)
+
+
+def test_entry_relative_path():
+    assert (
+        entry_relative_path("v0.1.0", "player")
+        == ".godotmaker/asset-generation/entries/v0.1.0/player.json"
+    )
+
+
+def test_write_entry_serializes_to_canonical_path(tmp_path):
+    result = write_entry(valid_entry(), project_root=tmp_path)
+    assert result["ok"] is True
+    assert result["path"] == ".godotmaker/asset-generation/entries/v0.1.0/player.json"
+    written = json.loads((tmp_path / result["path"]).read_text(encoding="utf-8"))
+    assert written == valid_entry()
+
+
+def test_validate_allows_internal_extra_fields():
+    entry = valid_entry(compiler_receipt={"hash": "abc", "compiler": "sprite_frames"})
+    validate_entry(entry)
+
+
+def test_validate_does_not_mutate_input():
+    entry = valid_entry()
+    snapshot = copy.deepcopy(entry)
+    validate_entry(entry)
+    assert entry == snapshot
+
+
+def _run_cli(*args):
+    return subprocess.run(
+        [sys.executable, str(STABLE_ENTRY_TOOL), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_validate_and_write(tmp_path):
+    entry_file = tmp_path / "entry.json"
+    entry_file.write_text(json.dumps(valid_entry()), encoding="utf-8")
+
+    ok = _run_cli(str(entry_file))
+    assert ok.returncode == 0
+    assert json.loads(ok.stdout)["ok"] is True
+
+    written = _run_cli(str(entry_file), "--project-root", str(tmp_path), "--write")
+    assert written.returncode == 0
+    payload = json.loads(written.stdout)
+    assert (tmp_path / payload["path"]).exists()
+
+
+def test_cli_rejects_legacy(tmp_path):
+    entry = valid_entry()
+    entry["runtime_artifact"] = "grid_sheet"
+    entry_file = tmp_path / "legacy.json"
+    entry_file.write_text(json.dumps(entry), encoding="utf-8")
+
+    result = _run_cli(str(entry_file))
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert "Regenerate" in payload["error"]

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -125,6 +125,26 @@ def test_legacy_field_nested_in_source_layout():
         validate_entry(entry)
 
 
+@pytest.mark.parametrize("field", ["tag", "asset_id"])
+@pytest.mark.parametrize(
+    "bad",
+    [".", "..", "C:", "a:b", "a/b", "a\\b", "con", "CON", "nul.png", "lpt1", "aux",
+     "a<b", "a>b", 'a"b', "a|b", "a?b", "a*b", "trail ", " lead", "trail."],
+)
+def test_identity_must_be_safe_path_segment(field, bad):
+    entry = valid_entry(**{field: bad})
+    with pytest.raises(StableEntryError):
+        validate_entry(entry)
+
+
+def test_write_entry_rejects_unsafe_tag(tmp_path):
+    entry = valid_entry(tag=".")
+    with pytest.raises(StableEntryError, match="must not be"):
+        write_entry(entry, project_root=tmp_path)
+    # Nothing was written outside the (never-created) canonical location.
+    assert not (tmp_path / ".godotmaker/asset-generation/entries/player.json").exists()
+
+
 @pytest.mark.parametrize("version", [True, False, 1.0, "1", None, 2])
 def test_version_must_be_strict_integer(version):
     entry = valid_entry(version=version)

--- a/tools/asset_generation_index.py
+++ b/tools/asset_generation_index.py
@@ -35,6 +35,7 @@ from asset_stable_entry import (
     _load_json,
     _safe_identifier,
     entry_relative_path,
+    is_schema_version,
     validate_entry,
 )
 
@@ -89,7 +90,10 @@ def _validate_item(item: Any, *, index: int) -> tuple[str, str, str]:
         expected = entry_relative_path(tag, asset_id)
     except StableEntryError as exc:
         raise GenerationIndexError(f"entries[{index}]: {exc}") from exc
-    if Path(entry_path).as_posix() != expected:
+    # Compare the raw string, not a normalized path: backslashes, ``//`` and
+    # ``./`` segments must be rejected so the same JSON validates identically on
+    # every OS and the pointer stays the exact canonical string.
+    if entry_path != expected:
         raise GenerationIndexError(
             f"entries[{index}].entry_path must be {expected}"
         )
@@ -107,8 +111,8 @@ def _validate_index_data(data: Any) -> list[dict[str, str]]:
         raise GenerationIndexError(
             f"Root index must only hold version and entries; unexpected fields: {listed}"
         )
-    if data.get("version") != SCHEMA_VERSION:
-        raise GenerationIndexError(f"Root index version must be {SCHEMA_VERSION}")
+    if not is_schema_version(data.get("version")):
+        raise GenerationIndexError(f"Root index version must be integer {SCHEMA_VERSION}")
     entries = data.get("entries")
     if not isinstance(entries, list):
         raise GenerationIndexError("Root index entries must be a list")

--- a/tools/asset_generation_index.py
+++ b/tools/asset_generation_index.py
@@ -38,6 +38,7 @@ from asset_stable_entry import (
     validate_entry,
 )
 
+ROOT_KEYS = {"version", "entries"}
 INDEX_ITEM_KEYS = {"asset_id", "tag", "entry_path"}
 
 
@@ -95,6 +96,35 @@ def _validate_item(item: Any, *, index: int) -> tuple[str, str, str]:
     return tag, asset_id, entry_path
 
 
+def _validate_index_data(data: Any) -> list[dict[str, str]]:
+    """Fully validate the root-object structure and return normalized items."""
+    if not isinstance(data, dict):
+        raise GenerationIndexError("Root index must be a JSON object")
+    _reject_legacy_container(data)
+    extra = set(data.keys()) - ROOT_KEYS
+    if extra:
+        listed = ", ".join(sorted(extra))
+        raise GenerationIndexError(
+            f"Root index must only hold version and entries; unexpected fields: {listed}"
+        )
+    if data.get("version") != SCHEMA_VERSION:
+        raise GenerationIndexError(f"Root index version must be {SCHEMA_VERSION}")
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise GenerationIndexError("Root index entries must be a list")
+
+    seen: set[tuple[str, str]] = set()
+    items: list[dict[str, str]] = []
+    for index, item in enumerate(entries):
+        tag, asset_id, entry_path = _validate_item(item, index=index)
+        key = (tag, asset_id)
+        if key in seen:
+            raise GenerationIndexError(f"Duplicate asset_id for tag {tag}: {asset_id}")
+        seen.add(key)
+        items.append({"asset_id": asset_id, "tag": tag, "entry_path": entry_path})
+    return items
+
+
 def check_index(
     index_path: Path,
     *,
@@ -105,26 +135,11 @@ def check_index(
     index_path = Path(index_path)
     root = Path(project_root) if project_root is not None else index_path.parent.parent.parent
 
-    data = _load_json_index(index_path)
-    if not isinstance(data, dict):
-        raise GenerationIndexError("Root index must be a JSON object")
-    _reject_legacy_container(data)
+    items = _validate_index_data(_load_json_index(index_path))
 
-    if data.get("version") != SCHEMA_VERSION:
-        raise GenerationIndexError(f"Root index version must be {SCHEMA_VERSION}")
-    entries = data.get("entries")
-    if not isinstance(entries, list):
-        raise GenerationIndexError("Root index entries must be a list")
-
-    seen: set[tuple[str, str]] = set()
     entry_checks = 0
-    for index, item in enumerate(entries):
-        tag, asset_id, entry_path = _validate_item(item, index=index)
-        key = (tag, asset_id)
-        if key in seen:
-            raise GenerationIndexError(f"Duplicate asset_id for tag {tag}: {asset_id}")
-        seen.add(key)
-
+    for item in items:
+        tag, asset_id, entry_path = item["tag"], item["asset_id"], item["entry_path"]
         if check_entries:
             resolved = root / entry_path
             if not resolved.exists():
@@ -135,14 +150,14 @@ def check_index(
                 raise GenerationIndexError(f"{entry_path}: {exc}") from exc
             if entry.get("asset_id") != asset_id or entry.get("tag") != tag:
                 raise GenerationIndexError(
-                    f"{entry_path} identity does not match index item {key}"
+                    f"{entry_path} identity does not match index item {(tag, asset_id)}"
                 )
             entry_checks += 1
 
     return {
         "ok": True,
         "path": str(index_path),
-        "entry_count": len(entries),
+        "entry_count": len(items),
         "check_entries": check_entries,
         "entry_checks": entry_checks,
     }
@@ -155,18 +170,11 @@ def _load_json_index(path: Path) -> Any:
         raise GenerationIndexError(str(exc)) from exc
 
 
-def _load_index(index_path: Path) -> dict[str, Any]:
+def _load_index_items(index_path: Path) -> list[dict[str, str]]:
+    """Load and fully validate an existing index, returning normalized items."""
     if not index_path.exists():
-        return {"version": SCHEMA_VERSION, "entries": []}
-    data = _load_json_index(index_path)
-    if not isinstance(data, dict):
-        raise GenerationIndexError(f"Root index must be an object: {index_path}")
-    _reject_legacy_container(data)
-    if data.get("version") != SCHEMA_VERSION:
-        raise GenerationIndexError(f"Root index version must be {SCHEMA_VERSION}: {index_path}")
-    if not isinstance(data.get("entries"), list):
-        raise GenerationIndexError(f"Root index missing entries list: {index_path}")
-    return data
+        return []
+    return _validate_index_data(_load_json_index(index_path))
 
 
 def _write_atomic(path: Path, data: dict[str, Any]) -> None:
@@ -194,18 +202,20 @@ def update_index(
     *,
     project_root: Path | None = None,
 ) -> dict[str, Any]:
-    """Upsert stable-entry pointers into the root index."""
+    """Upsert stable-entry pointers into the root index.
+
+    Each input entry file must already sit at its canonical
+    ``entries/<tag>/<asset_id>.json`` path (typically written first by
+    ``asset_stable_entry.write_entry``). The rewritten index is validated with
+    ``check_entries=True`` before the atomic replace, so a run can never write a
+    dangling or corrupt pointer.
+    """
     index_path = Path(index_path)
-    data = _load_index(index_path)
+    root = Path(project_root) if project_root is not None else index_path.parent.parent.parent
 
     items_by_key: dict[tuple[str, str], dict[str, str]] = {}
-    for index, item in enumerate(data["entries"]):
-        tag, asset_id, entry_path = _validate_item(item, index=index)
-        items_by_key[(tag, asset_id)] = {
-            "asset_id": asset_id,
-            "tag": tag,
-            "entry_path": entry_path,
-        }
+    for item in _load_index_items(index_path):
+        items_by_key[(item["tag"], item["asset_id"])] = item
 
     upserted: list[str] = []
     for entry_path in entry_paths:
@@ -215,10 +225,15 @@ def update_index(
             raise GenerationIndexError(f"{entry_path}: {exc}") from exc
         tag = entry["tag"]
         asset_id = entry["asset_id"]
+        canonical_rel = entry_relative_path(tag, asset_id)
+        if Path(entry_path).resolve() != (root / canonical_rel).resolve():
+            raise GenerationIndexError(
+                f"{entry_path} must be the canonical entry path {canonical_rel}"
+            )
         items_by_key[(tag, asset_id)] = {
             "asset_id": asset_id,
             "tag": tag,
-            "entry_path": entry_relative_path(tag, asset_id),
+            "entry_path": canonical_rel,
         }
         upserted.append(asset_id)
 
@@ -239,7 +254,7 @@ def update_index(
         json.dump(next_data, handle, indent=2)
         handle.write("\n")
     try:
-        check_index(tmp_path, project_root=project_root)
+        check_index(tmp_path, project_root=root, check_entries=True)
         _write_atomic(index_path, next_data)
     finally:
         if tmp_path.exists():

--- a/tools/asset_generation_index.py
+++ b/tools/asset_generation_index.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Validate and serialize the v1 generated-asset root index.
+
+The root index is the single index of generated stable entries. It stores only
+stable identity and a pointer to each entry file; it never duplicates a full
+entry body. It lives at::
+
+    .godotmaker/asset-generation/manifest.json
+
+Each item points at one stable entry::
+
+    {
+      "asset_id": "player",
+      "tag": "v0.1.0",
+      "entry_path": ".godotmaker/asset-generation/entries/v0.1.0/player.json"
+    }
+
+This is the v1.0.0 contract. An old ``runtime_artifact`` manifest (one that
+stores full entry bodies under ``assets``) is not migrated or dual-read; it
+fails with a clear message and must be regenerated through ``/gm-asset``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from asset_stable_entry import (
+    LEGACY_FIELDS,
+    SCHEMA_VERSION,
+    StableEntryError,
+    _load_json,
+    _safe_identifier,
+    entry_relative_path,
+    validate_entry,
+)
+
+INDEX_ITEM_KEYS = {"asset_id", "tag", "entry_path"}
+
+
+class GenerationIndexError(Exception):
+    """Raised when the generated-asset root index is invalid."""
+
+
+def _regenerate_error(reason: str) -> GenerationIndexError:
+    return GenerationIndexError(
+        f"{reason}; v1.0.0 provides no migration or compatibility read. "
+        "Regenerate generated assets through /gm-asset."
+    )
+
+
+def _reject_legacy_container(data: dict[str, Any]) -> None:
+    if "assets" in data:
+        raise _regenerate_error("Legacy runtime_artifact manifest detected (assets key)")
+    present = LEGACY_FIELDS.intersection(data.keys())
+    if present:
+        listed = ", ".join(sorted(present))
+        raise _regenerate_error(f"Legacy runtime_artifact fields detected ({listed})")
+
+
+def _validate_item(item: Any, *, index: int) -> tuple[str, str, str]:
+    if not isinstance(item, dict):
+        raise GenerationIndexError(f"entries[{index}] must be an object")
+    _reject_legacy_container(item)
+    extra = set(item.keys()) - INDEX_ITEM_KEYS
+    if extra:
+        listed = ", ".join(sorted(extra))
+        raise GenerationIndexError(
+            f"entries[{index}] must only hold identity and a pointer; "
+            f"unexpected fields: {listed}"
+        )
+
+    def _string(field: str) -> str:
+        value = item.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise GenerationIndexError(f"entries[{index}].{field} must be a non-empty string")
+        return value
+
+    asset_id = _string("asset_id")
+    tag = _string("tag")
+    entry_path = _string("entry_path")
+    try:
+        _safe_identifier(asset_id, "asset_id")
+        _safe_identifier(tag, "tag")
+        expected = entry_relative_path(tag, asset_id)
+    except StableEntryError as exc:
+        raise GenerationIndexError(f"entries[{index}]: {exc}") from exc
+    if Path(entry_path).as_posix() != expected:
+        raise GenerationIndexError(
+            f"entries[{index}].entry_path must be {expected}"
+        )
+    return tag, asset_id, entry_path
+
+
+def check_index(
+    index_path: Path,
+    *,
+    project_root: Path | None = None,
+    check_entries: bool = False,
+) -> dict[str, Any]:
+    """Validate one root index and return a summary."""
+    index_path = Path(index_path)
+    root = Path(project_root) if project_root is not None else index_path.parent.parent.parent
+
+    data = _load_json_index(index_path)
+    if not isinstance(data, dict):
+        raise GenerationIndexError("Root index must be a JSON object")
+    _reject_legacy_container(data)
+
+    if data.get("version") != SCHEMA_VERSION:
+        raise GenerationIndexError(f"Root index version must be {SCHEMA_VERSION}")
+    entries = data.get("entries")
+    if not isinstance(entries, list):
+        raise GenerationIndexError("Root index entries must be a list")
+
+    seen: set[tuple[str, str]] = set()
+    entry_checks = 0
+    for index, item in enumerate(entries):
+        tag, asset_id, entry_path = _validate_item(item, index=index)
+        key = (tag, asset_id)
+        if key in seen:
+            raise GenerationIndexError(f"Duplicate asset_id for tag {tag}: {asset_id}")
+        seen.add(key)
+
+        if check_entries:
+            resolved = root / entry_path
+            if not resolved.exists():
+                raise GenerationIndexError(f"Entry file not found: {entry_path}")
+            try:
+                entry = validate_entry(_load_json_index(resolved), project_root=root)
+            except StableEntryError as exc:
+                raise GenerationIndexError(f"{entry_path}: {exc}") from exc
+            if entry.get("asset_id") != asset_id or entry.get("tag") != tag:
+                raise GenerationIndexError(
+                    f"{entry_path} identity does not match index item {key}"
+                )
+            entry_checks += 1
+
+    return {
+        "ok": True,
+        "path": str(index_path),
+        "entry_count": len(entries),
+        "check_entries": check_entries,
+        "entry_checks": entry_checks,
+    }
+
+
+def _load_json_index(path: Path) -> Any:
+    try:
+        return _load_json(path)
+    except StableEntryError as exc:
+        raise GenerationIndexError(str(exc)) from exc
+
+
+def _load_index(index_path: Path) -> dict[str, Any]:
+    if not index_path.exists():
+        return {"version": SCHEMA_VERSION, "entries": []}
+    data = _load_json_index(index_path)
+    if not isinstance(data, dict):
+        raise GenerationIndexError(f"Root index must be an object: {index_path}")
+    _reject_legacy_container(data)
+    if data.get("version") != SCHEMA_VERSION:
+        raise GenerationIndexError(f"Root index version must be {SCHEMA_VERSION}: {index_path}")
+    if not isinstance(data.get("entries"), list):
+        raise GenerationIndexError(f"Root index missing entries list: {index_path}")
+    return data
+
+
+def _write_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        delete=False,
+        dir=str(path.parent),
+        suffix=".json",
+        mode="w",
+        encoding="utf-8",
+    ) as handle:
+        tmp_path = Path(handle.name)
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+    try:
+        tmp_path.replace(path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def update_index(
+    index_path: Path,
+    entry_paths: list[Path],
+    *,
+    project_root: Path | None = None,
+) -> dict[str, Any]:
+    """Upsert stable-entry pointers into the root index."""
+    index_path = Path(index_path)
+    data = _load_index(index_path)
+
+    items_by_key: dict[tuple[str, str], dict[str, str]] = {}
+    for index, item in enumerate(data["entries"]):
+        tag, asset_id, entry_path = _validate_item(item, index=index)
+        items_by_key[(tag, asset_id)] = {
+            "asset_id": asset_id,
+            "tag": tag,
+            "entry_path": entry_path,
+        }
+
+    upserted: list[str] = []
+    for entry_path in entry_paths:
+        try:
+            entry = validate_entry(_load_json_index(Path(entry_path)))
+        except StableEntryError as exc:
+            raise GenerationIndexError(f"{entry_path}: {exc}") from exc
+        tag = entry["tag"]
+        asset_id = entry["asset_id"]
+        items_by_key[(tag, asset_id)] = {
+            "asset_id": asset_id,
+            "tag": tag,
+            "entry_path": entry_relative_path(tag, asset_id),
+        }
+        upserted.append(asset_id)
+
+    next_data = {
+        "version": SCHEMA_VERSION,
+        "entries": list(items_by_key.values()),
+    }
+
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        delete=False,
+        dir=str(index_path.parent),
+        suffix=".json",
+        mode="w",
+        encoding="utf-8",
+    ) as handle:
+        tmp_path = Path(handle.name)
+        json.dump(next_data, handle, indent=2)
+        handle.write("\n")
+    try:
+        check_index(tmp_path, project_root=project_root)
+        _write_atomic(index_path, next_data)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+    return {
+        "ok": True,
+        "path": str(index_path),
+        "entry_count": len(next_data["entries"]),
+        "upserted": upserted,
+    }
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate and serialize the v1 generated-asset root index"
+    )
+    parser.add_argument(
+        "index",
+        nargs="?",
+        default=".godotmaker/asset-generation/manifest.json",
+        help="Root index path",
+    )
+    parser.add_argument("--project-root", default=".", type=Path)
+    parser.add_argument(
+        "--entry-file",
+        action="append",
+        help="Stable entry JSON file to upsert as a pointer",
+    )
+    parser.add_argument(
+        "--check-entries",
+        action="store_true",
+        help="Load and validate each referenced stable entry file",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.entry_file:
+            result = update_index(
+                Path(args.index),
+                [Path(path) for path in args.entry_file],
+                project_root=args.project_root,
+            )
+        else:
+            result = check_index(
+                Path(args.index),
+                project_root=args.project_root,
+                check_entries=args.check_entries,
+            )
+    except (GenerationIndexError, StableEntryError) as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Validate and serialize v1 generated-asset stable entries.
+
+A stable entry is the single source of truth for one worker-consumable
+generated asset. It stores stable identity plus the minimal contract a worker
+needs: the production family, the source layout, an optional minimal Godot
+artifact, and a processing status. It lives at::
+
+    .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
+
+This is the v1.0.0 contract. The old ``runtime_artifact`` schema is not read,
+migrated, or dual-written; entries carrying legacy fields fail with a clear
+message and must be regenerated through ``/gm-asset``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+
+ENTRIES_ROOT = ".godotmaker/asset-generation/entries"
+
+# Production families map one-to-one to the first-class asset skills.
+PRODUCTION_FAMILIES = {
+    "background-map",
+    "character-bundle",
+    "fx-bundle",
+    "ui-kit",
+    "card-kit",
+    "compact-prop-pack",
+    "platform-strip",
+    "scene-prop-set",
+    "screen-reference",
+    "tileset",
+}
+
+# ``source_layout.type`` describes pixel organization, not a Godot artifact.
+SOURCE_LAYOUT_TYPES = {
+    "single",
+    "grid_sheet",
+    "region_atlas",
+    "theme_recipe",
+    "tile_atlas",
+    "reference",
+}
+
+# Reference-only sources are never handed to workers as runtime game assets.
+REFERENCE_LAYOUTS = {"reference"}
+
+# Processing status maps to the L0-L4 readiness ladder.
+PROCESSING_STATUSES = {
+    "pending",       # L0 only; nothing produced yet
+    "source_ready",  # L1 source generation and processing succeeded
+    "compiled",      # L2 native Godot artifact compiled, not yet L3-L4 verified
+    "ready",         # L0-L4 all passed; worker-consumable
+    "failed",        # a stage failed
+}
+
+# Statuses that require a compiled ``godot_artifact`` for non-reference assets.
+ARTIFACT_REQUIRED_STATUSES = {"compiled", "ready"}
+
+# ``godot_artifact.type`` is a Godot ClassDB type, not a closed enum.
+GODOT_TYPE_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+# Any of these fields marks an old ``runtime_artifact`` manifest/entry.
+LEGACY_FIELDS = {
+    "runtime_artifact",
+    "production_shape",
+    "extraction_status",
+    "runtime_role",
+    "family",
+    "final_path",
+    "source_path",
+}
+
+_RES_PREFIX = "res://"
+
+
+class StableEntryError(Exception):
+    """Raised when a stable entry is invalid."""
+
+
+def _legacy_error(fields: set[str]) -> StableEntryError:
+    listed = ", ".join(sorted(fields))
+    return StableEntryError(
+        f"Legacy runtime_artifact schema detected (fields: {listed}); "
+        "v1.0.0 provides no migration or compatibility read. "
+        "Regenerate this asset through /gm-asset."
+    )
+
+
+def _reject_legacy(data: dict[str, Any]) -> None:
+    present = LEGACY_FIELDS.intersection(data.keys())
+    if present:
+        raise _legacy_error(present)
+
+
+def _non_empty_string(data: dict[str, Any], field: str, label: str) -> str:
+    value = data.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise StableEntryError(f"{label} must be a non-empty string")
+    return value
+
+
+def _safe_identifier(value: str, label: str) -> str:
+    if any(sep in value for sep in ("/", "\\")) or ".." in value:
+        raise StableEntryError(f"{label} must not contain path separators or '..'")
+    return value
+
+
+def _check_res_path(value: str, label: str) -> str:
+    if not value.startswith(_RES_PREFIX):
+        raise StableEntryError(f"{label} must be a res:// path")
+    remainder = value[len(_RES_PREFIX):]
+    if not remainder.strip():
+        raise StableEntryError(f"{label} must name a resource under res://")
+    if "\\" in value or ".." in value:
+        raise StableEntryError(f"{label} must use forward slashes and no '..'")
+    return value
+
+
+def _resolve_res_path(project_root: Path, res_path: str) -> Path:
+    return project_root / res_path[len(_RES_PREFIX):]
+
+
+def _validate_source_layout(data: dict[str, Any]) -> tuple[str, str]:
+    layout = data.get("source_layout")
+    if not isinstance(layout, dict):
+        raise StableEntryError("source_layout must be an object")
+    _reject_legacy(layout)
+    layout_type = _non_empty_string(layout, "type", "source_layout.type")
+    if layout_type not in SOURCE_LAYOUT_TYPES:
+        raise StableEntryError(f"source_layout.type is not allowed: {layout_type}")
+    layout_path = _non_empty_string(layout, "path", "source_layout.path")
+    _check_res_path(layout_path, "source_layout.path")
+    return layout_type, layout_path
+
+
+def _validate_godot_artifact(
+    data: dict[str, Any],
+    *,
+    layout_type: str,
+    processing_status: str,
+) -> tuple[str, str] | None:
+    artifact = data.get("godot_artifact")
+    is_reference = layout_type in REFERENCE_LAYOUTS
+
+    if artifact is None:
+        if is_reference:
+            return None
+        if processing_status in ARTIFACT_REQUIRED_STATUSES:
+            raise StableEntryError(
+                f"godot_artifact is required when processing_status is {processing_status}"
+            )
+        return None
+
+    if is_reference:
+        raise StableEntryError(
+            "godot_artifact must be absent for a reference source_layout"
+        )
+    if not isinstance(artifact, dict):
+        raise StableEntryError("godot_artifact must be an object or null")
+    _reject_legacy(artifact)
+
+    artifact_type = _non_empty_string(artifact, "type", "godot_artifact.type")
+    if not GODOT_TYPE_PATTERN.match(artifact_type):
+        raise StableEntryError(
+            "godot_artifact.type must be a Godot ClassDB type identifier"
+        )
+    artifact_path = _non_empty_string(artifact, "path", "godot_artifact.path")
+    _check_res_path(artifact_path, "godot_artifact.path")
+    return artifact_type, artifact_path
+
+
+def validate_entry(
+    data: Any,
+    *,
+    project_root: Path | None = None,
+    check_files: bool = False,
+) -> dict[str, Any]:
+    """Validate one stable entry object and return it unchanged."""
+    if not isinstance(data, dict):
+        raise StableEntryError("Stable entry must be a JSON object")
+
+    _reject_legacy(data)
+
+    if data.get("version") != SCHEMA_VERSION:
+        raise StableEntryError(f"Stable entry version must be {SCHEMA_VERSION}")
+
+    asset_id = _safe_identifier(
+        _non_empty_string(data, "asset_id", "asset_id"), "asset_id"
+    )
+    tag = _safe_identifier(_non_empty_string(data, "tag", "tag"), "tag")
+
+    family = _non_empty_string(data, "production_family", "production_family")
+    if family not in PRODUCTION_FAMILIES:
+        raise StableEntryError(f"production_family is not allowed: {family}")
+
+    processing_status = _non_empty_string(
+        data, "processing_status", "processing_status"
+    )
+    if processing_status not in PROCESSING_STATUSES:
+        raise StableEntryError(
+            f"processing_status is not allowed: {processing_status}"
+        )
+
+    layout_type, layout_path = _validate_source_layout(data)
+    artifact = _validate_godot_artifact(
+        data, layout_type=layout_type, processing_status=processing_status
+    )
+
+    if check_files:
+        if project_root is None:
+            raise StableEntryError("project_root is required to check files")
+        root = Path(project_root)
+        if not _resolve_res_path(root, layout_path).exists():
+            raise StableEntryError(f"source_layout.path not found: {layout_path}")
+        if artifact is not None:
+            _, artifact_path = artifact
+            if not _resolve_res_path(root, artifact_path).exists():
+                raise StableEntryError(
+                    f"godot_artifact.path not found: {artifact_path}"
+                )
+
+    return data
+
+
+def entry_relative_path(tag: str, asset_id: str) -> str:
+    """Return the canonical entry path for one ``(tag, asset_id)`` pair."""
+    _safe_identifier(tag, "tag")
+    _safe_identifier(asset_id, "asset_id")
+    return f"{ENTRIES_ROOT}/{tag}/{asset_id}.json"
+
+
+def _write_atomic(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        delete=False,
+        dir=str(path.parent),
+        suffix=".json",
+        mode="w",
+        encoding="utf-8",
+    ) as handle:
+        tmp_path = Path(handle.name)
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+    try:
+        tmp_path.replace(path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink()
+
+
+def write_entry(
+    entry: dict[str, Any],
+    *,
+    project_root: Path,
+    check_files: bool = False,
+) -> dict[str, Any]:
+    """Validate and serialize one stable entry to its canonical path."""
+    validated = validate_entry(entry, project_root=project_root, check_files=check_files)
+    relative = entry_relative_path(validated["tag"], validated["asset_id"])
+    target = Path(project_root) / relative
+    _write_atomic(target, validated)
+    return {
+        "ok": True,
+        "path": relative,
+        "asset_id": validated["asset_id"],
+        "tag": validated["tag"],
+    }
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - surfaced as a tool error
+        raise StableEntryError(f"Invalid JSON: {path}") from exc
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate and serialize a v1 generated-asset stable entry"
+    )
+    parser.add_argument("entry", type=Path, help="Stable entry JSON file")
+    parser.add_argument("--project-root", default=".", type=Path)
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Serialize the entry to its canonical entries/<tag>/<asset_id>.json path",
+    )
+    parser.add_argument(
+        "--check-files",
+        action="store_true",
+        help="Verify referenced source and artifact files exist",
+    )
+    args = parser.parse_args()
+
+    try:
+        data = _load_json(args.entry)
+        if args.write:
+            result = write_entry(
+                data if isinstance(data, dict) else {},
+                project_root=args.project_root,
+                check_files=args.check_files,
+            )
+        else:
+            validate_entry(
+                data, project_root=args.project_root, check_files=args.check_files
+            )
+            result = {"ok": True, "path": str(args.entry)}
+    except StableEntryError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -81,6 +81,12 @@ LEGACY_FIELDS = {
 
 _RES_PREFIX = "res://"
 
+# Both nested contract objects hold exactly a type and a path. Internal detail
+# (receipts, hashes, versions) belongs at the entry top level, never inside the
+# worker-facing artifact.
+SOURCE_LAYOUT_KEYS = {"type", "path"}
+GODOT_ARTIFACT_KEYS = {"type", "path"}
+
 
 class StableEntryError(Exception):
     """Raised when a stable entry is invalid."""
@@ -114,6 +120,13 @@ def _safe_identifier(value: str, label: str) -> str:
     return value
 
 
+def _reject_extra_keys(data: dict[str, Any], allowed: set[str], label: str) -> None:
+    extra = set(data.keys()) - allowed
+    if extra:
+        listed = ", ".join(sorted(extra))
+        raise StableEntryError(f"{label} must only hold type and path; unexpected fields: {listed}")
+
+
 def _check_res_path(value: str, label: str) -> str:
     if not value.startswith(_RES_PREFIX):
         raise StableEntryError(f"{label} must be a res:// path")
@@ -134,6 +147,7 @@ def _validate_source_layout(data: dict[str, Any]) -> tuple[str, str]:
     if not isinstance(layout, dict):
         raise StableEntryError("source_layout must be an object")
     _reject_legacy(layout)
+    _reject_extra_keys(layout, SOURCE_LAYOUT_KEYS, "source_layout")
     layout_type = _non_empty_string(layout, "type", "source_layout.type")
     if layout_type not in SOURCE_LAYOUT_TYPES:
         raise StableEntryError(f"source_layout.type is not allowed: {layout_type}")
@@ -167,6 +181,7 @@ def _validate_godot_artifact(
     if not isinstance(artifact, dict):
         raise StableEntryError("godot_artifact must be an object or null")
     _reject_legacy(artifact)
+    _reject_extra_keys(artifact, GODOT_ARTIFACT_KEYS, "godot_artifact")
 
     artifact_type = _non_empty_string(artifact, "type", "godot_artifact.type")
     if not GODOT_TYPE_PATTERN.match(artifact_type):
@@ -193,10 +208,8 @@ def validate_entry(
     if data.get("version") != SCHEMA_VERSION:
         raise StableEntryError(f"Stable entry version must be {SCHEMA_VERSION}")
 
-    asset_id = _safe_identifier(
-        _non_empty_string(data, "asset_id", "asset_id"), "asset_id"
-    )
-    tag = _safe_identifier(_non_empty_string(data, "tag", "tag"), "tag")
+    _safe_identifier(_non_empty_string(data, "asset_id", "asset_id"), "asset_id")
+    _safe_identifier(_non_empty_string(data, "tag", "tag"), "tag")
 
     family = _non_empty_string(data, "production_family", "production_family")
     if family not in PRODUCTION_FAMILIES:

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -79,6 +79,17 @@ LEGACY_FIELDS = {
     "source_path",
 }
 
+# Characters that are illegal in a Windows filename or act as path separators /
+# drive markers / alternate-data-stream selectors across platforms.
+_RESERVED_PATH_CHARS = set('<>:"/\\|?*')
+
+# Windows reserved device basenames (case-insensitive, any extension).
+_RESERVED_DEVICE_NAMES = {
+    "CON", "PRN", "AUX", "NUL",
+    *(f"COM{i}" for i in range(1, 10)),
+    *(f"LPT{i}" for i in range(1, 10)),
+}
+
 _RES_PREFIX = "res://"
 
 # Both nested contract objects hold exactly a type and a path. Internal detail
@@ -124,8 +135,25 @@ def _non_empty_string(data: dict[str, Any], field: str, label: str) -> str:
 
 
 def _safe_identifier(value: str, label: str) -> str:
-    if any(sep in value for sep in ("/", "\\")) or ".." in value:
-        raise StableEntryError(f"{label} must not contain path separators or '..'")
+    """Require a single cross-platform-safe path segment.
+
+    ``tag`` and ``asset_id`` become one directory / file-stem component of the
+    canonical entry path, so they must map to exactly that segment on every OS.
+    """
+    if value in (".", ".."):
+        raise StableEntryError(f"{label} must not be '.' or '..'")
+    for char in value:
+        if char in _RESERVED_PATH_CHARS or ord(char) < 32:
+            raise StableEntryError(
+                f"{label} must be a single safe path segment "
+                "(no path separators, ':' or reserved characters)"
+            )
+    if value != value.strip() or value.endswith("."):
+        raise StableEntryError(
+            f"{label} must not have leading/trailing spaces or a trailing dot"
+        )
+    if value.split(".", 1)[0].upper() in _RESERVED_DEVICE_NAMES:
+        raise StableEntryError(f"{label} must not be a Windows reserved device name")
     return value
 
 

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -92,6 +92,15 @@ class StableEntryError(Exception):
     """Raised when a stable entry is invalid."""
 
 
+def is_schema_version(value: Any) -> bool:
+    """Return True only for a strict JSON integer equal to the schema version.
+
+    ``bool`` is a subclass of ``int`` and ``1.0 == 1``, so a plain ``== 1``
+    would accept ``True`` and ``1.0``. Require an exact ``int`` type.
+    """
+    return type(value) is int and value == SCHEMA_VERSION
+
+
 def _legacy_error(fields: set[str]) -> StableEntryError:
     listed = ", ".join(sorted(fields))
     return StableEntryError(
@@ -133,13 +142,29 @@ def _check_res_path(value: str, label: str) -> str:
     remainder = value[len(_RES_PREFIX):]
     if not remainder.strip():
         raise StableEntryError(f"{label} must name a resource under res://")
-    if "\\" in value or ".." in value:
-        raise StableEntryError(f"{label} must use forward slashes and no '..'")
+    if "\\" in remainder:
+        raise StableEntryError(f"{label} must use forward slashes")
+    # Must be a clean, project-relative resource path: no absolute/UNC anchor,
+    # no drive letter, no empty (``//``), ``.`` or ``..`` segments.
+    segments = remainder.split("/")
+    for segment in segments:
+        if segment in ("", ".", ".."):
+            raise StableEntryError(
+                f"{label} must be a relative resource path with no empty, '.' or '..' segments"
+            )
+        if ":" in segment:
+            raise StableEntryError(f"{label} must not contain a drive letter or scheme")
     return value
 
 
 def _resolve_res_path(project_root: Path, res_path: str) -> Path:
     return project_root / res_path[len(_RES_PREFIX):]
+
+
+def _assert_within_root(project_root: Path, resolved: Path, label: str) -> None:
+    root = project_root.resolve()
+    if not resolved.resolve().is_relative_to(root):
+        raise StableEntryError(f"{label} resolves outside the project root")
 
 
 def _validate_source_layout(data: dict[str, Any]) -> tuple[str, str]:
@@ -205,8 +230,8 @@ def validate_entry(
 
     _reject_legacy(data)
 
-    if data.get("version") != SCHEMA_VERSION:
-        raise StableEntryError(f"Stable entry version must be {SCHEMA_VERSION}")
+    if not is_schema_version(data.get("version")):
+        raise StableEntryError(f"Stable entry version must be integer {SCHEMA_VERSION}")
 
     _safe_identifier(_non_empty_string(data, "asset_id", "asset_id"), "asset_id")
     _safe_identifier(_non_empty_string(data, "tag", "tag"), "tag")
@@ -232,11 +257,15 @@ def validate_entry(
         if project_root is None:
             raise StableEntryError("project_root is required to check files")
         root = Path(project_root)
-        if not _resolve_res_path(root, layout_path).exists():
+        source_file = _resolve_res_path(root, layout_path)
+        _assert_within_root(root, source_file, "source_layout.path")
+        if not source_file.exists():
             raise StableEntryError(f"source_layout.path not found: {layout_path}")
         if artifact is not None:
             _, artifact_path = artifact
-            if not _resolve_res_path(root, artifact_path).exists():
+            artifact_file = _resolve_res_path(root, artifact_path)
+            _assert_within_root(root, artifact_file, "godot_artifact.path")
+            if not artifact_file.exists():
                 raise StableEntryError(
                     f"godot_artifact.path not found: {artifact_path}"
                 )


### PR DESCRIPTION
## Summary

Defines and implements the v1.0.0 generated-asset stable entry and root index schema — contract foundation only; no resolver/compiler/gm-asset registration/migration in this PR.

## Motivation

Root manifests currently duplicate full entry bodies and depend on a `runtime_artifact` shape that mixes engine-runtime detail with stable identity. This PR introduces a stable per-asset entry (`production_family`, `source_layout`, minimal `godot_artifact`, `processing_status`) plus a pointer-only root index, so the root manifest never copies a full entry and the old `runtime_artifact` schema fails closed instead of silently drifting.

Multica issue: WOR-195

## Changes

- [x] `tools/asset_stable_entry.py` — validates and serializes one stable entry (`production_family`, `source_layout`, minimal `godot_artifact`, `processing_status`) to `.godotmaker/asset-generation/entries/<tag>/<asset_id>.json`. `runtime_artifact` is replaced by `source_layout`; `godot_artifact` holds only a Godot ClassDB `type` and a stable `res://` `path`.
- [x] `tools/asset_generation_index.py` — validates and serializes the root index as identity-plus-pointer items only; never duplicates full entry bodies.
- [x] Old `runtime_artifact` schema fails closed with a regenerate message; no migration, dual-write, or compatibility read.
- [x] Fail-closed hardening (review round 2): `source_layout` / `godot_artifact` restricted to exactly `{type, path}`; root index rejects unexpected top-level fields; `update_index` reuses full validation (duplicate detection) instead of silently dropping/overwriting; `update_index` requires canonical entry paths and validates the rewritten index with `check_entries=True` before the atomic replace, so no dangling pointers.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — `ruff check .` clean; `python -m pytest tests/` → 1134 passed (includes 51 new tests across the two modules).
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable — N/A, schema/serialization change with no runtime UI surface

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [ ] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

This PR intentionally breaks the old `runtime_artifact` schema (fail-closed, no compatibility read) as scoped v1.0.0 contract work; per the issue's explicit non-goals, resolver/compiler/gm-asset registration/migration are out of scope for this PR and are tracked separately (WOR-195 non-goals; parent-stage acceptance in WOR-232). No migration script is added here by design — flagging honestly rather than checking either box, since neither literally applies yet.

### Migration Upgrade Gate

Not applicable — no migration script is added or modified in this PR.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — N/A, no ECS systems touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
