### PR TITLE
Align production-unit autoslice examples with required --grid argument

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -21,4 +21,6 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Added the required `--grid` (and `--names`) argument to every production-unit `asset_sheet_process.py` example so the ui-kit, card-kit, compact-prop-pack, fx-bundle, scene-prop-set, and platform-strip commands run as written instead of failing on a missing required argument, and clarified that `--grid` is required in both autoslice and grid snap modes.
+
 ## Removed

--- a/skills/core/gm-asset/references/production-units/card-kit.md
+++ b/skills/core/gm-asset/references/production-units/card-kit.md
@@ -59,10 +59,16 @@ Separated card components:
 python tools/asset_sheet_process.py \
   --source <card_source.png> \
   --out-dir <curation_dir> \
+  --grid <COLSxROWS> \
+  --names <component_names> \
   --background magenta \
   --snap-mode autoslice \
   --component-mode largest
 ```
+
+`--grid` is required in both snap modes; in autoslice it sets the cell buckets
+and per-cell names that detected components are assigned to. Match `--grid` and
+`--names` to the card-component layout requested in the prompt.
 
 Use `--snap-mode grid` only for deliberate equal-cell badge or slot layouts.
 Do not use a source kit or source frame as an independent final card asset.

--- a/skills/core/gm-asset/references/production-units/compact-prop-pack.md
+++ b/skills/core/gm-asset/references/production-units/compact-prop-pack.md
@@ -47,10 +47,16 @@ Extract separated props:
 python tools/asset_sheet_process.py \
   --source <prop_source.png> \
   --out-dir <curation_dir> \
+  --grid <COLSxROWS> \
+  --names <prop_names> \
   --background magenta \
   --snap-mode autoslice \
   --component-mode largest
 ```
+
+`--grid` is required in both snap modes; in autoslice it sets the cell buckets
+and per-cell names that detected props are assigned to. Match `--grid` and
+`--names` to the prop layout requested in the prompt.
 
 Use `--snap-mode grid` only for deliberate equal-cell prop packs.
 Use the same autoslice path for one-item pickup, collectable, and small-prop

--- a/skills/core/gm-asset/references/production-units/fx-bundle.md
+++ b/skills/core/gm-asset/references/production-units/fx-bundle.md
@@ -62,10 +62,16 @@ Process one-frame foreground effects:
 python tools/asset_sheet_process.py \
   --source <fx_source.png> \
   --out-dir <curation_dir> \
+  --grid <COLSxROWS> \
+  --names <effect_names> \
   --background magenta \
   --snap-mode autoslice \
   --component-mode largest
 ```
+
+`--grid` is required in both snap modes; in autoslice it sets the cell buckets
+and per-cell names that detected effects are assigned to. Match `--grid` and
+`--names` to the one-frame effect layout requested in the prompt.
 
 Select one-frame foreground effects with `tools/asset_curation_select.py`.
 Write `runtime_artifact: single` in selected one-frame manifest entries.

--- a/skills/core/gm-asset/references/production-units/platform-strip.md
+++ b/skills/core/gm-asset/references/production-units/platform-strip.md
@@ -42,10 +42,16 @@ Process fixed strip cells:
 python tools/asset_sheet_process.py \
   --source <strip_source.png> \
   --out-dir <curation_dir> \
+  --grid <COLSxROWS> \
+  --names <segment_names> \
   --background magenta \
   --snap-mode grid \
   --component-mode largest
 ```
+
+`--grid` is required; in grid mode it defines the fixed strip cells that are
+cropped. Match `--grid` and `--names` to the strip layout, for example `1x3`
+or `1x4`.
 
 Use one selected final segment per cap, repeat middle, end, slope, or variant.
 Use a processed strip atlas only with runtime segment metadata beside the final

--- a/skills/core/gm-asset/references/production-units/scene-prop-set.md
+++ b/skills/core/gm-asset/references/production-units/scene-prop-set.md
@@ -49,10 +49,16 @@ Process one-item foreground object sources with autoslice:
 python tools/asset_sheet_process.py \
   --source <object_source.png> \
   --out-dir <curation_dir> \
+  --grid <COLSxROWS> \
+  --names <object_names> \
   --background magenta \
   --snap-mode autoslice \
   --component-mode largest
 ```
+
+`--grid` is required in both snap modes; in autoslice it sets the cell buckets
+and per-cell names that detected objects are assigned to. Match `--grid` and
+`--names` to the object layout requested in the prompt.
 
 Do not use a source image or reference mockup as an independent final prop.
 

--- a/skills/core/gm-asset/references/production-units/ui-kit.md
+++ b/skills/core/gm-asset/references/production-units/ui-kit.md
@@ -50,10 +50,16 @@ Extract separated UI components:
 python tools/asset_sheet_process.py \
   --source <ui_source.png> \
   --out-dir <curation_dir> \
+  --grid <COLSxROWS> \
+  --names <component_names> \
   --background magenta \
   --snap-mode autoslice \
   --component-mode largest
 ```
+
+`--grid` is required in both snap modes; in autoslice it sets the cell buckets
+and per-cell names that detected components are assigned to. Match `--grid` and
+`--names` to the component layout requested in the prompt.
 
 Use `--snap-mode grid` only for deliberate equal-cell layouts.
 Do not use a source kit or source panel as an independent final UI artifact.

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -96,6 +96,25 @@ def test_production_unit_docs_are_first_entry_points():
     assert "## Curation Field" in runtime
 
 
+def test_production_unit_sheet_process_examples_pass_grid():
+    units = [
+        "ui-kit",
+        "card-kit",
+        "compact-prop-pack",
+        "fx-bundle",
+        "scene-prop-set",
+        "platform-strip",
+    ]
+    for unit in units:
+        doc = _read(f"skills/core/gm-asset/references/production-units/{unit}.md")
+        for block in doc.split("```"):
+            if "python tools/asset_sheet_process.py" not in block:
+                continue
+            assert "--grid" in block, (
+                f"{unit}.md asset_sheet_process example is missing --grid"
+            )
+
+
 def test_ui_and_prop_units_default_to_autoslice():
     ui = _read("skills/core/gm-asset/references/production-units/ui-kit.md")
     card = _read("skills/core/gm-asset/references/production-units/card-kit.md")

--- a/tests/tools/test_asset_sheet_process.py
+++ b/tests/tools/test_asset_sheet_process.py
@@ -365,3 +365,93 @@ def test_cli_requires_snap_mode(tmp_path):
 
     assert result.returncode != 0
     assert "--snap-mode" in result.stderr
+
+
+def test_cli_autoslice_outputs_json(tmp_path):
+    source = tmp_path / "autoslice_sheet.png"
+    make_autoslice_sheet(source)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_sheet_process.py"),
+            "--source",
+            str(source),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--grid",
+            "2x1",
+            "--names",
+            "wide_button,right_icon",
+            "--asset-id",
+            "ui_kit_source",
+            "--snap-mode",
+            "autoslice",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["ok"] is True
+    assert data["snap_mode"] == "autoslice"
+    assert data["strategy"] == "transparent_autoslice"
+    assert data["accepted_count"] == 2
+
+
+@pytest.mark.parametrize("snap_mode", ["autoslice", "grid"])
+def test_cli_requires_grid_in_both_modes(tmp_path, snap_mode):
+    source = tmp_path / "sheet.png"
+    make_sheet(source)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_sheet_process.py"),
+            "--source",
+            str(source),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--names",
+            "a,b,c,d",
+            "--snap-mode",
+            snap_mode,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "--grid" in result.stderr
+
+
+@pytest.mark.parametrize("snap_mode", ["autoslice", "grid"])
+def test_cli_rejects_malformed_grid_in_both_modes(tmp_path, snap_mode):
+    source = tmp_path / "sheet.png"
+    make_sheet(source)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_sheet_process.py"),
+            "--source",
+            str(source),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--grid",
+            "2",
+            "--snap-mode",
+            snap_mode,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "--grid" in data["error"]

--- a/tools/asset_sheet_process.py
+++ b/tools/asset_sheet_process.py
@@ -687,7 +687,16 @@ def _main() -> int:
     parser = argparse.ArgumentParser(description="Process a production-shaped 2D asset sheet")
     parser.add_argument("--source", required=True, help="Source sheet image path")
     parser.add_argument("--out-dir", required=True, help="Output directory")
-    parser.add_argument("--grid", required=True, help="Grid layout, e.g. 2x2")
+    parser.add_argument(
+        "--grid",
+        required=True,
+        help=(
+            "Grid layout COLSxROWS, e.g. 2x2. Required for both snap modes. "
+            "In grid mode it defines the fixed cells that are cropped. In "
+            "autoslice mode it defines the cell buckets and per-cell naming "
+            "that detected rectangles are assigned to by their center"
+        ),
+    )
     parser.add_argument("--names", default=None, help="Comma-separated output names")
     parser.add_argument("--asset-id", default=None, help="Optional source asset id")
     parser.add_argument("--tag", default=None, help="Optional current tag")


### PR DESCRIPTION
## Summary

Align `production-unit` autoslice command examples with `asset_sheet_process.py`'s CLI contract by adding the required `--grid` (and `--names`) argument, and document the semantics of `--grid` for both grid and autoslice snap modes.

## Motivation

Several `gm-asset` production-unit docs (ui-kit, card-kit, compact-prop-pack, fx-bundle, scene-prop-set, platform-strip) showed `asset_sheet_process.py` example commands without `--grid`, but the CLI declares `--grid` as required. An LLM following the contract literally would hit an argparse error (exit code 2) before any slicing happened. `--grid` is load-bearing for autoslice too — it determines candidate count, which cell each detected rectangle buckets into by center, and candidate naming — so the fix updates the examples/docs rather than relaxing CLI validation.

## Changes

- [x] `tools/asset_sheet_process.py`: kept `--grid` required; expanded its help text to explain semantics in both grid mode (fixed crop cells) and autoslice mode (bucketing/naming of detected rectangles)
- [x] 6 production-unit docs: added `--grid <COLSxROWS>` and `--names <...>` to every `asset_sheet_process.py` example, with a short semantics note
- [x] `tests/tools/test_asset_sheet_process.py`: added CLI regression tests for valid autoslice, missing `--grid` in both modes, and invalid `--grid` in both modes
- [x] `tests/test_asset_runtime_contract_docs.py`: added a doc guard asserting every production-unit `asset_sheet_process.py` code block includes `--grid`
- [x] `docs/update/next.md`: added a Fixed entry

## Testing

- [x] New or updated tests pass (`python -m pytest tests/tools/test_asset_sheet_process.py tests/test_asset_runtime_contract_docs.py -q` -> 34 passed; `python -m pytest tests/ -q` -> 1089 passed)
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable (not applicable to this change)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
