### PR TITLE
feat(asset): constrain generated-asset outputs to a stable per-asset directory

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -18,6 +18,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Added
 
 - v1 generated-asset stable entry and root index schema: `tools/asset_stable_entry.py` (per-asset `production_family` / `source_layout` / minimal `godot_artifact` / `processing_status` entry written to `.godotmaker/asset-generation/entries/<tag>/<asset_id>.json`) and `tools/asset_generation_index.py` (pointer-only root index). Old `runtime_artifact` schema fails closed and must be regenerated through `/gm-asset`; no migration or compatibility read is provided.
+- Stable generated-asset output-path contract: deterministic `assets/generated/<production_family>/<asset_id>/` resolver (`tools/asset_output_path.py`), fail-closed stable-entry path validation, and a reusable `assert_within_output_dir` write guard.
 - Added a standalone asset-skill invocation and result contract under `skills/assets/_shared/` with declarative JSON schemas, valid samples, a dependency-free checker, and fail-closed tests (#98).
 
 ## Changed

--- a/tests/tools/test_asset_generation_index.py
+++ b/tests/tools/test_asset_generation_index.py
@@ -148,16 +148,35 @@ def test_check_entries_missing_file(tmp_path):
 
 
 def test_check_entries_identity_mismatch(tmp_path):
-    entry = valid_entry()
-    # Write the entry file at the player path but with a mismatched asset_id inside.
+    # Write a fully valid ``enemy`` entry (identity and paths consistent) at the
+    # ``player`` pointer location, so it clears schema validation and is caught
+    # by the index identity check rather than the output-path constraint.
     rel = ".godotmaker/asset-generation/entries/v0.1.0/player.json"
     target = tmp_path / rel
     target.parent.mkdir(parents=True, exist_ok=True)
-    mismatched = dict(entry, asset_id="enemy")
+    mismatched = valid_entry(asset_id="enemy")
     target.write_text(json.dumps(mismatched), encoding="utf-8")
     path = write_index(tmp_path / ".godotmaker/asset-generation/manifest.json", [index_item()])
     with pytest.raises(GenerationIndexError, match="does not match index item"):
         check_index(path, project_root=tmp_path, check_entries=True)
+
+
+def test_check_entries_rejects_symlinked_stable_dir(tmp_path):
+    # The root-index registration path must resolve-and-contain referenced
+    # paths: a symlinked assets tree pointing outside the project is rejected
+    # even though --check-entries does not pass check_files.
+    outside = tmp_path.parent / "outside_index"
+    outside.mkdir(exist_ok=True)
+    root = tmp_path / "proj"
+    root.mkdir()
+    try:
+        (root / "assets").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not permitted on this platform")
+    write_entry_file(root, valid_entry())
+    path = write_index(root / ".godotmaker/asset-generation/manifest.json", [index_item()])
+    with pytest.raises(GenerationIndexError, match="outside the project root"):
+        check_index(path, project_root=root, check_entries=True)
 
 
 def test_update_index_writes_pointers_only(tmp_path):

--- a/tests/tools/test_asset_output_path.py
+++ b/tests/tools/test_asset_output_path.py
@@ -1,0 +1,337 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_output_path import (  # noqa: E402
+    check_entry_file,
+    check_paths,
+    describe_output_dir,
+)
+from asset_stable_entry import (  # noqa: E402
+    StableEntryError,
+    assert_within_output_dir,
+    check_output_path,
+    check_support_files,
+    stable_output_dir,
+    stable_output_res_path,
+)
+
+
+def _symlink_escape_resolve(monkeypatch, real_stable, escaped):
+    """Make ``Path.resolve`` treat ``real_stable`` as a symlink to ``escaped``.
+
+    Portable stand-in for an out-of-project directory symlink so the guard's
+    fail-closed behavior is covered on platforms (Windows CI) that cannot create
+    symlinks without elevation.
+    """
+    orig_resolve = Path.resolve
+
+    def fake_resolve(self, *args, **kwargs):
+        real = orig_resolve(self, *args, **kwargs)
+        if real == real_stable:
+            return escaped
+        try:
+            tail = real.relative_to(real_stable)
+        except ValueError:
+            return real
+        return escaped / tail
+
+    monkeypatch.setattr(Path, "resolve", fake_resolve)
+
+OUTPUT_TOOL = TOOLS_DIR / "asset_output_path.py"
+
+
+def valid_entry(asset_id="player", family="character-bundle"):
+    return {
+        "version": 1,
+        "asset_id": asset_id,
+        "tag": "v0.1.0",
+        "production_family": family,
+        "source_layout": {
+            "type": "grid_sheet",
+            "path": f"res://assets/generated/{family}/{asset_id}/{asset_id}.png",
+        },
+        "godot_artifact": {
+            "type": "SpriteFrames",
+            "path": f"res://assets/generated/{family}/{asset_id}/{asset_id}.tres",
+        },
+        "processing_status": "ready",
+    }
+
+
+# --- Deterministic directory computation ------------------------------------
+
+def test_stable_output_dir_is_deterministic():
+    first = stable_output_dir("character-bundle", "player")
+    second = stable_output_dir("character-bundle", "player")
+    assert first == second == "assets/generated/character-bundle/player"
+    assert stable_output_res_path("character-bundle", "player") == (
+        "res://assets/generated/character-bundle/player"
+    )
+
+
+def test_unrelated_assets_get_disjoint_dirs():
+    player = stable_output_dir("character-bundle", "player")
+    enemy = stable_output_dir("character-bundle", "enemy")
+    other_family = stable_output_dir("ui-kit", "player")
+    assert player != enemy != other_family
+    # No asset's directory is a prefix of another's, so writes to one can never
+    # land inside another.
+    assert not enemy.startswith(player + "/")
+    assert not other_family.startswith(player + "/")
+
+
+@pytest.mark.parametrize("family", ["not-a-family", "", "Character-Bundle"])
+def test_illegal_family_rejected(family):
+    with pytest.raises(StableEntryError, match="production_family"):
+        stable_output_dir(family, "player")
+
+
+@pytest.mark.parametrize("asset_id", ["..", ".", "a/b", "a\\b", "C:", "con", "trail "])
+def test_illegal_asset_id_rejected(asset_id):
+    with pytest.raises(StableEntryError):
+        stable_output_dir("character-bundle", asset_id)
+
+
+# --- Path constraint --------------------------------------------------------
+
+def test_check_output_path_accepts_file_under_dir():
+    assert check_output_path(
+        "res://assets/generated/character-bundle/player/frames/idle.png",
+        production_family="character-bundle",
+        asset_id="player",
+        label="p",
+    )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "res://assets/generated/character-bundle/enemy/enemy.png",   # unrelated asset
+        "res://assets/generated/ui-kit/player/player.png",           # wrong family
+        "res://assets/generated/character-bundle/player",            # the dir itself
+        "res://assets/generated/character-bundle/player-final/x.png",  # drift dir
+        "res://tmp/character-bundle/player/x.png",                   # escape
+    ],
+)
+def test_check_output_path_rejects_off_target(path):
+    with pytest.raises(StableEntryError):
+        check_output_path(
+            path, production_family="character-bundle", asset_id="player", label="p"
+        )
+
+
+def test_assert_within_output_dir_accepts_in_tree_target(tmp_path):
+    root = tmp_path / "proj"
+    root.mkdir()
+    resolved = assert_within_output_dir(
+        root,
+        root / "assets/generated/ui-kit/coin/coin.png",
+        production_family="ui-kit",
+        asset_id="coin",
+    )
+    assert resolved == (root / "assets/generated/ui-kit/coin/coin.png").resolve()
+
+
+def test_assert_within_output_dir_rejects_symlinked_stable_dir(tmp_path, monkeypatch):
+    # If the stable directory itself is a symlink pointing out of the project,
+    # both it and the target resolve outside; the guard must still fail closed.
+    root = tmp_path / "proj"
+    root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    real_stable = Path.resolve(root) / "assets/generated/ui-kit/coin"
+    escaped = Path.resolve(outside) / "coin"
+    _symlink_escape_resolve(monkeypatch, real_stable, escaped)
+    with pytest.raises(StableEntryError, match="outside the project root"):
+        assert_within_output_dir(
+            root,
+            root / "assets/generated/ui-kit/coin/coin.png",
+            production_family="ui-kit",
+            asset_id="coin",
+        )
+
+
+def test_check_output_path_rejects_work_dependency():
+    with pytest.raises(StableEntryError, match="work/ workspace"):
+        check_output_path(
+            "res://.godotmaker/asset-generation/work/character-bundle/player/tmp.png",
+            production_family="character-bundle",
+            asset_id="player",
+            label="p",
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "res://C:/Windows/system.ini",   # Windows drive letter
+        "res://assets\\generated\\character-bundle\\player\\x.png",  # backslashes
+        "res:////server/share/x.png",    # UNC double slash
+        "assets/generated/character-bundle/player/x.png",           # missing res://
+    ],
+)
+def test_check_output_path_rejects_windows_and_res_escapes(path):
+    with pytest.raises(StableEntryError):
+        check_output_path(
+            path, production_family="character-bundle", asset_id="player", label="p"
+        )
+
+
+# --- Support files ----------------------------------------------------------
+
+def test_support_files_all_constrained():
+    ok = check_support_files(
+        [
+            "res://assets/generated/character-bundle/player/palette.gpl",
+            "res://assets/generated/character-bundle/player/meta/hitbox.json",
+        ],
+        production_family="character-bundle",
+        asset_id="player",
+    )
+    assert len(ok) == 2
+
+
+def test_support_files_reject_one_off_target():
+    with pytest.raises(StableEntryError, match="support_files\\[1\\]"):
+        check_support_files(
+            [
+                "res://assets/generated/character-bundle/player/palette.gpl",
+                "res://assets/generated/character-bundle/enemy/palette.gpl",
+            ],
+            production_family="character-bundle",
+            asset_id="player",
+        )
+
+
+def test_support_files_reject_non_list():
+    with pytest.raises(StableEntryError, match="must be a list"):
+        check_support_files(
+            "res://assets/generated/character-bundle/player/x.png",
+            production_family="character-bundle",
+            asset_id="player",
+        )
+
+
+# --- describe / check_paths helpers -----------------------------------------
+
+def test_describe_output_dir_shape():
+    result = describe_output_dir("tileset", "grass")
+    assert result == {
+        "ok": True,
+        "production_family": "tileset",
+        "asset_id": "grass",
+        "dir": "assets/generated/tileset/grass",
+        "res_dir": "res://assets/generated/tileset/grass",
+    }
+
+
+def test_check_paths_validates_all():
+    result = check_paths(
+        "character-bundle",
+        "player",
+        paths=["res://assets/generated/character-bundle/player/player.png"],
+        support_files=["res://assets/generated/character-bundle/player/palette.gpl"],
+    )
+    assert result["ok"] is True
+    assert result["checked_paths"] == [
+        "res://assets/generated/character-bundle/player/player.png"
+    ]
+
+
+# --- Entry-file validation --------------------------------------------------
+
+def test_check_entry_file_ok(tmp_path):
+    entry_file = tmp_path / "entry.json"
+    entry_file.write_text(json.dumps(valid_entry()), encoding="utf-8")
+    result = check_entry_file(
+        entry_file,
+        project_root=tmp_path,
+        support_files=["res://assets/generated/character-bundle/player/palette.gpl"],
+    )
+    assert result["ok"] is True
+    assert result["dir"] == "assets/generated/character-bundle/player"
+
+
+def test_check_entry_file_rejects_drifted_entry(tmp_path):
+    entry = valid_entry()
+    entry["godot_artifact"]["path"] = (
+        "res://assets/generated/character-bundle/player_v2/player.tres"
+    )
+    entry_file = tmp_path / "entry.json"
+    entry_file.write_text(json.dumps(entry), encoding="utf-8")
+    with pytest.raises(StableEntryError, match="must be a file under"):
+        check_entry_file(entry_file, project_root=tmp_path, support_files=[])
+
+
+# --- CLI --------------------------------------------------------------------
+
+def _run_cli(*args):
+    return subprocess.run(
+        [sys.executable, str(OUTPUT_TOOL), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_cli_computes_dir():
+    result = _run_cli("--family", "character-bundle", "--asset-id", "player")
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["dir"] == "assets/generated/character-bundle/player"
+    assert payload["res_dir"] == "res://assets/generated/character-bundle/player"
+
+
+def test_cli_validates_path():
+    ok = _run_cli(
+        "--family", "character-bundle", "--asset-id", "player",
+        "--path", "res://assets/generated/character-bundle/player/player.png",
+    )
+    assert ok.returncode == 0
+    assert json.loads(ok.stdout)["ok"] is True
+
+    bad = _run_cli(
+        "--family", "character-bundle", "--asset-id", "player",
+        "--path", "res://assets/generated/character-bundle/enemy/player.png",
+    )
+    assert bad.returncode == 1
+    assert json.loads(bad.stdout)["ok"] is False
+
+
+def test_cli_rejects_work_dependency():
+    result = _run_cli(
+        "--family", "character-bundle", "--asset-id", "player",
+        "--path", "res://.godotmaker/asset-generation/work/x.png",
+    )
+    assert result.returncode == 1
+    assert "work/ workspace" in json.loads(result.stdout)["error"]
+
+
+def test_cli_validates_entry(tmp_path):
+    entry_file = tmp_path / "entry.json"
+    entry_file.write_text(json.dumps(valid_entry()), encoding="utf-8")
+    result = _run_cli("--entry", str(entry_file), "--project-root", str(tmp_path))
+    assert result.returncode == 0
+    assert json.loads(result.stdout)["dir"] == "assets/generated/character-bundle/player"
+
+
+def test_cli_entry_rejects_conflicting_identity_flags(tmp_path):
+    entry_file = tmp_path / "entry.json"
+    entry_file.write_text(json.dumps(valid_entry()), encoding="utf-8")
+    result = _run_cli(
+        "--entry", str(entry_file), "--family", "character-bundle"
+    )
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["ok"] is False
+
+
+def test_cli_requires_identity_without_entry():
+    result = _run_cli("--path", "res://assets/generated/character-bundle/player/x.png")
+    assert result.returncode == 1
+    assert "required" in json.loads(result.stdout)["error"]

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -180,22 +180,121 @@ def test_godot_artifact_path_rejects_escapes():
         validate_entry(entry)
 
 
-def test_check_files_rejects_path_outside_root(tmp_path):
-    # A clean relative res:// path can never escape, but the post-resolve guard
-    # holds even if a symlink or ``project_root`` trick pointed elsewhere.
-    outside = tmp_path.parent / "outside"
-    outside.mkdir()
-    (outside / "leak.png").write_bytes(b"x")
+@pytest.mark.parametrize(
+    "path",
+    [
+        "res://assets/generated/ui-kit/player/player.png",           # wrong family
+        "res://assets/generated/character-bundle/enemy/player.png",  # unrelated asset dir
+        "res://assets/generated/character-bundle/player.png",        # missing asset dir
+        "res://assets/character-bundle/player/player.png",           # not under generated
+        "res://assets/generated/character-bundle/player-v2/x.png",   # v2 drift dir
+        "res://assets/generated/character-bundle/player_20240101/x.png",  # timestamp drift
+    ],
+)
+def test_source_layout_path_must_be_under_stable_dir(path):
+    entry = valid_entry()
+    entry["source_layout"]["path"] = path
+    with pytest.raises(StableEntryError, match="must be a file under"):
+        validate_entry(entry)
+
+
+def test_godot_artifact_path_must_be_under_stable_dir():
+    entry = valid_entry()
+    entry["godot_artifact"]["path"] = "res://assets/generated/character-bundle/enemy/enemy.tres"
+    with pytest.raises(StableEntryError, match="must be a file under"):
+        validate_entry(entry)
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "res://.godotmaker/asset-generation/work/character-bundle/player/player.png",
+        "res://.godotmaker/asset-generation/work",
+    ],
+)
+def test_work_dir_dependency_rejected(path):
+    entry = valid_entry()
+    entry["source_layout"]["path"] = path
+    with pytest.raises(StableEntryError, match="work/ workspace"):
+        validate_entry(entry)
+
+
+def test_nested_support_path_under_stable_dir_ok():
+    # A deeper file (e.g. a support frame) under the asset directory is allowed.
+    entry = valid_entry()
+    entry["source_layout"]["path"] = (
+        "res://assets/generated/character-bundle/player/frames/idle.png"
+    )
+    validate_entry(entry)
+
+
+def test_reference_layout_exempt_from_generated_tree():
+    # A reference is not a runtime handoff asset; it keeps its own location and
+    # is only held to res-path cleanliness.
+    validate_entry(reference_entry())
+    outside_tree = reference_entry(
+        source_layout={"type": "reference", "path": "res://docs/refs/title.png"}
+    )
+    validate_entry(outside_tree)
+
+
+def test_reference_layout_requires_reference_family():
+    # A runtime family must not use a reference layout to escape the stable-dir
+    # constraint with an arbitrary path.
+    entry = valid_entry(
+        source_layout={"type": "reference", "path": "res://docs/anything.png"},
+    )
+    del entry["godot_artifact"]
+    with pytest.raises(StableEntryError, match="reference source_layout is only allowed"):
+        validate_entry(entry)
+
+
+def test_reference_family_requires_reference_layout():
+    entry = reference_entry(
+        source_layout={
+            "type": "single",
+            "path": "res://assets/generated/screen-reference/title_screen/title_screen.png",
+        },
+    )
+    with pytest.raises(StableEntryError, match="must use a reference source_layout"):
+        validate_entry(entry)
+
+
+def test_containment_runs_without_check_files(tmp_path):
+    # A symlinked assets tree pointing outside the root must be rejected even
+    # when only a project_root is supplied (the index registration path), not
+    # just under check_files=True.
+    outside = tmp_path.parent / "outside_containment"
+    outside.mkdir(exist_ok=True)
     root = tmp_path / "proj"
     root.mkdir()
-    # Symlink a directory inside the root to a sibling outside it.
+    try:
+        (root / "assets").symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not permitted on this platform")
+    with pytest.raises(StableEntryError, match="outside the project root"):
+        validate_entry(valid_entry(), project_root=root)
+
+
+def test_check_files_rejects_path_outside_root(tmp_path):
+    # A clean, constraint-conforming res:// path can never escape, but the
+    # post-resolve guard holds even if a symlink or ``project_root`` trick
+    # pointed the stable directory elsewhere.
+    outside = tmp_path.parent / "outside"
+    outside.mkdir()
+    root = tmp_path / "proj"
+    root.mkdir()
+    # Symlink the whole assets tree inside the root to a sibling outside it.
     link = root / "assets"
     try:
         link.symlink_to(outside, target_is_directory=True)
     except (OSError, NotImplementedError):
         pytest.skip("symlinks not permitted on this platform")
     entry = valid_entry(
-        source_layout={"type": "single", "path": "res://assets/leak.png"},
+        source_layout={
+            "type": "single",
+            "path": "res://assets/generated/character-bundle/player/player.png",
+        },
     )
     del entry["godot_artifact"]
     entry["processing_status"] = "source_ready"

--- a/tools/asset_output_path.py
+++ b/tools/asset_output_path.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Compute and validate stable generated-asset output paths.
+
+Every worker-consumable generated file for one asset lives under a single,
+identity-derived directory::
+
+    assets/generated/<production_family>/<asset_id>/
+
+This tool is the deterministic authority for that constraint. It can:
+
+- print the canonical output directory for a ``(production_family, asset_id)``
+  pair (``--family`` + ``--asset-id``);
+- validate that a ``res://`` path (source image, native Godot artifact, or
+  support file) sits under that directory and does not depend on the temporary
+  generation ``work/`` workspace (``--path`` / ``--support-file``);
+- validate a whole stable entry file plus its declared support files
+  (``--entry``), deriving the identity from the entry itself.
+
+Because the directory is derived from stable identity, regeneration overwrites
+the same target in place; a timestamped, ``v2``, or ``final`` drift path, an
+out-of-tree escape, an illegal family/asset_id, or a ``work/`` dependency is
+rejected. This tool never writes or deletes files.
+
+The path constraint itself is enforced at the schema layer by
+``asset_stable_entry.validate_entry``; this tool exposes the same checks as a
+standalone command for the registration path.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from asset_stable_entry import (
+    StableEntryError,
+    _load_json,
+    check_output_path,
+    check_support_files,
+    stable_output_dir,
+    stable_output_res_path,
+    validate_entry,
+)
+
+
+def describe_output_dir(production_family: str, asset_id: str) -> dict[str, Any]:
+    """Return the canonical output directory for one asset, both forms."""
+    relative = stable_output_dir(production_family, asset_id)
+    return {
+        "ok": True,
+        "production_family": production_family,
+        "asset_id": asset_id,
+        "dir": relative,
+        "res_dir": stable_output_res_path(production_family, asset_id),
+    }
+
+
+def check_paths(
+    production_family: str,
+    asset_id: str,
+    *,
+    paths: list[str],
+    support_files: list[str],
+) -> dict[str, Any]:
+    """Validate arbitrary output and support paths against the stable directory."""
+    for index, path in enumerate(paths):
+        check_output_path(
+            path,
+            production_family=production_family,
+            asset_id=asset_id,
+            label=f"path[{index}]",
+        )
+    check_support_files(
+        support_files, production_family=production_family, asset_id=asset_id
+    )
+    result = describe_output_dir(production_family, asset_id)
+    result["checked_paths"] = list(paths)
+    result["checked_support_files"] = list(support_files)
+    return result
+
+
+def check_entry_file(
+    entry_path: Path,
+    *,
+    project_root: Path,
+    support_files: list[str],
+    check_files: bool = False,
+) -> dict[str, Any]:
+    """Validate a stable entry's paths, then its declared support files."""
+    entry = _load_json(Path(entry_path))
+    validated = validate_entry(
+        entry, project_root=project_root, check_files=check_files
+    )
+    production_family = validated["production_family"]
+    asset_id = validated["asset_id"]
+    check_support_files(
+        support_files, production_family=production_family, asset_id=asset_id
+    )
+    result = describe_output_dir(production_family, asset_id)
+    result["entry"] = str(entry_path)
+    result["checked_support_files"] = list(support_files)
+    return result
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Compute and validate stable generated-asset output paths"
+    )
+    parser.add_argument("--family", help="Production family (e.g. character-bundle)")
+    parser.add_argument("--asset-id", help="Stable asset identifier")
+    parser.add_argument(
+        "--path",
+        action="append",
+        default=[],
+        help="res:// path to validate against the stable directory (repeatable)",
+    )
+    parser.add_argument(
+        "--support-file",
+        action="append",
+        default=[],
+        help="res:// support-file path to validate (repeatable)",
+    )
+    parser.add_argument(
+        "--entry",
+        type=Path,
+        help="Stable entry JSON file; identity and paths are read from it",
+    )
+    parser.add_argument("--project-root", default=".", type=Path)
+    parser.add_argument(
+        "--check-files",
+        action="store_true",
+        help="With --entry, verify referenced source/artifact files exist",
+    )
+    args = parser.parse_args()
+
+    try:
+        if args.entry is not None:
+            if args.family or args.asset_id or args.path:
+                raise StableEntryError(
+                    "--entry derives identity from the file; do not pass "
+                    "--family/--asset-id/--path"
+                )
+            result = check_entry_file(
+                args.entry,
+                project_root=args.project_root,
+                support_files=args.support_file,
+                check_files=args.check_files,
+            )
+        else:
+            if not args.family or not args.asset_id:
+                raise StableEntryError(
+                    "--family and --asset-id are required without --entry"
+                )
+            if args.path or args.support_file:
+                result = check_paths(
+                    args.family,
+                    args.asset_id,
+                    paths=args.path,
+                    support_files=args.support_file,
+                )
+            else:
+                result = describe_output_dir(args.family, args.asset_id)
+    except StableEntryError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -53,6 +53,13 @@ SOURCE_LAYOUT_TYPES = {
 # Reference-only sources are never handed to workers as runtime game assets.
 REFERENCE_LAYOUTS = {"reference"}
 
+# Families whose assets are reference-only. A ``reference`` layout is legal only
+# for these, and these families must use a ``reference`` layout. Binding the two
+# closes the fail-open where a runtime family (e.g. ``character-bundle``) could
+# declare a ``reference`` layout to slip an arbitrary path past the stable-dir
+# constraint.
+REFERENCE_FAMILIES = {"screen-reference"}
+
 # Processing status maps to the L0-L4 readiness ladder.
 PROCESSING_STATUSES = {
     "pending",       # L0 only; nothing produced yet
@@ -91,6 +98,22 @@ _RESERVED_DEVICE_NAMES = {
 }
 
 _RES_PREFIX = "res://"
+
+# Every worker-consumable generated file (source image, native Godot artifact,
+# and required support files) lives under a deterministic, per-asset directory::
+#
+#     assets/generated/<production_family>/<asset_id>/
+#
+# Pinning outputs to this directory is what keeps timestamped, ``v2``, or
+# ``final`` drift paths out of the runtime handoff: the location is derived from
+# stable identity, so regeneration overwrites in place and never touches an
+# unrelated asset's directory. Reference-only layouts are handed to nobody as a
+# runtime game asset and keep their existing location outside this tree.
+GENERATED_ROOT = "assets/generated"
+
+# The generation workspace is temporary; no runtime handoff path may depend on
+# it (design: "No consumer may depend on files under work/").
+WORK_ROOT = ".godotmaker/asset-generation/work"
 
 # Both nested contract objects hold exactly a type and a path. Internal detail
 # (receipts, hashes, versions) belongs at the entry top level, never inside the
@@ -195,7 +218,121 @@ def _assert_within_root(project_root: Path, resolved: Path, label: str) -> None:
         raise StableEntryError(f"{label} resolves outside the project root")
 
 
-def _validate_source_layout(data: dict[str, Any]) -> tuple[str, str]:
+def stable_output_dir(production_family: str, asset_id: str) -> str:
+    """Return the canonical project-relative output directory for one asset.
+
+    The directory is derived only from stable identity, so it is deterministic
+    and unique per ``(production_family, asset_id)``. Every source image, native
+    Godot artifact, and support file for the asset must live under it.
+    """
+    if production_family not in PRODUCTION_FAMILIES:
+        raise StableEntryError(f"production_family is not allowed: {production_family}")
+    _safe_identifier(asset_id, "asset_id")
+    return f"{GENERATED_ROOT}/{production_family}/{asset_id}"
+
+
+def stable_output_res_path(production_family: str, asset_id: str) -> str:
+    """Return the ``res://`` form of the asset's canonical output directory."""
+    return _RES_PREFIX + stable_output_dir(production_family, asset_id)
+
+
+def check_output_path(
+    value: str,
+    *,
+    production_family: str,
+    asset_id: str,
+    label: str,
+) -> str:
+    """Require a ``res://`` file strictly under the asset's stable directory.
+
+    On top of ``_check_res_path`` cleanliness this enforces that ``value`` names
+    a file under ``assets/generated/<production_family>/<asset_id>/`` and never
+    depends on the temporary generation ``work/`` workspace. A drifting
+    location (``v2``, ``final``, a timestamped or unrelated directory) cannot
+    satisfy the exact-prefix requirement, so it fails closed.
+    """
+    _check_res_path(value, label)
+    remainder = value[len(_RES_PREFIX):]
+    if remainder == WORK_ROOT or remainder.startswith(WORK_ROOT + "/"):
+        raise StableEntryError(
+            f"{label} must not depend on the generation work/ workspace"
+        )
+    stable_dir = stable_output_dir(production_family, asset_id)
+    # A clean res path never ends in ``/`` (``_check_res_path`` rejects an empty
+    # last segment), so an exact-prefix match with the trailing slash guarantees
+    # a real file strictly under the directory, not the directory itself.
+    if not remainder.startswith(stable_dir + "/"):
+        raise StableEntryError(f"{label} must be a file under res://{stable_dir}/")
+    return value
+
+
+def check_support_files(
+    paths: Any,
+    *,
+    production_family: str,
+    asset_id: str,
+) -> list[str]:
+    """Validate that every required support file is under the stable directory."""
+    if not isinstance(paths, (list, tuple)):
+        raise StableEntryError("support files must be a list of res:// paths")
+    validated: list[str] = []
+    for index, path in enumerate(paths):
+        if not isinstance(path, str) or not path.strip():
+            raise StableEntryError(f"support_files[{index}] must be a non-empty string")
+        check_output_path(
+            path,
+            production_family=production_family,
+            asset_id=asset_id,
+            label=f"support_files[{index}]",
+        )
+        validated.append(path)
+    return validated
+
+
+def assert_within_output_dir(
+    project_root: Path,
+    target: Path | str,
+    *,
+    production_family: str,
+    asset_id: str,
+    label: str = "output",
+) -> Path:
+    """Assert an on-disk write target sits strictly under the asset's stable dir.
+
+    This is the write-time counterpart of ``check_output_path``: generation and
+    finalize tools call it before writing so a run can only ever touch its own
+    ``assets/generated/<production_family>/<asset_id>/`` directory, never an
+    unrelated asset's. A relative ``target`` is resolved against ``project_root``.
+    Symlinks are followed (``resolve``), so an in-tree link pointing elsewhere is
+    rejected too.
+    """
+    root = Path(project_root).resolve()
+    relative_dir = stable_output_dir(production_family, asset_id)
+    stable = (root / relative_dir).resolve()
+    # The stable directory itself must stay inside the project. Checking only
+    # ``resolved`` against a resolved ``stable`` is not enough: if the stable
+    # directory (or an ancestor) is a symlink pointing out of the project, both
+    # it and the target resolve outside and the containment check passes while
+    # the write still escapes. Anchor ``stable`` to ``root`` first.
+    if stable != root and not stable.is_relative_to(root):
+        raise StableEntryError(
+            f"{label} stable directory resolves outside the project root"
+        )
+    resolved = Path(target)
+    if not resolved.is_absolute():
+        resolved = root / resolved
+    resolved = resolved.resolve()
+    if resolved == stable or not resolved.is_relative_to(stable):
+        raise StableEntryError(f"{label} must be written under {relative_dir}/")
+    return resolved
+
+
+def _validate_source_layout(
+    data: dict[str, Any],
+    *,
+    production_family: str,
+    asset_id: str,
+) -> tuple[str, str]:
     layout = data.get("source_layout")
     if not isinstance(layout, dict):
         raise StableEntryError("source_layout must be an object")
@@ -205,7 +342,18 @@ def _validate_source_layout(data: dict[str, Any]) -> tuple[str, str]:
     if layout_type not in SOURCE_LAYOUT_TYPES:
         raise StableEntryError(f"source_layout.type is not allowed: {layout_type}")
     layout_path = _non_empty_string(layout, "path", "source_layout.path")
-    _check_res_path(layout_path, "source_layout.path")
+    if layout_type in REFERENCE_LAYOUTS:
+        # A reference is never handed to a worker as a runtime game asset, so it
+        # falls outside the stable generated tree; only res-path cleanliness
+        # applies.
+        _check_res_path(layout_path, "source_layout.path")
+    else:
+        check_output_path(
+            layout_path,
+            production_family=production_family,
+            asset_id=asset_id,
+            label="source_layout.path",
+        )
     return layout_type, layout_path
 
 
@@ -214,6 +362,8 @@ def _validate_godot_artifact(
     *,
     layout_type: str,
     processing_status: str,
+    production_family: str,
+    asset_id: str,
 ) -> tuple[str, str] | None:
     artifact = data.get("godot_artifact")
     is_reference = layout_type in REFERENCE_LAYOUTS
@@ -242,7 +392,12 @@ def _validate_godot_artifact(
             "godot_artifact.type must be a Godot ClassDB type identifier"
         )
     artifact_path = _non_empty_string(artifact, "path", "godot_artifact.path")
-    _check_res_path(artifact_path, "godot_artifact.path")
+    check_output_path(
+        artifact_path,
+        production_family=production_family,
+        asset_id=asset_id,
+        label="godot_artifact.path",
+    )
     return artifact_type, artifact_path
 
 
@@ -261,7 +416,8 @@ def validate_entry(
     if not is_schema_version(data.get("version")):
         raise StableEntryError(f"Stable entry version must be integer {SCHEMA_VERSION}")
 
-    _safe_identifier(_non_empty_string(data, "asset_id", "asset_id"), "asset_id")
+    asset_id = _non_empty_string(data, "asset_id", "asset_id")
+    _safe_identifier(asset_id, "asset_id")
     _safe_identifier(_non_empty_string(data, "tag", "tag"), "tag")
 
     family = _non_empty_string(data, "production_family", "production_family")
@@ -276,27 +432,49 @@ def validate_entry(
             f"processing_status is not allowed: {processing_status}"
         )
 
-    layout_type, layout_path = _validate_source_layout(data)
+    layout_type, layout_path = _validate_source_layout(
+        data, production_family=family, asset_id=asset_id
+    )
+    # Bind reference layout and reference family so neither can be used to
+    # bypass the other's contract.
+    if layout_type in REFERENCE_LAYOUTS and family not in REFERENCE_FAMILIES:
+        raise StableEntryError(
+            "a reference source_layout is only allowed for a reference family "
+            f"({', '.join(sorted(REFERENCE_FAMILIES))})"
+        )
+    if family in REFERENCE_FAMILIES and layout_type not in REFERENCE_LAYOUTS:
+        raise StableEntryError(
+            f"production_family {family} must use a reference source_layout"
+        )
     artifact = _validate_godot_artifact(
-        data, layout_type=layout_type, processing_status=processing_status
+        data,
+        layout_type=layout_type,
+        processing_status=processing_status,
+        production_family=family,
+        asset_id=asset_id,
     )
 
-    if check_files:
-        if project_root is None:
-            raise StableEntryError("project_root is required to check files")
+    # Whenever a project root is supplied, resolve-and-contain the referenced
+    # paths even if existence is not being checked. The root-index registration
+    # path (``check_index(..., check_entries=True)``) calls this with only a
+    # project root, so containment must not be gated behind ``check_files`` or a
+    # symlinked ``assets/generated`` could pass registration.
+    if project_root is not None:
         root = Path(project_root)
         source_file = _resolve_res_path(root, layout_path)
         _assert_within_root(root, source_file, "source_layout.path")
-        if not source_file.exists():
+        if check_files and not source_file.exists():
             raise StableEntryError(f"source_layout.path not found: {layout_path}")
         if artifact is not None:
             _, artifact_path = artifact
             artifact_file = _resolve_res_path(root, artifact_path)
             _assert_within_root(root, artifact_file, "godot_artifact.path")
-            if not artifact_file.exists():
+            if check_files and not artifact_file.exists():
                 raise StableEntryError(
                     f"godot_artifact.path not found: {artifact_path}"
                 )
+    elif check_files:
+        raise StableEntryError("project_root is required to check files")
 
     return data
 


### PR DESCRIPTION
## Summary

Constrain every worker-consumable generated file (source images, native Godot
artifacts, and required support files) to a single, identity-derived directory:

```
assets/generated/<production_family>/<asset_id>/
```

This keeps timestamped / `v2` / `final` drift paths, project escapes, illegal
identities, and temporary `work/` dependencies out of the runtime handoff.

## Motivation

The v1 generated-asset stable entry / root index schema pins runtime handoff
data, but nothing forced the referenced output paths onto a deterministic,
per-asset location. Drift paths could still enter the handoff. This PR adds the
stable output-path constraint on top of the existing schema.

## Changes

- [x] Add `tools/asset_output_path.py`: deterministic authority that computes
      and validates the `assets/generated/<family>/<asset_id>/` directory, a
      `res://` path, a stable entry file, or a list of support files (CLI +
      importable functions).
- [x] Enforce the constraint in `asset_stable_entry.validate_entry` on
      non-reference `source_layout.path` and on `godot_artifact.path`; add
      `stable_output_dir` / `stable_output_res_path` / `check_output_path` /
      `check_support_files`, plus `GENERATED_ROOT` / `WORK_ROOT`.
- [x] Reject, fail-closed: path escape / drift dir (`v2`, `final`, timestamp,
      unrelated asset), illegal `production_family`, illegal `asset_id`, and any
      dependency on `.godotmaker/asset-generation/work/`.
- [x] Reference-only layouts stay exempt (they are not runtime handoff assets).
- [x] Tests: new `tests/tools/test_asset_output_path.py`; extend
      `test_asset_stable_entry.py`; keep `test_asset_generation_index.py`
      meaningful under the tightened contract.
- [x] `docs/update/next.md` Added entry.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

Targeted: `pytest tests/tools tests/test_asset_runtime_contract_docs.py` -> 818
passed, 1 skipped. Full: `python -m pytest tests/` -> 1249 passed, 1 skipped
(the single skip is a symlink test that needs privileges Windows does not grant
here; the post-resolve within-root guard is still covered directly).
`ruff check .` -> All checks passed.

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed

This is part of the v1.0.0 breaking generated-asset contract. Per the issue
scope it adds no migration script, compatibility reader, dual write, or legacy
`runtime_artifact` fallback; non-conforming state fails closed and is
regenerated through `/gm-asset`.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
