### PR TITLE
Allow StyleBoxTexture stable entries

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -32,7 +32,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - `asset_generation_index.py --check-files` verifies that every registered source and artifact still exists, catching an asset deleted after registration.
 - Generated assets now stop at `source_ready`: the native compilers and the L0-L4 runner are not implemented, so `/gm-asset` registers stable entries but produces no worker-consumable runtime asset and leaves generated ASSETS.md rows `MISSING`.
 - `godot_artifact` is written only by a native compiler, so a `grid_sheet` can no longer be published as a `Texture2D` standing in for its unbuilt `SpriteFrames`.
-- The stable-entry schema now binds each `source_layout.type` to the Godot resource it compiles to, so a mismatched `godot_artifact.type` is rejected instead of reaching a worker.
+- The stable-entry schema now validates each `source_layout.type` against its closed compatible Godot artifact-type set, including `StyleBoxTexture` for `single` and `region_atlas`, so mismatches are rejected before reaching a worker.
 
 ## Fixed
 

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -234,6 +234,19 @@ python tools/asset_output_path.py --entry <entry.json> --project-root . --check-
 stable identity plus `production_family`, `source_layout`, an optional minimal
 `godot_artifact`, and `processing_status` — nothing else.
 
+For non-reference entries, `godot_artifact.type` must be a Godot ClassDB
+identifier in the closed layout compatibility set; it is not an allow-list for
+arbitrary ClassDB types:
+
+| `source_layout.type` | Allowed `godot_artifact.type` |
+|---|---|
+| `single` | `Texture2D` or `StyleBoxTexture` |
+| `region_atlas` | `AtlasTexture` or `StyleBoxTexture` |
+| `grid_sheet` | `SpriteFrames` |
+| `theme_recipe` | `Theme` |
+| `tile_atlas` | `TileSet` |
+| `reference` | no `godot_artifact` |
+
 Manual entry point:
 
 ```bash

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -192,6 +192,19 @@ python tools/asset_output_path.py --entry <entry.json> --project-root . --check-
 
 `asset_stable_entry.py` 校验一个 v1 stable entry，并把它序列化到 `.godotmaker/asset-generation/entries/<tag>/<asset_id>.json`。entry 只保存稳定身份加上 `production_family`、`source_layout`、可选的最小 `godot_artifact` 和 `processing_status`，不保存其他字段。
 
+对于非 `reference` entry，`godot_artifact.type` 必须是 Godot ClassDB
+标识符，且必须位于下列封闭的 layout 兼容集合中；这不表示可以使用任意
+ClassDB 类型：
+
+| `source_layout.type` | 允许的 `godot_artifact.type` |
+|---|---|
+| `single` | `Texture2D` 或 `StyleBoxTexture` |
+| `region_atlas` | `AtlasTexture` 或 `StyleBoxTexture` |
+| `grid_sheet` | `SpriteFrames` |
+| `theme_recipe` | `Theme` |
+| `tile_atlas` | `TileSet` |
+| `reference` | 不带 `godot_artifact` |
+
 手动入口：
 
 ```bash

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -296,9 +296,9 @@ compilation and verification arrive with the compiler work.
 
 Compiler target compatibility by source layout, for when that work lands:
 
-1. `single`: `Texture2D` or `StyleBoxTexture`.
+1. `single`: `Texture2D`, no support file; or `StyleBoxTexture`.
 2. `grid_sheet`: `SpriteFrames`, with action metadata beside the artifact.
-3. `region_atlas`: `AtlasTexture` or `StyleBoxTexture`.
+3. `region_atlas`: `AtlasTexture` or `StyleBoxTexture`, with atlas metadata beside the artifact.
 4. `theme_recipe`: `Theme`. `tile_atlas`: `TileSet`.
 5. `reference`: no artifact; never mark an ASSETS runtime row generated from it.
 

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -123,16 +123,18 @@ stable identity plus the minimal contract a worker needs, and nothing else:
 Rules:
 
 1. `source_layout` holds exactly `type` and `path`.
-2. `godot_artifact` holds exactly `type` and `path`. `type` is the Godot ClassDB
-   type the native compiler produced for this layout:
+2. `godot_artifact` holds exactly `type` and `path`. `type` is a Godot ClassDB
+   identifier the native compiler may produce for this layout. The table is a
+   closed compatibility set, not permission to use any ClassDB type:
 
-   | `source_layout.type` | Compiled `godot_artifact.type` |
+   | `source_layout.type` | Allowed `godot_artifact.type` |
    |---|---|
+   | `single` | `Texture2D` or `StyleBoxTexture` |
    | `grid_sheet` | `SpriteFrames` |
-   | `region_atlas` | `AtlasTexture` |
+   | `region_atlas` | `AtlasTexture` or `StyleBoxTexture` |
    | `theme_recipe` | `Theme` |
    | `tile_atlas` | `TileSet` |
-   | `single` | `Texture2D` |
+   | `reference` | no `godot_artifact` |
 
 3. Both paths are `res://` paths under the asset's stable output directory. A
    path under `.godotmaker/` is rejected, so finalize into the stable directory
@@ -292,11 +294,11 @@ so `/gm-build` and worker dispatch currently receive no generated runtime assets
 Registration, stable paths, and the pointer index are what this stage delivers;
 compilation and verification arrive with the compiler work.
 
-Compiler target by source layout, for when that work lands:
+Compiler target compatibility by source layout, for when that work lands:
 
-1. `single`: `Texture2D`, no support file.
+1. `single`: `Texture2D` or `StyleBoxTexture`.
 2. `grid_sheet`: `SpriteFrames`, with action metadata beside the artifact.
-3. `region_atlas`: `AtlasTexture`, with atlas metadata beside the artifact.
+3. `region_atlas`: `AtlasTexture` or `StyleBoxTexture`.
 4. `theme_recipe`: `Theme`. `tile_atlas`: `TileSet`.
 5. `reference`: no artifact; never mark an ASSETS runtime row generated from it.
 

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -1,5 +1,6 @@
 import copy
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -75,7 +76,11 @@ def test_every_non_reference_layout_has_an_artifact_type():
 
 @pytest.mark.parametrize(
     ("layout", "artifact_type"),
-    sorted(LAYOUT_ARTIFACT_TYPES.items()),
+    [
+        (layout, artifact_type)
+        for layout, artifact_types in sorted(LAYOUT_ARTIFACT_TYPES.items())
+        for artifact_type in artifact_types
+    ],
 )
 def test_matching_artifact_type_is_accepted(layout, artifact_type):
     entry = valid_entry(
@@ -88,6 +93,22 @@ def test_matching_artifact_type_is_accepted(layout, artifact_type):
             "path": "res://assets/generated/character-bundle/player/player.tres",
         },
     )
+    validate_entry(entry)
+
+
+@pytest.mark.parametrize("layout", ["single", "region_atlas"])
+def test_styleboxtexture_artifact_type_is_accepted_for_compatible_layouts(layout):
+    entry = valid_entry(
+        source_layout={
+            "type": layout,
+            "path": "res://assets/generated/character-bundle/player/player.png",
+        },
+        godot_artifact={
+            "type": "StyleBoxTexture",
+            "path": "res://assets/generated/character-bundle/player/player.tres",
+        },
+    )
+
     validate_entry(entry)
 
 
@@ -117,10 +138,10 @@ def test_mismatched_artifact_type_is_rejected(layout, artifact_type):
             "path": "res://assets/generated/character-bundle/player/player.tres",
         },
     )
-    expected = LAYOUT_ARTIFACT_TYPES[layout]
+    expected = ", ".join(LAYOUT_ARTIFACT_TYPES[layout])
     with pytest.raises(
         StableEntryError,
-        match=f"must be {expected}, not {artifact_type}",
+        match=re.escape(f"must be one of: {expected}; not {artifact_type}"),
     ):
         validate_entry(entry)
 

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -72,6 +72,17 @@ def test_every_non_reference_layout_has_an_artifact_type():
     instead of a contract error.
     """
     assert set(LAYOUT_ARTIFACT_TYPES) == SOURCE_LAYOUT_TYPES - REFERENCE_LAYOUTS
+    assert all(
+        isinstance(artifact_types, tuple) and artifact_types
+        for artifact_types in LAYOUT_ARTIFACT_TYPES.values()
+    )
+    assert LAYOUT_ARTIFACT_TYPES == {
+        "single": ("Texture2D", "StyleBoxTexture"),
+        "grid_sheet": ("SpriteFrames",),
+        "region_atlas": ("AtlasTexture", "StyleBoxTexture"),
+        "theme_recipe": ("Theme",),
+        "tile_atlas": ("TileSet",),
+    }
 
 
 @pytest.mark.parametrize(
@@ -96,22 +107,6 @@ def test_matching_artifact_type_is_accepted(layout, artifact_type):
     validate_entry(entry)
 
 
-@pytest.mark.parametrize("layout", ["single", "region_atlas"])
-def test_styleboxtexture_artifact_type_is_accepted_for_compatible_layouts(layout):
-    entry = valid_entry(
-        source_layout={
-            "type": layout,
-            "path": "res://assets/generated/character-bundle/player/player.png",
-        },
-        godot_artifact={
-            "type": "StyleBoxTexture",
-            "path": "res://assets/generated/character-bundle/player/player.tres",
-        },
-    )
-
-    validate_entry(entry)
-
-
 @pytest.mark.parametrize(
     ("layout", "artifact_type"),
     [
@@ -125,6 +120,9 @@ def test_styleboxtexture_artifact_type_is_accepted_for_compatible_layouts(layout
         ("grid_sheet", "AtlasTexture"),
         ("region_atlas", "SpriteFrames"),
         ("single", "Resource"),
+        ("grid_sheet", "StyleBoxTexture"),
+        ("theme_recipe", "StyleBoxTexture"),
+        ("tile_atlas", "StyleBoxTexture"),
     ],
 )
 def test_mismatched_artifact_type_is_rejected(layout, artifact_type):

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -72,7 +72,8 @@ PROCESSING_STATUSES = {
 # Statuses that require a compiled ``godot_artifact`` for non-reference assets.
 ARTIFACT_REQUIRED_STATUSES = {"compiled", "ready"}
 
-# ``godot_artifact.type`` is a Godot ClassDB type, not a closed enum.
+# ``godot_artifact.type`` has the shape of a Godot ClassDB identifier, while
+# the layout-to-type compatibility relation below is deliberately closed.
 GODOT_TYPE_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # The Godot resource types each non-reference layout may compile to. The

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -75,18 +75,21 @@ ARTIFACT_REQUIRED_STATUSES = {"compiled", "ready"}
 # ``godot_artifact.type`` is a Godot ClassDB type, not a closed enum.
 GODOT_TYPE_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-# The Godot resource each non-reference layout compiles to. The pairing is fixed:
-# a ``grid_sheet`` published as a plain ``Texture2D`` is a static image standing
+# The Godot resource types each non-reference layout may compile to. The
+# compatibility relation is deliberately closed: Godot ClassDB identifiers are
+# not a general allow-list. A ``StyleBoxTexture`` may use either a single image
+# or a region from an atlas, while every other layout has one permitted result.
+# A ``grid_sheet`` published as a plain ``Texture2D`` is a static image standing
 # in for the ``SpriteFrames`` the worker was promised, and binding it yields a
 # frozen sprite where an animation was specified. Declaring the source image as
 # the artifact is the exact shortcut this mapping exists to reject, so a type
 # that does not match its layout fails closed rather than reaching a worker.
 LAYOUT_ARTIFACT_TYPES = {
-    "single": "Texture2D",
-    "grid_sheet": "SpriteFrames",
-    "region_atlas": "AtlasTexture",
-    "theme_recipe": "Theme",
-    "tile_atlas": "TileSet",
+    "single": ("Texture2D", "StyleBoxTexture"),
+    "grid_sheet": ("SpriteFrames",),
+    "region_atlas": ("AtlasTexture", "StyleBoxTexture"),
+    "theme_recipe": ("Theme",),
+    "tile_atlas": ("TileSet",),
 }
 
 # Any of these fields marks an old ``runtime_artifact`` manifest/entry.
@@ -405,11 +408,11 @@ def _validate_godot_artifact(
         raise StableEntryError(
             "godot_artifact.type must be a Godot ClassDB type identifier"
         )
-    expected_type = LAYOUT_ARTIFACT_TYPES[layout_type]
-    if artifact_type != expected_type:
+    allowed_types = LAYOUT_ARTIFACT_TYPES[layout_type]
+    if artifact_type not in allowed_types:
         raise StableEntryError(
             f"godot_artifact.type for a {layout_type} source_layout must be "
-            f"{expected_type}, not {artifact_type}"
+            f"one of: {', '.join(allowed_types)}; not {artifact_type}"
         )
     artifact_path = _non_empty_string(artifact, "path", "godot_artifact.path")
     check_output_path(


### PR DESCRIPTION
## Summary

- Allow StyleBoxTexture stable artifacts for single and region_atlas source layouts.
- Keep the layout/artifact compatibility relation closed and report every allowed type on a mismatch.
- Synchronize runtime guidance, public English and Chinese tool docs, tests, and release notes.

## Motivation

`tools/asset_stable_entry.py` validated `source_layout.type -> godot_artifact.type` as a strict one-to-one mapping, which rejected the v1-authorized StyleBoxTexture combinations for `single` and `region_atlas` layouts before the compiler registry / StyleBoxTexture compiler landed. This corrects the compatibility relation to match the authoritative design while keeping unlisted combinations fail-closed.

Related Multica issue: WOR-239

## Changes

- [x] Widen the validator's layout/artifact mapping to a compatibility set: `single -> Texture2D | StyleBoxTexture`, `region_atlas -> AtlasTexture | StyleBoxTexture`, `grid_sheet -> SpriteFrames`, `theme_recipe -> Theme`, `tile_atlas -> TileSet`, `reference -> no godot_artifact`.
- [x] Keep unlisted layout/artifact combinations rejected, with error messages listing all allowed types.
- [x] Synchronize `skills/core/gm-asset/references/asset-runtime-pipeline.md` and the public English/Chinese tool docs (`docs/wiki/05-tools/asset-tools.md`, `docs/zh/wiki/05-tools/asset-tools.md`).
- [x] Update `tests/tools/test_asset_stable_entry.py` to cover the new legal StyleBoxTexture paths and confirm mismatches still fail.

## Testing

- [x] New or updated tests pass (`python -m pytest tests/tools/test_asset_stable_entry.py`; `python -m pytest`)
- [x] Gitleaks passes or no secret-bearing files were touched (no secret-bearing files touched; CI Secret Scan check green)
- [ ] Manual testing completed, if applicable — not applicable (validator/doc-only change, covered by automated tests)

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed (widens validator acceptance for an already-authorized combination; no file moves or config key renames)

### Migration Upgrade Gate

Not applicable — no migration script was added or modified in this PR.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — not applicable (no ECS systems touched)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
