### PR TITLE
Add fixed-slot atlas PNG assembler

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,6 +17,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
+- Added `tools/asset_atlas_assemble.py` for reproducible fixed-slot physical PNG atlases and region metadata; it rejects implicit packing, trimming, heuristic discovery, invalid bounds, overlap, size mismatches, and missing source PNGs.
 - v1 generated-asset stable entry and root index schema: `tools/asset_stable_entry.py` (per-asset `production_family` / `source_layout` / minimal `godot_artifact` / `processing_status` entry written to `.godotmaker/asset-generation/entries/<tag>/<asset_id>.json`) and `tools/asset_generation_index.py` (pointer-only root index). Old `runtime_artifact` schema fails closed and must be regenerated through `/gm-asset`; no migration or compatibility read is provided.
 - Stable generated-asset output-path contract: deterministic `assets/generated/<production_family>/<asset_id>/` resolver (`tools/asset_output_path.py`), fail-closed stable-entry path validation, and a reusable `assert_within_output_dir` write guard.
 - Added a standalone asset-skill invocation and result contract under `skills/assets/_shared/` with declarative JSON schemas, valid samples, a dependency-free checker, and fail-closed tests (#98).

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -18,6 +18,7 @@ Primary pipeline tools:
 10. `asset_stable_entry.py`
 11. `asset_generation_index.py`
 12. `asset_assets_md_update.py`
+13. `asset_atlas_assemble.py`
 
 ## asset_source_generate.py
 
@@ -226,6 +227,30 @@ Manual entry point:
 python tools/asset_output_path.py --family <production_family> --asset-id <asset_id>
 python tools/asset_output_path.py --entry <entry.json> --project-root . --check-files
 ```
+
+## asset_atlas_assemble.py
+
+`asset_atlas_assemble.py` builds a physical PNG atlas from an explicit JSON
+declaration of slot rectangles. It does not pack, trim, resize, or discover
+regions. Sources are project-root-relative PNG paths whose dimensions must
+exactly equal their declared slots; output PNG and metadata paths must both be
+inside `assets/generated/<production_family>/<asset_id>/`.
+
+Manual entry point:
+
+```bash
+python tools/asset_atlas_assemble.py \
+  --declaration <fixed_slots.json> \
+  --atlas-out assets/generated/ui-kit/<asset_id>/<asset_id>.png \
+  --metadata-out assets/generated/ui-kit/<asset_id>/<asset_id>.json \
+  --family ui-kit \
+  --asset-id <asset_id> \
+  --project-root .
+```
+
+The tool writes the physical atlas and its deterministic region metadata as one
+rollback-protected output pair. It is the fixed-slot assembly step; compiling
+the metadata to `AtlasTexture` is a separate compiler step.
 
 ## asset_stable_entry.py
 

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -16,6 +16,7 @@ GodotMaker 通过几个小型 Python 辅助脚本生成和处理 2D 美术资源
 10. `asset_stable_entry.py`
 11. `asset_generation_index.py`
 12. `asset_assets_md_update.py`
+13. `asset_atlas_assemble.py`
 
 ## asset_source_generate.py
 
@@ -187,6 +188,24 @@ python tools/asset_finalize_entry_draft.py \
 python tools/asset_output_path.py --family <production_family> --asset-id <asset_id>
 python tools/asset_output_path.py --entry <entry.json> --project-root . --check-files
 ```
+
+## asset_atlas_assemble.py
+
+`asset_atlas_assemble.py` 根据显式声明 slot rect 的 JSON 组装物理 PNG atlas。它不做 packing、trim、resize 或 region 推断。source 必须是相对 project root 的 PNG 路径，尺寸必须与声明的 slot 精确一致；输出 PNG 和 metadata 都必须位于 `assets/generated/<production_family>/<asset_id>/` 内。
+
+手动入口：
+
+```bash
+python tools/asset_atlas_assemble.py \
+  --declaration <fixed_slots.json> \
+  --atlas-out assets/generated/ui-kit/<asset_id>/<asset_id>.png \
+  --metadata-out assets/generated/ui-kit/<asset_id>/<asset_id>.json \
+  --family ui-kit \
+  --asset-id <asset_id> \
+  --project-root .
+```
+
+该工具把物理 atlas 和确定性的 region metadata 作为可回滚的一对输出写入。它只负责固定 slot 的组装；把 metadata 编译成 `AtlasTexture` 是独立的 compiler 步骤。
 
 ## asset_stable_entry.py
 

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -339,8 +339,7 @@ declaration. The assembler does not pack, trim, or discover regions:
       "name": "battle_button",
       "rect": [0, 0, 256, 96],
       "source": "battle_button.png",
-      "pivot": [0.5, 0.5],
-      "nine_slice": null
+      "pivot": [0.5, 0.5]
     }
   ]
 }
@@ -351,12 +350,18 @@ python tools/asset_atlas_assemble.py \
   --declaration <fixed_slots.json> \
   --atlas-out assets/generated/ui-kit/main_atlas/main_atlas.png \
   --metadata-out assets/generated/ui-kit/main_atlas/main_atlas.json \
+  --family ui-kit \
+  --asset-id main_atlas \
   --project-root .
 ```
 
 Every source must be a PNG with exactly the declared slot size. Out-of-bounds,
 overlapping, missing, or malformed slots fail before either output is written.
-The emitted regions are ordered by name for stable metadata.
+Source paths are project-root relative, as are all other asset-tool inputs.
+Both outputs must be under the declared asset's stable directory and are
+committed together; a write failure restores any prior output pair. The emitted
+regions are ordered by name for stable metadata, with `nine_slice: null` because
+nine-slice behavior is outside this tool.
 
 Action metadata shape (`assets/generated/character-bundle/player/player.json`):
 

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -327,6 +327,37 @@ Atlas metadata shape (`assets/generated/ui-kit/main_atlas/main_atlas.json`):
 }
 ```
 
+Build that physical atlas and its metadata only from an explicit fixed-slot
+declaration. The assembler does not pack, trim, or discover regions:
+
+```json
+{
+  "version": 1,
+  "atlas": {"width": 512, "height": 256},
+  "slots": [
+    {
+      "name": "battle_button",
+      "rect": [0, 0, 256, 96],
+      "source": "battle_button.png",
+      "pivot": [0.5, 0.5],
+      "nine_slice": null
+    }
+  ]
+}
+```
+
+```bash
+python tools/asset_atlas_assemble.py \
+  --declaration <fixed_slots.json> \
+  --atlas-out assets/generated/ui-kit/main_atlas/main_atlas.png \
+  --metadata-out assets/generated/ui-kit/main_atlas/main_atlas.json \
+  --project-root .
+```
+
+Every source must be a PNG with exactly the declared slot size. Out-of-bounds,
+overlapping, missing, or malformed slots fail before either output is written.
+The emitted regions are ordered by name for stable metadata.
+
 Action metadata shape (`assets/generated/character-bundle/player/player.json`):
 
 ```json

--- a/tests/tools/test_asset_atlas_assemble.py
+++ b/tests/tools/test_asset_atlas_assemble.py
@@ -1,0 +1,135 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_atlas_assemble import AtlasAssemblyError, assemble_atlas  # noqa: E402
+
+
+def write_png(path: Path, size: tuple[int, int], color: tuple[int, int, int, int]):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGBA", size, color).save(path)
+
+
+def write_declaration(path: Path, slots: list[dict], size=(12, 8)):
+    path.write_text(
+        json.dumps({"version": 1, "atlas": {"width": size[0], "height": size[1]}, "slots": slots}),
+        encoding="utf-8",
+    )
+
+
+def valid_slots():
+    return [
+        {"name": "button", "rect": [0, 0, 4, 4], "source": "button.png"},
+        {"name": "icon", "rect": [6, 2, 2, 3], "source": "icon.png", "pivot": [0, 1]},
+    ]
+
+
+def prepare_valid_declaration(tmp_path: Path) -> Path:
+    write_png(tmp_path / "button.png", (4, 4), (255, 0, 0, 255))
+    write_png(tmp_path / "icon.png", (2, 3), (0, 255, 0, 128))
+    declaration = tmp_path / "slots.json"
+    write_declaration(declaration, valid_slots())
+    return declaration
+
+
+def test_assemble_atlas_places_multiple_explicit_slots_and_writes_metadata(tmp_path):
+    declaration = prepare_valid_declaration(tmp_path)
+
+    result = assemble_atlas(
+        declaration,
+        Path("assets/generated/ui-kit/main_atlas/main_atlas.png"),
+        Path("assets/generated/ui-kit/main_atlas/main_atlas.json"),
+        project_root=tmp_path,
+    )
+
+    assert result["ok"] is True
+    assert result["atlas_path"] == "res://assets/generated/ui-kit/main_atlas/main_atlas.png"
+    assert result["slot_count"] == 2
+    atlas = Image.open(tmp_path / "assets/generated/ui-kit/main_atlas/main_atlas.png")
+    try:
+        assert atlas.size == (12, 8)
+        assert atlas.getpixel((0, 0)) == (255, 0, 0, 255)
+        assert atlas.getpixel((6, 2)) == (0, 255, 0, 128)
+        assert atlas.getpixel((5, 2))[3] == 0
+    finally:
+        atlas.close()
+    metadata = json.loads((tmp_path / "assets/generated/ui-kit/main_atlas/main_atlas.json").read_text())
+    assert metadata == {
+        "version": 1,
+        "atlas_path": "res://assets/generated/ui-kit/main_atlas/main_atlas.png",
+        "regions": [
+            {"name": "button", "rect": [0, 0, 4, 4], "pivot": [0.5, 0.5], "nine_slice": None},
+            {"name": "icon", "rect": [6, 2, 2, 3], "pivot": [0.0, 1.0], "nine_slice": None},
+        ],
+    }
+
+
+def test_assemble_atlas_is_reproducible_and_metadata_order_is_stable(tmp_path):
+    declaration = prepare_valid_declaration(tmp_path)
+    atlas = Path("out/atlas.png")
+    metadata = Path("out/atlas.json")
+    first = assemble_atlas(declaration, atlas, metadata, project_root=tmp_path)
+    first_png = (tmp_path / atlas).read_bytes()
+    first_json = (tmp_path / metadata).read_bytes()
+    second = assemble_atlas(declaration, atlas, metadata, project_root=tmp_path)
+
+    assert first == second
+    assert (tmp_path / atlas).read_bytes() == first_png
+    assert (tmp_path / metadata).read_bytes() == first_json
+
+
+@pytest.mark.parametrize(
+    ("slots", "message"),
+    [
+        ([{"name": "one", "rect": [0, 0, 4, 4], "source": "button.png"}, {"name": "two", "rect": [3, 0, 4, 4], "source": "button.png"}], "overlaps"),
+        ([{"name": "one", "rect": [10, 0, 4, 4], "source": "button.png"}], "outside"),
+        ([{"name": "one", "rect": [0, 0, 4, 4], "source": "missing.png"}], "missing"),
+        ([{"name": "one", "rect": [0, 0, 3, 4], "source": "button.png"}], "does not match"),
+    ],
+)
+def test_assemble_atlas_fails_closed_for_invalid_slot_declarations(tmp_path, slots, message):
+    write_png(tmp_path / "button.png", (4, 4), (255, 0, 0, 255))
+    declaration = tmp_path / "slots.json"
+    write_declaration(declaration, slots)
+    output = tmp_path / "atlas.png"
+
+    with pytest.raises(AtlasAssemblyError, match=message):
+        assemble_atlas(declaration, output, tmp_path / "atlas.json", project_root=tmp_path)
+    assert not output.exists()
+
+
+def test_assemble_atlas_rejects_implicit_or_unsupported_slot_features(tmp_path):
+    write_png(tmp_path / "button.png", (4, 4), (255, 0, 0, 255))
+    declaration = tmp_path / "slots.json"
+    write_declaration(
+        declaration,
+        [{"name": "button", "rect": [0, 0, 4, 4], "source": "button.png", "trim": True}],
+    )
+    with pytest.raises(AtlasAssemblyError, match="unexpected fields"):
+        assemble_atlas(declaration, tmp_path / "atlas.png", tmp_path / "atlas.json", project_root=tmp_path)
+
+
+def test_cli_outputs_json(tmp_path):
+    declaration = prepare_valid_declaration(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_atlas_assemble.py"),
+            "--declaration", str(declaration),
+            "--atlas-out", "assets/generated/ui-kit/main_atlas/main_atlas.png",
+            "--metadata-out", "assets/generated/ui-kit/main_atlas/main_atlas.json",
+            "--project-root", str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert json.loads(result.stdout)["ok"] is True

--- a/tests/tools/test_asset_atlas_assemble.py
+++ b/tests/tools/test_asset_atlas_assemble.py
@@ -9,7 +9,15 @@ from PIL import Image
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
 
+import asset_atlas_assemble as atlas_assemble  # noqa: E402
 from asset_atlas_assemble import AtlasAssemblyError, assemble_atlas  # noqa: E402
+
+
+FAMILY = "ui-kit"
+ASSET_ID = "main_atlas"
+OUTPUT_DIR = Path("assets/generated") / FAMILY / ASSET_ID
+ATLAS_OUTPUT = OUTPUT_DIR / "main_atlas.png"
+METADATA_OUTPUT = OUTPUT_DIR / "main_atlas.json"
 
 
 def write_png(path: Path, size: tuple[int, int], color: tuple[int, int, int, int]):
@@ -19,7 +27,13 @@ def write_png(path: Path, size: tuple[int, int], color: tuple[int, int, int, int
 
 def write_declaration(path: Path, slots: list[dict], size=(12, 8)):
     path.write_text(
-        json.dumps({"version": 1, "atlas": {"width": size[0], "height": size[1]}, "slots": slots}),
+        json.dumps(
+            {
+                "version": 1,
+                "atlas": {"width": size[0], "height": size[1]},
+                "slots": slots,
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -32,88 +46,256 @@ def valid_slots():
 
 
 def prepare_valid_declaration(tmp_path: Path) -> Path:
-    write_png(tmp_path / "button.png", (4, 4), (255, 0, 0, 255))
+    button = Image.new("RGBA", (4, 4), (255, 0, 0, 255))
+    button.putpixel((1, 1), (255, 64, 32, 0))
+    button.save(tmp_path / "button.png")
     write_png(tmp_path / "icon.png", (2, 3), (0, 255, 0, 128))
     declaration = tmp_path / "slots.json"
     write_declaration(declaration, valid_slots())
     return declaration
 
 
-def test_assemble_atlas_places_multiple_explicit_slots_and_writes_metadata(tmp_path):
-    declaration = prepare_valid_declaration(tmp_path)
-
-    result = assemble_atlas(
+def assemble(tmp_path: Path, declaration: Path, atlas=ATLAS_OUTPUT, metadata=METADATA_OUTPUT):
+    return assemble_atlas(
         declaration,
-        Path("assets/generated/ui-kit/main_atlas/main_atlas.png"),
-        Path("assets/generated/ui-kit/main_atlas/main_atlas.json"),
+        atlas,
+        metadata,
+        production_family=FAMILY,
+        asset_id=ASSET_ID,
         project_root=tmp_path,
     )
+
+
+def test_assemble_atlas_places_multiple_explicit_slots_and_preserves_pixels(tmp_path):
+    declaration = prepare_valid_declaration(tmp_path)
+
+    result = assemble(tmp_path, declaration)
 
     assert result["ok"] is True
     assert result["atlas_path"] == "res://assets/generated/ui-kit/main_atlas/main_atlas.png"
     assert result["slot_count"] == 2
-    atlas = Image.open(tmp_path / "assets/generated/ui-kit/main_atlas/main_atlas.png")
+    atlas = Image.open(tmp_path / ATLAS_OUTPUT)
     try:
         assert atlas.size == (12, 8)
         assert atlas.getpixel((0, 0)) == (255, 0, 0, 255)
+        assert atlas.getpixel((1, 1)) == (255, 64, 32, 0)
         assert atlas.getpixel((6, 2)) == (0, 255, 0, 128)
-        assert atlas.getpixel((5, 2))[3] == 0
+        assert atlas.getpixel((5, 2)) == (0, 0, 0, 0)
     finally:
         atlas.close()
-    metadata = json.loads((tmp_path / "assets/generated/ui-kit/main_atlas/main_atlas.json").read_text())
+    metadata = json.loads((tmp_path / METADATA_OUTPUT).read_text())
     assert metadata == {
         "version": 1,
         "atlas_path": "res://assets/generated/ui-kit/main_atlas/main_atlas.png",
         "regions": [
-            {"name": "button", "rect": [0, 0, 4, 4], "pivot": [0.5, 0.5], "nine_slice": None},
-            {"name": "icon", "rect": [6, 2, 2, 3], "pivot": [0.0, 1.0], "nine_slice": None},
+            {
+                "name": "button",
+                "rect": [0, 0, 4, 4],
+                "pivot": [0.5, 0.5],
+                "nine_slice": None,
+            },
+            {
+                "name": "icon",
+                "rect": [6, 2, 2, 3],
+                "pivot": [0.0, 1.0],
+                "nine_slice": None,
+            },
         ],
     }
 
 
+def test_assemble_atlas_accepts_slots_flush_with_the_atlas_boundary(tmp_path):
+    write_png(tmp_path / "edge.png", (4, 4), (30, 40, 50, 255))
+    declaration = tmp_path / "slots.json"
+    write_declaration(
+        declaration,
+        [{"name": "edge", "rect": [8, 4, 4, 4], "source": "edge.png"}],
+    )
+
+    assemble(tmp_path, declaration)
+
+    atlas = Image.open(tmp_path / ATLAS_OUTPUT)
+    try:
+        assert atlas.getpixel((11, 7)) == (30, 40, 50, 255)
+    finally:
+        atlas.close()
+
+
 def test_assemble_atlas_is_reproducible_and_metadata_order_is_stable(tmp_path):
     declaration = prepare_valid_declaration(tmp_path)
-    atlas = Path("out/atlas.png")
-    metadata = Path("out/atlas.json")
-    first = assemble_atlas(declaration, atlas, metadata, project_root=tmp_path)
-    first_png = (tmp_path / atlas).read_bytes()
-    first_json = (tmp_path / metadata).read_bytes()
-    second = assemble_atlas(declaration, atlas, metadata, project_root=tmp_path)
+    first = assemble(tmp_path, declaration)
+    first_png = (tmp_path / ATLAS_OUTPUT).read_bytes()
+    first_json = (tmp_path / METADATA_OUTPUT).read_bytes()
+    second = assemble(tmp_path, declaration)
 
     assert first == second
-    assert (tmp_path / atlas).read_bytes() == first_png
-    assert (tmp_path / metadata).read_bytes() == first_json
+    assert (tmp_path / ATLAS_OUTPUT).read_bytes() == first_png
+    assert (tmp_path / METADATA_OUTPUT).read_bytes() == first_json
 
 
 @pytest.mark.parametrize(
     ("slots", "message"),
     [
-        ([{"name": "one", "rect": [0, 0, 4, 4], "source": "button.png"}, {"name": "two", "rect": [3, 0, 4, 4], "source": "button.png"}], "overlaps"),
+        (
+            [
+                {"name": "one", "rect": [0, 0, 4, 4], "source": "button.png"},
+                {"name": "two", "rect": [3, 0, 4, 4], "source": "button.png"},
+            ],
+            "overlaps",
+        ),
         ([{"name": "one", "rect": [10, 0, 4, 4], "source": "button.png"}], "outside"),
         ([{"name": "one", "rect": [0, 0, 4, 4], "source": "missing.png"}], "missing"),
-        ([{"name": "one", "rect": [0, 0, 3, 4], "source": "button.png"}], "does not match"),
+        (
+            [{"name": "one", "rect": [0, 0, 3, 4], "source": "button.png"}],
+            "does not match",
+        ),
+        (
+            [
+                {"name": "one", "rect": [0, 0, 4, 4], "source": "button.png"},
+                {"name": "one", "rect": [4, 0, 4, 4], "source": "button.png"},
+            ],
+            "duplicated",
+        ),
+        ([{"name": "one", "rect": [0, 0, 0, 4], "source": "button.png"}], "positive"),
     ],
 )
 def test_assemble_atlas_fails_closed_for_invalid_slot_declarations(tmp_path, slots, message):
     write_png(tmp_path / "button.png", (4, 4), (255, 0, 0, 255))
     declaration = tmp_path / "slots.json"
     write_declaration(declaration, slots)
-    output = tmp_path / "atlas.png"
 
     with pytest.raises(AtlasAssemblyError, match=message):
-        assemble_atlas(declaration, output, tmp_path / "atlas.json", project_root=tmp_path)
-    assert not output.exists()
+        assemble(tmp_path, declaration)
+    assert not (tmp_path / ATLAS_OUTPUT).exists()
+    assert not (tmp_path / METADATA_OUTPUT).exists()
 
 
-def test_assemble_atlas_rejects_implicit_or_unsupported_slot_features(tmp_path):
+@pytest.mark.parametrize("feature", ["trim", "rotate", "padding", "nine_slice"])
+def test_assemble_atlas_rejects_implicit_or_unsupported_slot_features(tmp_path, feature):
     write_png(tmp_path / "button.png", (4, 4), (255, 0, 0, 255))
+    declaration = tmp_path / "slots.json"
+    slot = {"name": "button", "rect": [0, 0, 4, 4], "source": "button.png"}
+    slot[feature] = True
+    write_declaration(declaration, [slot])
+
+    with pytest.raises(AtlasAssemblyError, match="unexpected fields"):
+        assemble(tmp_path, declaration)
+
+
+@pytest.mark.parametrize("source_name", ["button.jpg", "not_png.png"])
+def test_assemble_atlas_rejects_non_png_sources(tmp_path, source_name):
+    source = tmp_path / source_name
+    Image.new("RGB", (4, 4), (255, 0, 0)).save(source, format="JPEG")
     declaration = tmp_path / "slots.json"
     write_declaration(
         declaration,
-        [{"name": "button", "rect": [0, 0, 4, 4], "source": "button.png", "trim": True}],
+        [{"name": "button", "rect": [0, 0, 4, 4], "source": source_name}],
     )
-    with pytest.raises(AtlasAssemblyError, match="unexpected fields"):
-        assemble_atlas(declaration, tmp_path / "atlas.png", tmp_path / "atlas.json", project_root=tmp_path)
+
+    with pytest.raises(AtlasAssemblyError, match="PNG"):
+        assemble(tmp_path, declaration)
+
+
+def test_assemble_atlas_rejects_outside_source_and_output_paths(tmp_path):
+    outside = tmp_path.parent / "outside.png"
+    write_png(outside, (4, 4), (255, 0, 0, 255))
+    declaration = tmp_path / "slots.json"
+    write_declaration(
+        declaration,
+        [{"name": "button", "rect": [0, 0, 4, 4], "source": str(outside)}],
+    )
+    with pytest.raises(AtlasAssemblyError, match="outside the project root"):
+        assemble(tmp_path, declaration)
+
+    declaration = prepare_valid_declaration(tmp_path)
+    with pytest.raises(AtlasAssemblyError, match="must be written under"):
+        assemble(tmp_path, declaration, Path("addons/icon.png"), METADATA_OUTPUT)
+
+
+def test_assemble_atlas_rejects_using_its_output_as_a_source(tmp_path):
+    write_png(tmp_path / ATLAS_OUTPUT, (4, 4), (255, 0, 0, 255))
+    declaration = tmp_path / "slots.json"
+    write_declaration(
+        declaration,
+        [{"name": "button", "rect": [0, 0, 4, 4], "source": ATLAS_OUTPUT.as_posix()}],
+    )
+    original = (tmp_path / ATLAS_OUTPUT).read_bytes()
+
+    with pytest.raises(AtlasAssemblyError, match="must not be the atlas output"):
+        assemble(tmp_path, declaration)
+    assert (tmp_path / ATLAS_OUTPUT).read_bytes() == original
+
+
+def test_assemble_atlas_rejects_an_excessively_large_atlas(tmp_path):
+    declaration = tmp_path / "slots.json"
+    write_declaration(
+        declaration,
+        [{"name": "button", "rect": [0, 0, 4, 4], "source": "button.png"}],
+        size=(200000, 200000),
+    )
+
+    with pytest.raises(AtlasAssemblyError, match="safety limit"):
+        assemble(tmp_path, declaration)
+
+
+def test_assemble_atlas_rolls_back_both_outputs_when_second_commit_fails(
+    tmp_path, monkeypatch
+):
+    declaration = prepare_valid_declaration(tmp_path)
+    write_png(tmp_path / ATLAS_OUTPUT, (12, 8), (10, 20, 30, 255))
+    (tmp_path / METADATA_OUTPUT).parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / METADATA_OUTPUT).write_text('{"old": true}\n', encoding="utf-8")
+    original_png = (tmp_path / ATLAS_OUTPUT).read_bytes()
+    original_json = (tmp_path / METADATA_OUTPUT).read_bytes()
+    real_replace = atlas_assemble.os.replace
+    metadata_path = (tmp_path / METADATA_OUTPUT).resolve()
+    failed = False
+
+    def fail_metadata_commit(source, destination):
+        nonlocal failed
+        if Path(destination).resolve() == metadata_path and not failed:
+            failed = True
+            raise OSError("simulated metadata commit failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(atlas_assemble.os, "replace", fail_metadata_commit)
+
+    with pytest.raises(AtlasAssemblyError, match="rolled back"):
+        assemble(tmp_path, declaration)
+    assert (tmp_path / ATLAS_OUTPUT).read_bytes() == original_png
+    assert (tmp_path / METADATA_OUTPUT).read_bytes() == original_json
+
+
+def test_cli_reports_write_failures_as_json_and_leaves_no_orphan_atlas(tmp_path):
+    declaration = prepare_valid_declaration(tmp_path)
+    blocked_parent = tmp_path / OUTPUT_DIR / "blocked"
+    blocked_parent.parent.mkdir(parents=True, exist_ok=True)
+    blocked_parent.write_text("not a directory", encoding="utf-8")
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_atlas_assemble.py"),
+            "--declaration",
+            str(declaration),
+            "--atlas-out",
+            str(ATLAS_OUTPUT),
+            "--metadata-out",
+            str(OUTPUT_DIR / "blocked" / "metadata.json"),
+            "--family",
+            FAMILY,
+            "--asset-id",
+            ASSET_ID,
+            "--project-root",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["ok"] is False
+    assert not (tmp_path / ATLAS_OUTPUT).exists()
 
 
 def test_cli_outputs_json(tmp_path):
@@ -122,10 +304,18 @@ def test_cli_outputs_json(tmp_path):
         [
             sys.executable,
             str(TOOLS_DIR / "asset_atlas_assemble.py"),
-            "--declaration", str(declaration),
-            "--atlas-out", "assets/generated/ui-kit/main_atlas/main_atlas.png",
-            "--metadata-out", "assets/generated/ui-kit/main_atlas/main_atlas.json",
-            "--project-root", str(tmp_path),
+            "--declaration",
+            str(declaration),
+            "--atlas-out",
+            str(ATLAS_OUTPUT),
+            "--metadata-out",
+            str(METADATA_OUTPUT),
+            "--family",
+            FAMILY,
+            "--asset-id",
+            ASSET_ID,
+            "--project-root",
+            str(tmp_path),
         ],
         capture_output=True,
         text=True,

--- a/tools/asset_atlas_assemble.py
+++ b/tools/asset_atlas_assemble.py
@@ -1,25 +1,30 @@
 #!/usr/bin/env python3
 """Assemble a physical PNG atlas from explicitly declared fixed slots.
 
-This is deliberately not a packing tool.  Every source PNG must be assigned to
+This is deliberately not a packing tool. Every source PNG must be assigned to
 one declared rectangle of an explicitly sized atlas; sources are neither
-trimmed nor inspected to discover regions.  The companion metadata describes
-those same declared rectangles for a later AtlasTexture compiler.
+trimmed nor inspected to discover regions. Both output files are constrained to
+the asset's stable generated-output directory and are committed together.
 """
 from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
 import sys
 import tempfile
 from pathlib import Path
 from typing import Any
 
+from asset_stable_entry import StableEntryError, assert_within_output_dir
+
 
 SCHEMA_VERSION = 1
+MAX_ATLAS_PIXELS = 64 * 1024 * 1024
 DECLARATION_KEYS = {"version", "atlas", "slots"}
 ATLAS_KEYS = {"width", "height"}
-SLOT_KEYS = {"name", "rect", "source", "pivot", "nine_slice"}
+SLOT_KEYS = {"name", "rect", "source", "pivot"}
 
 
 class AtlasAssemblyError(Exception):
@@ -107,46 +112,102 @@ def _load_png(path: Path):
     return image
 
 
-def _output_path(project_root: Path, raw_path: Path, label: str) -> Path:
+def _project_file(project_root: Path, value: Path | str, label: str) -> Path:
     root = Path(project_root).resolve()
-    path = Path(raw_path)
-    if not path.is_absolute():
-        path = root / path
-    resolved = path.resolve()
+    path = Path(value)
+    resolved = path.resolve() if path.is_absolute() else (root / path).resolve()
     if not resolved.is_relative_to(root):
         raise AtlasAssemblyError(f"{label} resolves outside the project root")
     return resolved
 
 
-def _res_path(project_root: Path, path: Path) -> str:
-    return "res://" + path.resolve().relative_to(Path(project_root).resolve()).as_posix()
+def _temporary_path(directory: Path, suffix: str) -> Path:
+    with tempfile.NamedTemporaryFile(delete=False, dir=directory, suffix=suffix) as handle:
+        return Path(handle.name)
 
 
-def _atomic_save_png(image, output: Path) -> None:
-    output.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(delete=False, dir=output.parent, suffix=".png") as handle:
-        temporary = Path(handle.name)
+def _write_png_temp(image, directory: Path) -> Path:
     try:
+        temporary = _temporary_path(directory, ".png")
         image.save(temporary, format="PNG", optimize=False, compress_level=9)
-        temporary.replace(output)
-    finally:
-        if temporary.exists():
-            temporary.unlink()
+        return temporary
+    except (MemoryError, OSError, ValueError) as exc:
+        if "temporary" in locals():
+            temporary.unlink(missing_ok=True)
+        raise AtlasAssemblyError("Unable to write atlas PNG") from exc
 
 
-def _atomic_write_json(data: dict[str, Any], output: Path) -> None:
-    output.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        delete=False, dir=output.parent, suffix=".json", mode="w", encoding="utf-8"
-    ) as handle:
-        temporary = Path(handle.name)
-        json.dump(data, handle, indent=2)
-        handle.write("\n")
+def _write_json_temp(data: dict[str, Any], directory: Path) -> Path:
     try:
-        temporary.replace(output)
+        temporary = _temporary_path(directory, ".json")
+        with temporary.open("w", encoding="utf-8", newline="\n") as handle:
+            json.dump(data, handle, indent=2)
+            handle.write("\n")
+        return temporary
+    except (MemoryError, OSError, TypeError, ValueError) as exc:
+        if "temporary" in locals():
+            temporary.unlink(missing_ok=True)
+        raise AtlasAssemblyError("Unable to write atlas metadata") from exc
+
+
+def _backup(path: Path) -> Path | None:
+    if not path.exists():
+        return None
+    try:
+        backup = _temporary_path(path.parent, path.suffix)
+        shutil.copy2(path, backup)
+    except OSError as exc:
+        if "backup" in locals():
+            backup.unlink(missing_ok=True)
+        raise AtlasAssemblyError(f"Unable to back up existing output: {path}") from exc
+    return backup
+
+
+def _restore(path: Path, backup: Path | None) -> None:
+    if backup is None:
+        path.unlink(missing_ok=True)
+    else:
+        os.replace(backup, path)
+
+
+def _commit_output_pair(
+    atlas_temp: Path,
+    atlas_output: Path,
+    metadata_temp: Path,
+    metadata_output: Path,
+) -> None:
+    """Replace both outputs or restore the previous pair after an I/O failure."""
+    atlas_backup: Path | None = None
+    metadata_backup: Path | None = None
+    atlas_replaced = False
+    metadata_replaced = False
+    try:
+        atlas_backup = _backup(atlas_output)
+        metadata_backup = _backup(metadata_output)
+        os.replace(atlas_temp, atlas_output)
+        atlas_replaced = True
+        os.replace(metadata_temp, metadata_output)
+        metadata_replaced = True
+    except OSError as exc:
+        try:
+            if atlas_replaced:
+                _restore(atlas_output, atlas_backup)
+                atlas_backup = None
+            if metadata_replaced:
+                _restore(metadata_output, metadata_backup)
+                metadata_backup = None
+        except OSError as rollback_exc:
+            raise AtlasAssemblyError(
+                "Unable to commit atlas outputs and rollback failed"
+            ) from rollback_exc
+        raise AtlasAssemblyError("Unable to commit atlas outputs; changes were rolled back") from exc
     finally:
-        if temporary.exists():
-            temporary.unlink()
+        atlas_temp.unlink(missing_ok=True)
+        metadata_temp.unlink(missing_ok=True)
+        if atlas_backup is not None:
+            atlas_backup.unlink(missing_ok=True)
+        if metadata_backup is not None:
+            metadata_backup.unlink(missing_ok=True)
 
 
 def _load_declaration(path: Path) -> dict[str, Any]:
@@ -166,21 +227,43 @@ def assemble_atlas(
     atlas_output: Path,
     metadata_output: Path,
     *,
+    production_family: str,
+    asset_id: str,
     project_root: Path,
 ) -> dict[str, Any]:
     """Validate a declaration, then write its physical atlas PNG and metadata."""
-    declaration_path = Path(declaration_path).resolve()
+    project_root = Path(project_root).resolve()
+    declaration_path = _project_file(project_root, declaration_path, "declaration")
     declaration = _load_declaration(declaration_path)
     atlas = _require_object(declaration.get("atlas"), "declaration.atlas")
     _reject_extra_keys(atlas, ATLAS_KEYS, "declaration.atlas")
     atlas_width = _positive_int(atlas.get("width"), "declaration.atlas.width")
     atlas_height = _positive_int(atlas.get("height"), "declaration.atlas.height")
+    if atlas_width * atlas_height > MAX_ATLAS_PIXELS:
+        raise AtlasAssemblyError(
+            f"Declared atlas exceeds the {MAX_ATLAS_PIXELS}-pixel safety limit"
+        )
     slots = declaration.get("slots")
     if not isinstance(slots, list) or not slots:
         raise AtlasAssemblyError("declaration.slots must be a non-empty list")
 
-    atlas_output = _output_path(project_root, atlas_output, "atlas output")
-    metadata_output = _output_path(project_root, metadata_output, "metadata output")
+    try:
+        atlas_output = assert_within_output_dir(
+            project_root,
+            atlas_output,
+            production_family=production_family,
+            asset_id=asset_id,
+            label="atlas output",
+        )
+        metadata_output = assert_within_output_dir(
+            project_root,
+            metadata_output,
+            production_family=production_family,
+            asset_id=asset_id,
+            label="metadata output",
+        )
+    except StableEntryError as exc:
+        raise AtlasAssemblyError(str(exc)) from exc
     if atlas_output.suffix.lower() != ".png":
         raise AtlasAssemblyError("atlas output must end in .png")
     if metadata_output.suffix.lower() != ".json":
@@ -211,17 +294,20 @@ def assemble_atlas(
         source = slot.get("source")
         if not isinstance(source, str) or not source.strip():
             raise AtlasAssemblyError(f"{label}.source must be a non-empty PNG path")
-        source_path = (declaration_path.parent / source).resolve()
+        source_path = _project_file(project_root, source, f"{label}.source")
         if source_path == atlas_output:
             raise AtlasAssemblyError(f"{label}.source must not be the atlas output")
-        if slot.get("nine_slice") is not None:
-            raise AtlasAssemblyError(f"{label}.nine_slice must be null; nine-slice is not handled here")
         parsed_slots.append(
-            {"name": name, "rect": rect, "source": source_path, "pivot": _pivot(slot.get("pivot"), f"{label}.pivot")}
+            {
+                "name": name,
+                "rect": rect,
+                "source": source_path,
+                "pivot": _pivot(slot.get("pivot"), f"{label}.pivot"),
+            }
         )
 
-    # Validate every source and its declared size before creating either output.
     loaded_images: list[tuple[dict[str, Any], Any]] = []
+    canvas = None
     try:
         for slot in parsed_slots:
             image = _load_png(slot["source"])
@@ -236,9 +322,14 @@ def assemble_atlas(
 
         from PIL import Image
 
-        canvas = Image.new("RGBA", (atlas_width, atlas_height), (0, 0, 0, 0))
+        try:
+            canvas = Image.new("RGBA", (atlas_width, atlas_height), (0, 0, 0, 0))
+        except (MemoryError, OSError, ValueError) as exc:
+            raise AtlasAssemblyError("Unable to allocate the declared atlas") from exc
         for slot, image in loaded_images:
-            canvas.alpha_composite(image, dest=slot["rect"][:2])
+            # Slots are non-overlapping, so a direct copy preserves every RGBA
+            # value, including transparent RGB edge-padding used by filtering.
+            canvas.paste(image, box=slot["rect"][:2])
         regions = [
             {
                 "name": slot["name"],
@@ -250,20 +341,32 @@ def assemble_atlas(
         ]
         metadata = {
             "version": SCHEMA_VERSION,
-            "atlas_path": _res_path(project_root, atlas_output),
+            "atlas_path": "res://" + atlas_output.relative_to(project_root).as_posix(),
             "regions": regions,
         }
-        _atomic_save_png(canvas, atlas_output)
-        canvas.close()
-        _atomic_write_json(metadata, metadata_output)
+        # Both parents are made ready before either temporary output is written.
+        try:
+            atlas_output.parent.mkdir(parents=True, exist_ok=True)
+            metadata_output.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise AtlasAssemblyError("Unable to prepare atlas output directories") from exc
+        atlas_temp = _write_png_temp(canvas, atlas_output.parent)
+        try:
+            metadata_temp = _write_json_temp(metadata, metadata_output.parent)
+        except AtlasAssemblyError:
+            atlas_temp.unlink(missing_ok=True)
+            raise
+        _commit_output_pair(atlas_temp, atlas_output, metadata_temp, metadata_output)
     finally:
+        if canvas is not None:
+            canvas.close()
         for _, image in loaded_images:
             image.close()
 
     return {
         "ok": True,
         "atlas_path": metadata["atlas_path"],
-        "metadata_path": _res_path(project_root, metadata_output),
+        "metadata_path": "res://" + metadata_output.relative_to(project_root).as_posix(),
         "width": atlas_width,
         "height": atlas_height,
         "slot_count": len(parsed_slots),
@@ -278,13 +381,17 @@ def _main() -> int:
     parser.add_argument("--declaration", required=True, type=Path, help="Fixed-slot declaration JSON")
     parser.add_argument("--atlas-out", required=True, type=Path, help="Physical atlas PNG output")
     parser.add_argument("--metadata-out", required=True, type=Path, help="Atlas region metadata JSON output")
-    parser.add_argument("--project-root", default=".", type=Path, help="Project root for outputs and res:// paths")
+    parser.add_argument("--family", required=True, help="Production family for the stable output directory")
+    parser.add_argument("--asset-id", required=True, help="Asset id for the stable output directory")
+    parser.add_argument("--project-root", default=".", type=Path, help="Project root for inputs and outputs")
     args = parser.parse_args()
     try:
         result = assemble_atlas(
             args.declaration,
             args.atlas_out,
             args.metadata_out,
+            production_family=args.family,
+            asset_id=args.asset_id,
             project_root=args.project_root,
         )
     except AtlasAssemblyError as exc:

--- a/tools/asset_atlas_assemble.py
+++ b/tools/asset_atlas_assemble.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Assemble a physical PNG atlas from explicitly declared fixed slots.
+
+This is deliberately not a packing tool.  Every source PNG must be assigned to
+one declared rectangle of an explicitly sized atlas; sources are neither
+trimmed nor inspected to discover regions.  The companion metadata describes
+those same declared rectangles for a later AtlasTexture compiler.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+DECLARATION_KEYS = {"version", "atlas", "slots"}
+ATLAS_KEYS = {"width", "height"}
+SLOT_KEYS = {"name", "rect", "source", "pivot", "nine_slice"}
+
+
+class AtlasAssemblyError(Exception):
+    """Raised when a fixed-slot atlas declaration cannot be assembled."""
+
+
+def _require_object(value: Any, label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise AtlasAssemblyError(f"{label} must be an object")
+    return value
+
+
+def _reject_extra_keys(value: dict[str, Any], allowed: set[str], label: str) -> None:
+    extra = sorted(set(value) - allowed)
+    if extra:
+        raise AtlasAssemblyError(f"{label} has unexpected fields: {', '.join(extra)}")
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if type(value) is not int or value <= 0:
+        raise AtlasAssemblyError(f"{label} must be a positive integer")
+    return value
+
+
+def _non_negative_int(value: Any, label: str) -> int:
+    if type(value) is not int or value < 0:
+        raise AtlasAssemblyError(f"{label} must be a non-negative integer")
+    return value
+
+
+def _rect(value: Any, label: str) -> tuple[int, int, int, int]:
+    if not isinstance(value, list) or len(value) != 4:
+        raise AtlasAssemblyError(f"{label} must be [x, y, width, height]")
+    x = _non_negative_int(value[0], f"{label}[0]")
+    y = _non_negative_int(value[1], f"{label}[1]")
+    width = _positive_int(value[2], f"{label}[2]")
+    height = _positive_int(value[3], f"{label}[3]")
+    return x, y, width, height
+
+
+def _pivot(value: Any, label: str) -> list[float]:
+    if value is None:
+        return [0.5, 0.5]
+    if not isinstance(value, list) or len(value) != 2:
+        raise AtlasAssemblyError(f"{label} must be [x, y]")
+    pivot: list[float] = []
+    for index, component in enumerate(value):
+        if type(component) not in {int, float} or not 0 <= component <= 1:
+            raise AtlasAssemblyError(f"{label}[{index}] must be a number from 0 to 1")
+        pivot.append(float(component))
+    return pivot
+
+
+def _rectangles_overlap(
+    left: tuple[int, int, int, int], right: tuple[int, int, int, int]
+) -> bool:
+    left_x, left_y, left_width, left_height = left
+    right_x, right_y, right_width, right_height = right
+    return not (
+        left_x + left_width <= right_x
+        or right_x + right_width <= left_x
+        or left_y + left_height <= right_y
+        or right_y + right_height <= left_y
+    )
+
+
+def _load_png(path: Path):
+    try:
+        from PIL import Image
+    except ImportError as exc:  # pragma: no cover - environment dependency
+        raise AtlasAssemblyError("Pillow is required to assemble PNG atlases") from exc
+
+    if path.suffix.lower() != ".png":
+        raise AtlasAssemblyError(f"Slot source must be a PNG file: {path}")
+    if not path.is_file():
+        raise AtlasAssemblyError(f"Slot source is missing: {path}")
+    try:
+        image = Image.open(path)
+        image.load()
+    except Exception as exc:  # noqa: BLE001 - converted into a tool error
+        raise AtlasAssemblyError(f"Slot source is not a readable PNG: {path}") from exc
+    if image.format != "PNG":
+        image.close()
+        raise AtlasAssemblyError(f"Slot source is not a PNG file: {path}")
+    return image
+
+
+def _output_path(project_root: Path, raw_path: Path, label: str) -> Path:
+    root = Path(project_root).resolve()
+    path = Path(raw_path)
+    if not path.is_absolute():
+        path = root / path
+    resolved = path.resolve()
+    if not resolved.is_relative_to(root):
+        raise AtlasAssemblyError(f"{label} resolves outside the project root")
+    return resolved
+
+
+def _res_path(project_root: Path, path: Path) -> str:
+    return "res://" + path.resolve().relative_to(Path(project_root).resolve()).as_posix()
+
+
+def _atomic_save_png(image, output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(delete=False, dir=output.parent, suffix=".png") as handle:
+        temporary = Path(handle.name)
+    try:
+        image.save(temporary, format="PNG", optimize=False, compress_level=9)
+        temporary.replace(output)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _atomic_write_json(data: dict[str, Any], output: Path) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        delete=False, dir=output.parent, suffix=".json", mode="w", encoding="utf-8"
+    ) as handle:
+        temporary = Path(handle.name)
+        json.dump(data, handle, indent=2)
+        handle.write("\n")
+    try:
+        temporary.replace(output)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _load_declaration(path: Path) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001 - converted into a tool error
+        raise AtlasAssemblyError(f"Invalid atlas declaration: {path}") from exc
+    data = _require_object(data, "declaration")
+    _reject_extra_keys(data, DECLARATION_KEYS, "declaration")
+    if type(data.get("version")) is not int or data["version"] != SCHEMA_VERSION:
+        raise AtlasAssemblyError(f"declaration.version must be integer {SCHEMA_VERSION}")
+    return data
+
+
+def assemble_atlas(
+    declaration_path: Path,
+    atlas_output: Path,
+    metadata_output: Path,
+    *,
+    project_root: Path,
+) -> dict[str, Any]:
+    """Validate a declaration, then write its physical atlas PNG and metadata."""
+    declaration_path = Path(declaration_path).resolve()
+    declaration = _load_declaration(declaration_path)
+    atlas = _require_object(declaration.get("atlas"), "declaration.atlas")
+    _reject_extra_keys(atlas, ATLAS_KEYS, "declaration.atlas")
+    atlas_width = _positive_int(atlas.get("width"), "declaration.atlas.width")
+    atlas_height = _positive_int(atlas.get("height"), "declaration.atlas.height")
+    slots = declaration.get("slots")
+    if not isinstance(slots, list) or not slots:
+        raise AtlasAssemblyError("declaration.slots must be a non-empty list")
+
+    atlas_output = _output_path(project_root, atlas_output, "atlas output")
+    metadata_output = _output_path(project_root, metadata_output, "metadata output")
+    if atlas_output.suffix.lower() != ".png":
+        raise AtlasAssemblyError("atlas output must end in .png")
+    if metadata_output.suffix.lower() != ".json":
+        raise AtlasAssemblyError("metadata output must end in .json")
+    if atlas_output == metadata_output:
+        raise AtlasAssemblyError("atlas output and metadata output must be different files")
+
+    parsed_slots: list[dict[str, Any]] = []
+    names: set[str] = set()
+    rectangles: list[tuple[int, int, int, int]] = []
+    for index, raw_slot in enumerate(slots):
+        label = f"declaration.slots[{index}]"
+        slot = _require_object(raw_slot, label)
+        _reject_extra_keys(slot, SLOT_KEYS, label)
+        name = slot.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise AtlasAssemblyError(f"{label}.name must be a non-empty string")
+        if name in names:
+            raise AtlasAssemblyError(f"Slot name is duplicated: {name}")
+        names.add(name)
+        rect = _rect(slot.get("rect"), f"{label}.rect")
+        x, y, width, height = rect
+        if x + width > atlas_width or y + height > atlas_height:
+            raise AtlasAssemblyError(f"{label}.rect is outside the declared atlas bounds")
+        if any(_rectangles_overlap(rect, existing) for existing in rectangles):
+            raise AtlasAssemblyError(f"{label}.rect overlaps another declared slot")
+        rectangles.append(rect)
+        source = slot.get("source")
+        if not isinstance(source, str) or not source.strip():
+            raise AtlasAssemblyError(f"{label}.source must be a non-empty PNG path")
+        source_path = (declaration_path.parent / source).resolve()
+        if source_path == atlas_output:
+            raise AtlasAssemblyError(f"{label}.source must not be the atlas output")
+        if slot.get("nine_slice") is not None:
+            raise AtlasAssemblyError(f"{label}.nine_slice must be null; nine-slice is not handled here")
+        parsed_slots.append(
+            {"name": name, "rect": rect, "source": source_path, "pivot": _pivot(slot.get("pivot"), f"{label}.pivot")}
+        )
+
+    # Validate every source and its declared size before creating either output.
+    loaded_images: list[tuple[dict[str, Any], Any]] = []
+    try:
+        for slot in parsed_slots:
+            image = _load_png(slot["source"])
+            if image.size != slot["rect"][2:]:
+                image.close()
+                raise AtlasAssemblyError(
+                    f"Slot source size {image.size} does not match declared rect "
+                    f"{slot['rect'][2]}x{slot['rect'][3]}: {slot['source']}"
+                )
+            loaded_images.append((slot, image.convert("RGBA")))
+            image.close()
+
+        from PIL import Image
+
+        canvas = Image.new("RGBA", (atlas_width, atlas_height), (0, 0, 0, 0))
+        for slot, image in loaded_images:
+            canvas.alpha_composite(image, dest=slot["rect"][:2])
+        regions = [
+            {
+                "name": slot["name"],
+                "rect": list(slot["rect"]),
+                "pivot": slot["pivot"],
+                "nine_slice": None,
+            }
+            for slot in sorted(parsed_slots, key=lambda item: item["name"])
+        ]
+        metadata = {
+            "version": SCHEMA_VERSION,
+            "atlas_path": _res_path(project_root, atlas_output),
+            "regions": regions,
+        }
+        _atomic_save_png(canvas, atlas_output)
+        canvas.close()
+        _atomic_write_json(metadata, metadata_output)
+    finally:
+        for _, image in loaded_images:
+            image.close()
+
+    return {
+        "ok": True,
+        "atlas_path": metadata["atlas_path"],
+        "metadata_path": _res_path(project_root, metadata_output),
+        "width": atlas_width,
+        "height": atlas_height,
+        "slot_count": len(parsed_slots),
+        "regions": metadata["regions"],
+    }
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assemble a physical PNG atlas from explicit fixed slot rectangles"
+    )
+    parser.add_argument("--declaration", required=True, type=Path, help="Fixed-slot declaration JSON")
+    parser.add_argument("--atlas-out", required=True, type=Path, help="Physical atlas PNG output")
+    parser.add_argument("--metadata-out", required=True, type=Path, help="Atlas region metadata JSON output")
+    parser.add_argument("--project-root", default=".", type=Path, help="Project root for outputs and res:// paths")
+    args = parser.parse_args()
+    try:
+        result = assemble_atlas(
+            args.declaration,
+            args.atlas_out,
+            args.metadata_out,
+            project_root=args.project_root,
+        )
+    except AtlasAssemblyError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+    print(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())


### PR DESCRIPTION
## Summary

Add a fail-closed fixed-slot PNG atlas assembler and deterministic region metadata generator.

## Motivation

The downstream AtlasTexture compilation and UI resource compilation pipeline needs a deterministic, reproducible physical atlas PNG plus slot metadata as input. Slot rects must be declared explicitly — no auto-packing, trimming, or heuristic region discovery — so the output is stable and auditable.

## Changes

- [x] Add `tools/asset_atlas_assemble.py`: assembles a physical atlas PNG from explicitly declared slot rects and PNG sources only; rejects auto-packing, trim, and heuristic region discovery.
- [x] Fail-closed validation before any write: out-of-bounds slots, overlapping slots, duplicate slot names, missing/non-PNG sources, source/rect size mismatches, oversized atlas dimensions.
- [x] Outputs go through the existing stable-output-dir guard (`--family` / `--asset-id`), with two-file (atlas + metadata) commit and rollback on partial failure — no orphaned atlas/metadata pairs.
- [x] Slot pixels are copied via `paste` (not `alpha_composite`), so alpha=0 source pixels keep their RGB (alpha bleed / edge padding) instead of being zeroed.
- [x] Deterministic output: same input produces byte-identical PNG and sorted-by-name region metadata across repeated runs.
- [x] Add regression tests: multi-slot, edge-adjacent slots, internal transparent pixels, illegal declarations, stable-path/containment violations, oversized atlas, dual-write rollback, CLI I/O failures (21 tests total).
- [x] Document the declaration format in `skills/core/gm-asset/references/asset-runtime-pipeline.md` and list the tool in `docs/wiki/05-tools/asset-tools.md` (+ `docs/zh` mirror).

## Testing

- [x] New or updated tests pass (`python -m pytest tests/tools/test_asset_atlas_assemble.py` — 21 passed; `python -m pytest` — 1496 passed, 3 skipped)
- [x] Gitleaks passes or no secret-bearing files were touched (CI `Secret Scan` check: pass)
- [ ] Manual testing completed, if applicable — not applicable; no UI/runtime surface to drive manually, only CLI + automated tests

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed

This adds a new, previously-nonexistent CLI tool. It does not modify any existing `runtime_artifact`/stable-entry format, move existing files, or change behavior for already-published target projects.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — not applicable, no ECS systems touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated

## Scope boundary

- Does not compile `AtlasTexture` resources or perform any Godot resource loading/rendering validation — that belongs to a later stage of the asset pipeline.
- Not yet wired into the asset-generation skill's execution path: `docs/wiki/05-tools/asset-tools.md` lists the tool, but the production-unit docs (`ui-kit.md`, `card-kit.md`, `compact-prop-pack.md`) still instruct agents to hand-write the atlas and metadata. Routing is expected to land in a follow-up change.
- No nine-slice handling, no slot inference/auto-packing, no stale-file cleanup (all explicitly out of scope for this tool).

## Residual risks (non-blocking, noted at review approval)

- If the atlas commit succeeds but the metadata commit fails, and the subsequent atlas-restore `os.replace` also fails, the rollback path deletes the atlas backup before it can be used, leaving no recoverable copy of the prior atlas (requires two independent I/O failures to trigger).
- A small dead-code branch remains where `metadata_replaced` is checked in an `except` block it can no longer reach.
- The stable-path guard constrains the metadata output directory but not the filename itself; a `<stable>/sub/x.json` path is still accepted even though the runtime pipeline doc expects `<asset_id>.json`.
- The production-unit docs referenced above have not been updated to route through this tool or mention its new required `--family` / `--asset-id` CLI args and stable-path write constraint.
