### PR TITLE
Fix reference-only asset completion semantics in gm-asset

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -36,6 +36,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Finalized, registered screen references can now complete their matching ASSETS.md rows at `source_ready` after the root-index gate passes, without becoming worker runtime artifacts.
 - Added the required `--grid` (and `--names`) argument to every production-unit `asset_sheet_process.py` example so the ui-kit, card-kit, compact-prop-pack, fx-bundle, scene-prop-set, and platform-strip commands run as written instead of failing on a missing required argument, and clarified that `--grid` is required in both autoslice and grid snap modes.
 - Point generated-asset runtime handoff (gm-build, gm-fixgap, worker dispatch, worker agent) at `.godotmaker/asset-generation/manifest.json` instead of the analyst's `assets/manifest.json` (#97)
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -28,15 +28,14 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - `/gm-asset` now registers every generated asset as a v1 stable entry plus a pointer-only root index entry instead of a full-body `runtime_artifact` manifest.
 - Generated runtime handoff for gm-build, gm-fixgap, worker dispatch, and ASSETS.md rows now resolves the stable entry behind each root-index pointer.
-- An ASSETS.md row reaches `generated` only from a `ready` non-reference stable entry, so an unfinished or failed asset can no longer look complete to `/gm-build`.
+- An ASSETS.md runtime row reaches `generated` only from a `ready` non-reference stable entry, while a finalized registered screen reference completes its reference row at `source_ready` without becoming a worker runtime artifact.
 - `asset_generation_index.py --check-files` verifies that every registered source and artifact still exists, catching an asset deleted after registration.
-- Generated assets now stop at `source_ready`: the native compilers and the L0-L4 runner are not implemented, so `/gm-asset` registers stable entries but produces no worker-consumable runtime asset and leaves generated ASSETS.md rows `MISSING`.
+- Generated runtime assets now stop at `source_ready`: the native compilers and the L0-L4 runner are not implemented, so `/gm-asset` registers stable entries but produces no worker-consumable runtime asset and leaves generated runtime ASSETS.md rows `MISSING`.
 - `godot_artifact` is written only by a native compiler, so a `grid_sheet` can no longer be published as a `Texture2D` standing in for its unbuilt `SpriteFrames`.
 - The stable-entry schema now binds each `source_layout.type` to the Godot resource it compiles to, so a mismatched `godot_artifact.type` is rejected instead of reaching a worker.
 
 ## Fixed
 
-- Finalized, registered screen references can now complete their matching ASSETS.md rows at `source_ready` after the root-index gate passes, without becoming worker runtime artifacts.
 - Added the required `--grid` (and `--names`) argument to every production-unit `asset_sheet_process.py` example so the ui-kit, card-kit, compact-prop-pack, fx-bundle, scene-prop-set, and platform-strip commands run as written instead of failing on a missing required argument, and clarified that `--grid` is required in both autoslice and grid snap modes.
 - Point generated-asset runtime handoff (gm-build, gm-fixgap, worker dispatch, worker agent) at `.godotmaker/asset-generation/manifest.json` instead of the analyst's `assets/manifest.json` (#97)
 

--- a/docs/wiki/03-skills/core-skills.md
+++ b/docs/wiki/03-skills/core-skills.md
@@ -10,7 +10,7 @@ There are nine role skills, each responsible for one part of game creation. In t
 |---------|-------------|-------|---------|
 | `/gm-scaffold` | Creates a new Godot project with the right folder structure, required addons, and a first git commit | Nothing (run this once per project) | `project.godot`, `addons/`, initial `CLAUDE.md` or `AGENTS.md` |
 | `/gm-gdd` | Interviews you about the game, then writes the design documents and work plan | A scaffolded project | `GDD.md`, `PLAN.md`, `STRUCTURE.md`, `SCENES.md`, `ASSETS.md`, `TOC.md` |
-| `/gm-asset` | Generates missing art or analyses art you provide, so the build has visuals to work with | `ASSETS.md` from `/gm-gdd` | Art files in `assets/`, updated `ASSETS.md` |
+| `/gm-asset` | Generates missing art or analyses art you provide, so the build has visuals to work with | `ASSETS.md` from `/gm-gdd` | Art files, scene references, and updated `ASSETS.md`; references can complete without being runtime artifacts |
 | `/gm-build` | Implements the game by sending tasks to worker sub-agents one batch at a time, with reviewers checking the result | Design documents from `/gm-gdd` | Game code in `src/`, `scenes/`, unit tests, end-to-end tests |
 | `/gm-verify` | Runs a mechanical check: does the project compile, do unit tests pass, are required files present | A built project | A printed pass/fail report and a `verify` event appended to `.godotmaker/stage.jsonl` |
 | `/gm-evaluate` | Runs the game independently, takes screenshots, and scores the result against the GDD | A verified project | `.godotmaker/evaluation.json`, screenshots in `e2e/screenshots/` |

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -265,10 +265,12 @@ read.
 ## asset_assets_md_update.py
 
 `asset_assets_md_update.py` promotes ASSETS.md rows from registered stable
-entries. It revalidates the entry and its referenced files first and accepts only
-a `ready` non-reference entry, so a row can reach `generated` only once the asset
-is a finished, worker-consumable runtime asset. It records the entry pointer
-instead of duplicating any path into the row.
+entries. It revalidates every entry and referenced file first. Runtime rows
+require a `ready` non-reference entry, so they become `generated` only when the
+asset is worker-consumable. A `screen-reference` row may instead complete at
+`source_ready` when its finalized reference file, canonical stable entry, and
+root-index pointer pass the full root-index gate. This records the same entry
+pointer but never creates a `godot_artifact` or sends the reference to a worker.
 
 Manual entry point:
 
@@ -292,6 +294,7 @@ Manual use cases:
 6. Select one extracted candidate into a runtime asset path.
 7. Print or validate one asset's stable output directory.
 8. Validate and register one stable entry and its root-index pointer.
+9. Complete a finalized screen reference without treating it as runtime art.
 
 If you want to update visual targets used by `/gm-evaluate`, re-run
 `/gm-asset` rather than editing generated images directly.

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -268,8 +268,10 @@ read.
 entries. It revalidates every entry and referenced file first. Runtime rows
 require a `ready` non-reference entry, so they become `generated` only when the
 asset is worker-consumable. A `screen-reference` row may instead complete at
-`source_ready` when its finalized reference file, canonical stable entry, and
-root-index pointer pass the full root-index gate. This records the same entry
+`source_ready` and remain repeatable at `ready` when its finalized reference
+file, canonical stable entry, and root-index pointer pass validation. The
+updater validates the reference file plus every root-index pointer without
+requiring unrelated pending entries to have files. This records the same entry
 pointer but never creates a `godot_artifact` or sends the reference to a worker.
 
 Manual entry point:

--- a/docs/zh/wiki/03-skills/core-skills.md
+++ b/docs/zh/wiki/03-skills/core-skills.md
@@ -10,7 +10,7 @@ Core 技能分为两类：九个以 `/gm-*` 暴露的角色技能，以及十二
 |------|------|----------|--------|
 | `/gm-scaffold` | 创建一个新的 Godot 项目，包含正确的目录结构、所需插件，并完成首次 git 提交 | 无（每个项目只运行一次） | `project.godot`、`addons/`、初始 `CLAUDE.md` 或 `AGENTS.md` |
 | `/gm-gdd` | 询问你关于游戏的构想，然后编写设计文档和工作计划 | 已搭建好的项目骨架 | `GDD.md`、`PLAN.md`、`STRUCTURE.md`、`SCENES.md`、`ASSETS.md`、`TOC.md` |
-| `/gm-asset` | 生成缺失的美术资源，或分析你提供的美术资源，为构建阶段准备好可用的素材 | `/gm-gdd` 产出的 `ASSETS.md` | `assets/` 下的美术文件，更新后的 `ASSETS.md` |
+| `/gm-asset` | 生成缺失的美术资源，或分析你提供的美术资源，为构建阶段准备好可用的素材 | `/gm-gdd` 产出的 `ASSETS.md` | 美术文件、场景参考图和更新后的 `ASSETS.md`；参考图可以完成，但不会成为运行时资产 |
 | `/gm-build` | 通过向 Worker（工人）子 Agent 分批派发任务来实现游戏，Reviewer 会对结果进行审查 | `/gm-gdd` 产出的设计文档 | `src/`、`scenes/` 下的游戏代码，单元测试，端对端测试 |
 | `/gm-verify` | 运行机械性检查：项目能否编译、单元测试是否通过、必要文件是否存在 | 已构建好的项目 | 一份打印到聊天里的通过/失败报告，并向 `.godotmaker/stage.jsonl` 追加一个 `verify` 事件 |
 | `/gm-evaluate` | 独立运行游戏，截图并对照 GDD 给结果评分 | 已通过验证的项目 | `.godotmaker/evaluation.json`，`e2e/screenshots/` 下的截图 |

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -216,7 +216,7 @@ python tools/asset_generation_index.py --project-root . --check-entries --check-
 
 ## asset_assets_md_update.py
 
-`asset_assets_md_update.py` 会根据已注册的 stable entry 更新 ASSETS.md 行。它先重新校验 entry 和被引用的文件，并且只接受 `ready` 的非 reference entry，所以只有素材确实是可被 worker 消费的成品时，行才会变成 `generated`；行里只记录 entry 指针，不复制任何路径。
+`asset_assets_md_update.py` 会根据已注册的 stable entry 更新 ASSETS.md 行。它先重新校验每个 entry 和被引用的文件。运行时行必须使用 `ready` 的非 reference entry，因此只有素材确实可被 worker 消费时才会变成 `generated`。`screen-reference` 行是例外：当 finalize 后的参考图文件、canonical stable entry 和 root-index 指针通过适用校验时，可在 `source_ready`（或后续 `ready`）变为 `generated`。它记录同一个 entry 指针，但绝不会创建 `godot_artifact` 或交给 worker 作为运行时资产。
 
 手动入口：
 
@@ -239,5 +239,6 @@ python tools/asset_assets_md_update.py \
 6. 把某个 extracted candidate 选入运行时素材路径。
 7. 打印或校验某个素材的稳定输出目录。
 8. 校验并注册一个 stable entry 及其 root-index 指针。
+9. 完成一张 finalize 后的场景参考图，而不把它当作运行时美术。
 
 如果想更新 `/gm-evaluate` 用于对比的视觉目标，请重新运行 `/gm-asset`，不要直接编辑已生成的图片。

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -100,8 +100,9 @@ FAILED with the missing path.}
  Use existing final paths from ASSETS.md or from the stable entries the
  .godotmaker/asset-generation/manifest.json index points at.
  Do not use source sheets, curation candidates, prompt files, or scene
- references as runtime assets unless ASSETS.md explicitly lists that path as
- the final asset.
+ references as runtime assets. An ASSETS.md row whose type is `reference` is
+ never a runtime asset, even when it is `generated` and lists a final reference
+ path.
  Do not replace an available final asset with placeholder art, procedural
  shapes, or freshly drawn stand-ins.}
 

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -99,10 +99,8 @@ FAILED with the missing path.}
  final runtime asset path.
  Use existing final paths from ASSETS.md or from the stable entries the
  .godotmaker/asset-generation/manifest.json index points at.
- Do not use source sheets, curation candidates, prompt files, or scene
- references as runtime assets. An ASSETS.md row whose type is `reference` is
- never a runtime asset, even when it is `generated` and lists a final reference
- path.
+ Do not use source sheets, curation candidates, prompt files, scene references,
+ or ASSETS.md rows whose type is `reference` as runtime assets.
  Do not replace an available final asset with placeholder art, procedural
  shapes, or freshly drawn stand-ins.}
 

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -237,32 +237,27 @@ python tools/asset_generation_index.py --project-root . \
   --entry-file .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
 ```
 
-6. Run the full root-index gate before marking any runtime entry `generated`.
-   `--check-files` verifies that every registered entry's source and artifact
-   still exist, so it is required for runtime handoff:
+6. Before marking any runtime entry `generated`, run the full root-index gate:
 
 ```bash
 python tools/asset_generation_index.py --project-root . --check-entries --check-files
 ```
 
-7. Update the matching ASSETS.md rows only after the root-index gate passes. A
-   `ready` non-reference entry is a finished runtime asset. A
-   `screen-reference` entry completes its reference row at `source_ready` (or
-   remains repeatable at `ready`) when its finalized file, canonical stable
-   entry, and root-index pointer pass validation. The updater schema-validates
-   the complete root index and validates the reference entry's own file, so an
-   unrelated pending entry cannot block this reference-only path. It never
-   creates a `godot_artifact` or a worker runtime handoff:
+7. Update the matching ASSETS.md rows only after the root-index gate passes:
+
+   - Mark a `ready` non-reference entry `generated` after the full root-index
+     gate passes.
+   - Mark a `screen-reference` entry `generated` at `source_ready` or `ready`
+     after its finalized file, canonical entry, and root-index pointer validate.
+   - Do not create a `godot_artifact` or worker runtime handoff for a reference.
 
 ```bash
 python tools/asset_assets_md_update.py \
   --entry-file .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
 ```
 
-The updater rejects any other entry. The native compilers and the L0-L4 runner
-are not implemented, so no generated runtime asset reaches `ready` yet and the
-command reports a blocking status for those rows. A validated reference-only row
-is the exception and is promoted by the updater, never by hand-editing a status.
+Keep runtime entries below `ready` as `MISSING`. Do not hand-edit an ASSETS.md
+status, the root index, or a stable entry.
 
 8. Redispatch failed or incomplete production units once when the failure is
    actionable from the report.
@@ -275,21 +270,18 @@ pass.
 
 For current-tag rows only:
 
-1. Confirm rows whose non-reference entry is `ready` are `generated`, and whose
-   validated reference-only entry is `source_ready` or `ready` are `generated`.
+1. Confirm a `ready` non-reference entry is `generated`; confirm a validated
+   `source_ready` or `ready` reference-only entry is `generated`.
 2. Mark provided files `provided`.
 3. Mark unprovided audio `deferred`.
-4. Keep runtime rows without a registered `ready` entry as `MISSING`. Until
-   the native compilers and the L0-L4 runner land this covers every generated
-   runtime row. A registered, validated `screen-reference` at `source_ready`
-   is the sole reference-only exception and becomes `generated` without being
-   worker-consumable.
+4. Keep runtime rows without a registered `ready` entry as `MISSING`. Mark a
+   registered, validated `screen-reference` at `source_ready` or `ready` as
+   `generated`.
 5. Confirm `Generation Params` include the stable entry pointer only.
 6. Update the Visual Asset Contract for gameplay-visible generated assets.
 
-Report the registered reference-only entries to the user and say plainly that
-they are not worker-consumable. Do not mark a runtime row `generated`, invent a
-`godot_artifact`, or edit `processing_status` to close the stage.
+Report registered reference-only entries as non-runtime assets. Do not mark a
+runtime row `generated`, invent a `godot_artifact`, or edit `processing_status`.
 
 Do not mark source sheets, references, or curation candidates as final runtime
 assets unless the production-unit report selected them as final outputs.
@@ -307,12 +299,9 @@ or leave a fix task for a later role.
 
 ## Completion
 
-The native compilers and the L0-L4 runner are not implemented, so generated
-runtime rows cannot reach this state yet: those rows stay `MISSING` by design.
-Registered, validated reference-only rows may complete at `source_ready`; report
-them as visual references, not worker-consumable assets. If any runtime rows
-remain, tell the user the asset stage is blocked on compiler work rather than
-forcing it closed.
+Keep generated runtime rows below `ready` as `MISSING`. Registered, validated
+reference-only rows may complete at `source_ready` or `ready`. If runtime rows
+remain, report the asset stage blocked on compiler work.
 
 After ASSETS.md has no current-tag `MISSING` rows except deferred audio:
 

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -244,8 +244,12 @@ python tools/asset_generation_index.py --project-root . \
 python tools/asset_generation_index.py --project-root . --check-entries --check-files
 ```
 
-7. Update the matching ASSETS.md rows only after the root-index gate passes, and
-   only for `ready` non-reference entries:
+7. Update the matching ASSETS.md rows only after the root-index gate passes. A
+   `ready` non-reference entry is a finished runtime asset; a
+   `screen-reference` entry completes its reference row at `source_ready` when
+   its finalized file, canonical stable entry, and root-index pointer all pass
+   validation. The reference path never creates a `godot_artifact` or a worker
+   runtime handoff:
 
 ```bash
 python tools/asset_assets_md_update.py \
@@ -272,9 +276,11 @@ For current-tag rows only:
 1. Confirm rows whose entry is `ready` are `generated`.
 2. Mark provided files `provided`.
 3. Mark unprovided audio `deferred`.
-4. Keep rows without a registered `ready` entry as `MISSING`. Until the native
-   compilers and the L0-L4 runner land this covers every generated row,
-   including reference rows.
+4. Keep runtime rows without a registered `ready` entry as `MISSING`. Until
+   the native compilers and the L0-L4 runner land this covers every generated
+   runtime row. A registered, validated `screen-reference` at `source_ready`
+   is the sole reference-only exception and becomes `generated` without being
+   worker-consumable.
 5. Confirm `Generation Params` include the stable entry pointer only.
 6. Update the Visual Asset Contract for gameplay-visible generated assets.
 
@@ -298,11 +304,12 @@ or leave a fix task for a later role.
 
 ## Completion
 
-The native compilers and the L0-L4 runner are not implemented, so a tag whose
-plan contains generated visual assets cannot reach this state yet: those rows
-stay `MISSING` by design. Stop after Step 6, report the registered
-`source_ready` entries, and tell the user the asset stage is blocked on the
-compiler work rather than forcing the stage closed.
+The native compilers and the L0-L4 runner are not implemented, so generated
+runtime rows cannot reach this state yet: those rows stay `MISSING` by design.
+Registered, validated reference-only rows may complete at `source_ready`; report
+them as visual references, not worker-consumable assets. If any runtime rows
+remain, tell the user the asset stage is blocked on compiler work rather than
+forcing it closed.
 
 After ASSETS.md has no current-tag `MISSING` rows except deferred audio:
 

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -237,19 +237,22 @@ python tools/asset_generation_index.py --project-root . \
   --entry-file .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
 ```
 
-6. Run the full root-index gate. `--check-files` verifies that every registered
-   entry's source and artifact still exist, so it is required here:
+6. Run the full root-index gate before marking any runtime entry `generated`.
+   `--check-files` verifies that every registered entry's source and artifact
+   still exist, so it is required for runtime handoff:
 
 ```bash
 python tools/asset_generation_index.py --project-root . --check-entries --check-files
 ```
 
 7. Update the matching ASSETS.md rows only after the root-index gate passes. A
-   `ready` non-reference entry is a finished runtime asset; a
-   `screen-reference` entry completes its reference row at `source_ready` when
-   its finalized file, canonical stable entry, and root-index pointer all pass
-   validation. The reference path never creates a `godot_artifact` or a worker
-   runtime handoff:
+   `ready` non-reference entry is a finished runtime asset. A
+   `screen-reference` entry completes its reference row at `source_ready` (or
+   remains repeatable at `ready`) when its finalized file, canonical stable
+   entry, and root-index pointer pass validation. The updater schema-validates
+   the complete root index and validates the reference entry's own file, so an
+   unrelated pending entry cannot block this reference-only path. It never
+   creates a `godot_artifact` or a worker runtime handoff:
 
 ```bash
 python tools/asset_assets_md_update.py \
@@ -257,10 +260,9 @@ python tools/asset_assets_md_update.py \
 ```
 
 The updater rejects any other entry. The native compilers and the L0-L4 runner
-are not implemented, so no generated asset reaches `ready` yet and this command
-currently reports the blocking status instead of promoting a row. That is
-expected: registration is what this stage delivers. Leave the row `MISSING` and
-do not hand-edit a status to make the stage look complete.
+are not implemented, so no generated runtime asset reaches `ready` yet and the
+command reports a blocking status for those rows. A validated reference-only row
+is the exception and is promoted by the updater, never by hand-editing a status.
 
 8. Redispatch failed or incomplete production units once when the failure is
    actionable from the report.
@@ -273,7 +275,8 @@ pass.
 
 For current-tag rows only:
 
-1. Confirm rows whose entry is `ready` are `generated`.
+1. Confirm rows whose non-reference entry is `ready` are `generated`, and whose
+   validated reference-only entry is `source_ready` or `ready` are `generated`.
 2. Mark provided files `provided`.
 3. Mark unprovided audio `deferred`.
 4. Keep runtime rows without a registered `ready` entry as `MISSING`. Until
@@ -284,9 +287,9 @@ For current-tag rows only:
 5. Confirm `Generation Params` include the stable entry pointer only.
 6. Update the Visual Asset Contract for gameplay-visible generated assets.
 
-Report the registered `source_ready` entries to the user and say plainly that
-generated assets are not yet worker-consumable. Do not mark a row `generated`,
-invent a `godot_artifact`, or edit `processing_status` to close the stage.
+Report the registered reference-only entries to the user and say plainly that
+they are not worker-consumable. Do not mark a runtime row `generated`, invent a
+`godot_artifact`, or edit `processing_status` to close the stage.
 
 Do not mark source sheets, references, or curation candidates as final runtime
 assets unless the production-unit report selected them as final outputs.

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -39,7 +39,8 @@ Current-tag visual anchors are:
 1. User-provided image assets accepted as `direct_runtime`.
 2. Current-tag `references/scene_*.png` files with matching reports.
 3. Current-tag generated `screen-reference` or `style_reference` stable
-   entries whose files exist.
+   entries at `source_ready` whose files exist and whose canonical pointers
+   pass the root-index gate. They are visual anchors, never runtime artifacts.
 4. Current-tag canonical character or UI reference images whose stable entries
    are `ready`.
 
@@ -157,11 +158,13 @@ Use this order when units depend on each other:
 
 Update current-tag rows after producer reports:
 
-1. `generated`: a `ready` stable entry is registered and the root-index gate
-   passed.
+1. `generated`: either a `ready` non-reference stable entry is registered and
+   the root-index gate passed, or a `source_ready` reference-only stable entry
+   has its finalized file, canonical pointer, and root-index gate validated.
 2. `provided`: user-provided file matched the row.
 3. `deferred`: unprovided audio or intentionally skipped asset.
-4. `MISSING`: source exists but the runtime output or curation is incomplete.
+4. `MISSING`: a runtime source exists but the runtime output or curation is
+   incomplete, or a reference lacks its finalized, registered, validated entry.
 
 Update `Generation Params` with:
 

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -39,8 +39,9 @@ Current-tag visual anchors are:
 1. User-provided image assets accepted as `direct_runtime`.
 2. Current-tag `references/scene_*.png` files with matching reports.
 3. Current-tag generated `screen-reference` or `style_reference` stable
-   entries at `source_ready` whose files exist and whose canonical pointers
-   pass the root-index gate. They are visual anchors, never runtime artifacts.
+   entries at `source_ready` or `ready` whose files exist and whose canonical
+   pointers pass the root-index gate. They are visual anchors, never runtime
+   artifacts.
 4. Current-tag canonical character or UI reference images whose stable entries
    are `ready`.
 
@@ -159,8 +160,9 @@ Use this order when units depend on each other:
 Update current-tag rows after producer reports:
 
 1. `generated`: either a `ready` non-reference stable entry is registered and
-   the root-index gate passed, or a `source_ready` reference-only stable entry
-   has its finalized file, canonical pointer, and root-index gate validated.
+   the root-index gate passed, or a `source_ready` or `ready` reference-only
+   stable entry has its finalized file, canonical pointer, and root-index gate
+   validated.
 2. `provided`: user-provided file matched the row.
 3. `deferred`: unprovided audio or intentionally skipped asset.
 4. `MISSING`: a runtime source exists but the runtime output or curation is

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -39,9 +39,8 @@ Current-tag visual anchors are:
 1. User-provided image assets accepted as `direct_runtime`.
 2. Current-tag `references/scene_*.png` files with matching reports.
 3. Current-tag generated `screen-reference` or `style_reference` stable
-   entries at `source_ready` or `ready` whose files exist and whose canonical
-   pointers pass the root-index gate. They are visual anchors, never runtime
-   artifacts.
+   entries at `source_ready` or `ready` with existing files and canonical
+   pointers that pass the root-index gate. Use them as visual anchors only.
 4. Current-tag canonical character or UI reference images whose stable entries
    are `ready`.
 
@@ -159,10 +158,9 @@ Use this order when units depend on each other:
 
 Update current-tag rows after producer reports:
 
-1. `generated`: either a `ready` non-reference stable entry is registered and
-   the root-index gate passed, or a `source_ready` or `ready` reference-only
-   stable entry has its finalized file, canonical pointer, and root-index gate
-   validated.
+1. `generated`: a registered `ready` non-reference stable entry after the full
+   root-index gate, or a validated `source_ready` or `ready` reference-only
+   stable entry with its finalized file and canonical root-index pointer.
 2. `provided`: user-provided file matched the row.
 3. `deferred`: unprovided audio or intentionally skipped asset.
 4. `MISSING`: a runtime source exists but the runtime output or curation is

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -254,16 +254,12 @@ python tools/asset_assets_md_update.py \
 ```
 
 The updater promotes a runtime row to `generated` only for a `ready`
-non-reference entry. A `screen-reference` row is the narrow exception: it may
-become `generated` at `source_ready` and remains repeatable at `ready` after its
-finalized reference file, canonical stable entry, and root-index pointer pass.
-The updater schema-validates every index pointer and validates the selected
-reference entry's file; it deliberately does not require unrelated pending
-entries from other tags to have produced files. That records the same
-`manifest_entry` pointer without creating a `godot_artifact` or making the
-reference worker-consumable. All other `source_ready` entries remain `MISSING`
-until the compilers and L0-L4 runner land; do not work around that by editing
-rows or statuses by hand.
+non-reference entry. A `screen-reference` row may become `generated` at
+`source_ready` or `ready` with a finalized reference file, canonical stable
+entry, and root-index pointer. It schema-validates index pointers and validates
+the selected reference file. Do not create a `godot_artifact`, worker handoff,
+or hand-edited ASSETS.md status for a reference. Keep all other `source_ready`
+entries `MISSING`.
 
 Register entries for new current-tag assets. Preserve prior entries unless the
 same current-tag asset is being regenerated.
@@ -303,8 +299,7 @@ Compiler target by source layout, for when that work lands:
 2. `grid_sheet`: `SpriteFrames`, with action metadata beside the artifact.
 3. `region_atlas`: `AtlasTexture`, with atlas metadata beside the artifact.
 4. `theme_recipe`: `Theme`. `tile_atlas`: `TileSet`.
-5. `reference`: no artifact; it may complete a reference-type ASSETS row but
-   never an ASSETS runtime row.
+5. `reference`: no artifact; complete a reference-type ASSETS row only.
 
 Support files are named after the asset and live beside the artifact:
 

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -253,12 +253,14 @@ python tools/asset_assets_md_update.py \
   --entry-file .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
 ```
 
-The updater promotes a row to `generated` only for a `ready` non-reference entry
-and fails closed on anything else, because `generated` is what tells `/gm-build`
-the row's asset is finished. Until the compilers and the L0-L4 runner land no
-entry reaches `ready`, so generated rows stay `MISSING` and this command reports
-the blocking status instead of promoting anything. That is the honest state; do
-not work around it by editing rows or statuses by hand.
+The updater promotes a runtime row to `generated` only for a `ready`
+non-reference entry. A `screen-reference` row is the narrow exception: it may
+become `generated` at `source_ready` only after its finalized reference file,
+canonical stable entry, root-index pointer, and full root-index file gate pass.
+That records the same `manifest_entry` pointer without creating a
+`godot_artifact` or making the reference worker-consumable. All other
+`source_ready` entries remain `MISSING` until the compilers and L0-L4 runner
+land; do not work around that by editing rows or statuses by hand.
 
 Register entries for new current-tag assets. Preserve prior entries unless the
 same current-tag asset is being regenerated.

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -255,12 +255,15 @@ python tools/asset_assets_md_update.py \
 
 The updater promotes a runtime row to `generated` only for a `ready`
 non-reference entry. A `screen-reference` row is the narrow exception: it may
-become `generated` at `source_ready` only after its finalized reference file,
-canonical stable entry, root-index pointer, and full root-index file gate pass.
-That records the same `manifest_entry` pointer without creating a
-`godot_artifact` or making the reference worker-consumable. All other
-`source_ready` entries remain `MISSING` until the compilers and L0-L4 runner
-land; do not work around that by editing rows or statuses by hand.
+become `generated` at `source_ready` and remains repeatable at `ready` after its
+finalized reference file, canonical stable entry, and root-index pointer pass.
+The updater schema-validates every index pointer and validates the selected
+reference entry's file; it deliberately does not require unrelated pending
+entries from other tags to have produced files. That records the same
+`manifest_entry` pointer without creating a `godot_artifact` or making the
+reference worker-consumable. All other `source_ready` entries remain `MISSING`
+until the compilers and L0-L4 runner land; do not work around that by editing
+rows or statuses by hand.
 
 Register entries for new current-tag assets. Preserve prior entries unless the
 same current-tag asset is being regenerated.
@@ -300,7 +303,8 @@ Compiler target by source layout, for when that work lands:
 2. `grid_sheet`: `SpriteFrames`, with action metadata beside the artifact.
 3. `region_atlas`: `AtlasTexture`, with atlas metadata beside the artifact.
 4. `theme_recipe`: `Theme`. `tile_atlas`: `TileSet`.
-5. `reference`: no artifact; never mark an ASSETS runtime row generated from it.
+5. `reference`: no artifact; it may complete a reference-type ASSETS row but
+   never an ASSETS runtime row.
 
 Support files are named after the asset and live beside the artifact:
 

--- a/tests/tools/test_asset_assets_md_update.py
+++ b/tests/tools/test_asset_assets_md_update.py
@@ -9,6 +9,7 @@ TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
 
 from asset_assets_md_update import AssetsMdUpdateError, update_assets_md  # noqa: E402
+from asset_generation_index import update_index  # noqa: E402
 from asset_stable_entry import entry_relative_path, stable_output_dir  # noqa: E402
 
 TAG = "v0.1.0"
@@ -174,32 +175,127 @@ def test_update_assets_md_rejects_unready_entry(tmp_path, status):
     assert "| generated |" not in assets_md.read_text(encoding="utf-8")
 
 
-def test_update_assets_md_rejects_reference_entry(tmp_path):
-    """A screen reference is never handed to a worker as a runtime asset."""
-    assets_md = tmp_path / "ASSETS.md"
-    assets_md.write_text(
+def make_reference_entry(**overrides):
+    entry = {
+        "version": 1,
+        "asset_id": "scene_main",
+        "tag": TAG,
+        "production_family": "screen-reference",
+        "source_layout": {
+            "type": "reference",
+            "path": "res://references/scene_main.png",
+        },
+        "processing_status": "source_ready",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def write_reference_assets_md(path: Path):
+    path.write_text(
         "| ID | Tag | Name | Type | Size | Generation Params | Path | Status |\n"
         "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
         f"| 1 | {TAG} | scene_main | reference | 1280x720 | — | references/scene_main.png | MISSING |\n",
         encoding="utf-8",
     )
+
+
+def test_update_assets_md_promotes_registered_source_ready_reference(tmp_path):
+    """References complete after deterministic registration, not runtime readiness."""
+    assets_md = tmp_path / "ASSETS.md"
+    write_reference_assets_md(assets_md)
     touch(tmp_path, "references/scene_main.png")
-    entry_file = write_entry(
-        tmp_path,
-        {
-            "version": 1,
-            "asset_id": "scene_main",
-            "tag": TAG,
-            "production_family": "screen-reference",
-            "source_layout": {
-                "type": "reference",
-                "path": "res://references/scene_main.png",
-            },
-            "processing_status": "ready",
-        },
+    entry_file = write_entry(tmp_path, make_reference_entry())
+    update_index(
+        tmp_path / ".godotmaker/asset-generation/manifest.json",
+        [entry_file],
+        project_root=tmp_path,
     )
 
-    with pytest.raises(AssetsMdUpdateError, match="is a reference entry"):
+    update_assets_md(assets_md, [entry_file])
+
+    text = assets_md.read_text(encoding="utf-8")
+    assert "| generated |" in text
+    assert f"manifest_entry={entry_relative_path(TAG, 'scene_main')}" in text
+
+
+def test_reference_entry_must_be_registered_and_pass_the_root_index_gate(tmp_path):
+    assets_md = tmp_path / "ASSETS.md"
+    write_reference_assets_md(assets_md)
+    touch(tmp_path, "references/scene_main.png")
+    entry_file = write_entry(tmp_path, make_reference_entry())
+
+    with pytest.raises(AssetsMdUpdateError, match="root-index gate"):
+        update_assets_md(assets_md, [entry_file])
+
+    update_index(
+        tmp_path / ".godotmaker/asset-generation/manifest.json",
+        [entry_file],
+        project_root=tmp_path,
+    )
+    (tmp_path / "references/scene_main.png").unlink()
+
+    with pytest.raises(AssetsMdUpdateError, match="source_layout.path not found"):
+        update_assets_md(assets_md, [entry_file])
+
+    assert "| generated |" not in assets_md.read_text(encoding="utf-8")
+
+
+def test_reference_entry_rejects_a_valid_index_without_its_pointer(tmp_path):
+    assets_md = tmp_path / "ASSETS.md"
+    write_reference_assets_md(assets_md)
+    touch(tmp_path, "references/scene_main.png")
+    entry_file = write_entry(tmp_path, make_reference_entry())
+    touch(tmp_path, "references/scene_other.png")
+    other_entry = write_entry(
+        tmp_path,
+        make_reference_entry(
+            asset_id="scene_other",
+            source_layout={
+                "type": "reference",
+                "path": "res://references/scene_other.png",
+            },
+        ),
+    )
+    update_index(
+        tmp_path / ".godotmaker/asset-generation/manifest.json",
+        [other_entry],
+        project_root=tmp_path,
+    )
+
+    with pytest.raises(AssetsMdUpdateError, match="is not registered in the root index"):
+        update_assets_md(assets_md, [entry_file])
+
+    assert "| generated |" not in assets_md.read_text(encoding="utf-8")
+
+
+def test_reference_entry_rejects_root_index_identity_mismatch(tmp_path):
+    assets_md = tmp_path / "ASSETS.md"
+    write_reference_assets_md(assets_md)
+    touch(tmp_path, "references/scene_main.png")
+    entry_file = write_entry(tmp_path, make_reference_entry())
+    bad_entry_path = tmp_path / entry_relative_path("v0.2.0", "scene_main")
+    bad_entry_path.parent.mkdir(parents=True, exist_ok=True)
+    bad_entry_path.write_text(entry_file.read_text(encoding="utf-8"), encoding="utf-8")
+    index_path = tmp_path / ".godotmaker/asset-generation/manifest.json"
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "asset_id": "scene_main",
+                        "tag": "v0.2.0",
+                        "entry_path": entry_relative_path("v0.2.0", "scene_main"),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssetsMdUpdateError, match="identity does not match"):
         update_assets_md(assets_md, [entry_file])
 
     assert "| generated |" not in assets_md.read_text(encoding="utf-8")

--- a/tests/tools/test_asset_assets_md_update.py
+++ b/tests/tools/test_asset_assets_md_update.py
@@ -200,12 +200,13 @@ def write_reference_assets_md(path: Path):
     )
 
 
-def test_update_assets_md_promotes_registered_source_ready_reference(tmp_path):
+@pytest.mark.parametrize("status", ["source_ready", "ready"])
+def test_update_assets_md_promotes_registered_reference(tmp_path, status):
     """References complete after deterministic registration, not runtime readiness."""
     assets_md = tmp_path / "ASSETS.md"
     write_reference_assets_md(assets_md)
     touch(tmp_path, "references/scene_main.png")
-    entry_file = write_entry(tmp_path, make_reference_entry())
+    entry_file = write_entry(tmp_path, make_reference_entry(processing_status=status))
     update_index(
         tmp_path / ".godotmaker/asset-generation/manifest.json",
         [entry_file],
@@ -217,6 +218,19 @@ def test_update_assets_md_promotes_registered_source_ready_reference(tmp_path):
     text = assets_md.read_text(encoding="utf-8")
     assert "| generated |" in text
     assert f"manifest_entry={entry_relative_path(TAG, 'scene_main')}" in text
+
+
+@pytest.mark.parametrize("status", ["pending", "compiled", "failed"])
+def test_update_assets_md_rejects_incomplete_reference(tmp_path, status):
+    assets_md = tmp_path / "ASSETS.md"
+    write_reference_assets_md(assets_md)
+    touch(tmp_path, "references/scene_main.png")
+    entry_file = write_entry(tmp_path, make_reference_entry(processing_status=status))
+
+    with pytest.raises(AssetsMdUpdateError, match=f"processing_status is {status}"):
+        update_assets_md(assets_md, [entry_file])
+
+    assert "| generated |" not in assets_md.read_text(encoding="utf-8")
 
 
 def test_reference_entry_must_be_registered_and_pass_the_root_index_gate(tmp_path):
@@ -299,6 +313,26 @@ def test_reference_entry_rejects_root_index_identity_mismatch(tmp_path):
         update_assets_md(assets_md, [entry_file])
 
     assert "| generated |" not in assets_md.read_text(encoding="utf-8")
+
+
+def test_reference_entry_ignores_unrelated_unfinished_index_entry(tmp_path):
+    """A pending asset may be registered without blocking a reference row."""
+    assets_md = tmp_path / "ASSETS.md"
+    write_reference_assets_md(assets_md)
+    touch(tmp_path, "references/scene_main.png")
+    reference_entry = write_entry(tmp_path, make_reference_entry())
+    pending_runtime = make_entry(processing_status="pending")
+    pending_runtime.pop("godot_artifact")
+    pending_entry = write_entry(tmp_path, pending_runtime)
+    update_index(
+        tmp_path / ".godotmaker/asset-generation/manifest.json",
+        [reference_entry, pending_entry],
+        project_root=tmp_path,
+    )
+
+    update_assets_md(assets_md, [reference_entry])
+
+    assert "| generated |" in assets_md.read_text(encoding="utf-8")
 
 
 def test_update_assets_md_rejects_missing_artifact_file(tmp_path):

--- a/tools/asset_assets_md_update.py
+++ b/tools/asset_assets_md_update.py
@@ -32,7 +32,7 @@ from asset_generation_index import GenerationIndexError, check_index
 
 # The only readiness state that means "a worker can load this asset now".
 PROMOTABLE_STATUS = "ready"
-REFERENCE_PROMOTABLE_STATUS = "source_ready"
+REFERENCE_PROMOTABLE_STATUSES = {"source_ready", "ready"}
 ROOT_INDEX_RELATIVE = ".godotmaker/asset-generation/manifest.json"
 
 
@@ -53,21 +53,22 @@ def _assert_promotable(entry: dict[str, Any], entry_path: Path) -> bool:
     ``validate_entry`` proves the entry is well-formed and its files exist, but a
     well-formed runtime entry can still be mid-flight (``pending``,
     ``source_ready``, ``compiled``) or failed outright. A screen reference is
-    intentionally different: it completes at ``source_ready`` after separate
-    root-index validation, but is never handed to a worker as a runtime asset.
+    intentionally different: it completes at ``source_ready`` and remains
+    repeatable if a future process records it as ``ready``. Neither status makes
+    a reference worker-consumable.
     """
     is_reference = entry["source_layout"]["type"] in REFERENCE_LAYOUTS
     status = entry["processing_status"]
-    expected_status = (
-        REFERENCE_PROMOTABLE_STATUS if is_reference else PROMOTABLE_STATUS
-    )
+    if is_reference and status in REFERENCE_PROMOTABLE_STATUSES:
+        return True
+    expected_status = "source_ready or ready" if is_reference else PROMOTABLE_STATUS
     if status != expected_status:
         raise AssetsMdUpdateError(
             f"{entry_path} processing_status is {status}; only a {expected_status} "
             f"{'reference' if is_reference else 'runtime'} entry may update an "
             "ASSETS.md row"
         )
-    return is_reference
+    return False
 
 
 def _assert_registered_reference(
@@ -76,13 +77,15 @@ def _assert_registered_reference(
     """Require a reference to pass the root-index gate before completion.
 
     A reference has no runtime artifact, so its ``source_ready`` status is
-    enough only after the canonical entry is registered and the full root index
-    still validates its source files. The membership check prevents a valid but
+    enough only after the canonical entry is registered and the root index
+    schema-validates every pointer. The caller separately validates this entry's
+    source file, avoiding unrelated pending entries from other tags blocking a
+    reference-only completion. The membership check prevents a valid but
     unregistered entry from changing ASSETS.md directly.
     """
     index_path = project_root / ROOT_INDEX_RELATIVE
     try:
-        check_index(index_path, project_root=project_root, check_files=True)
+        check_index(index_path, project_root=project_root, check_entries=True)
     except GenerationIndexError as exc:
         raise AssetsMdUpdateError(
             f"Reference entry cannot pass the root-index gate: {exc}"

--- a/tools/asset_assets_md_update.py
+++ b/tools/asset_assets_md_update.py
@@ -7,9 +7,10 @@ validated against the v1 schema before any row is touched, and the row records
 the entry pointer — never a duplicated path snapshot — so the entry stays the
 single source of truth for the asset.
 
-Only an entry that is genuinely worker-consumable may promote a row. ASSETS.md
-``generated`` is what tells ``/gm-build`` a row's asset is finished, so this tool
-fails closed on anything else.
+Runtime entries may promote a row only when they are genuinely
+worker-consumable. A registered reference-only entry has a separate completion
+path: it proves an accepted scene/style reference exists without claiming that
+a worker can consume it as a runtime artifact.
 """
 from __future__ import annotations
 
@@ -27,9 +28,12 @@ from asset_stable_entry import (
     entry_relative_path,
     validate_entry,
 )
+from asset_generation_index import GenerationIndexError, check_index
 
 # The only readiness state that means "a worker can load this asset now".
 PROMOTABLE_STATUS = "ready"
+REFERENCE_PROMOTABLE_STATUS = "source_ready"
+ROOT_INDEX_RELATIVE = ".godotmaker/asset-generation/manifest.json"
 
 
 class AssetsMdUpdateError(Exception):
@@ -43,26 +47,57 @@ def _load_json(path: Path) -> Any:
         raise AssetsMdUpdateError(f"Invalid JSON: {path}") from exc
 
 
-def _assert_promotable(entry: dict[str, Any], entry_path: Path) -> None:
-    """Reject any entry that is not a finished runtime asset.
+def _assert_promotable(entry: dict[str, Any], entry_path: Path) -> bool:
+    """Validate an entry's completion path and return whether it is a reference.
 
     ``validate_entry`` proves the entry is well-formed and its files exist, but a
-    well-formed entry can still be mid-flight (``pending``, ``source_ready``,
-    ``compiled``), failed outright, or a screen reference that is never handed to
-    a worker as a runtime game asset. Marking such a row ``generated`` would tell
-    ``/gm-build`` to bind an asset that is not finished, so the precondition is
-    enforced here rather than left to the caller.
+    well-formed runtime entry can still be mid-flight (``pending``,
+    ``source_ready``, ``compiled``) or failed outright. A screen reference is
+    intentionally different: it completes at ``source_ready`` after separate
+    root-index validation, but is never handed to a worker as a runtime asset.
     """
+    is_reference = entry["source_layout"]["type"] in REFERENCE_LAYOUTS
     status = entry["processing_status"]
-    if status != PROMOTABLE_STATUS:
+    expected_status = (
+        REFERENCE_PROMOTABLE_STATUS if is_reference else PROMOTABLE_STATUS
+    )
+    if status != expected_status:
         raise AssetsMdUpdateError(
-            f"{entry_path} processing_status is {status}; only a "
-            f"{PROMOTABLE_STATUS} entry may update an ASSETS.md row"
+            f"{entry_path} processing_status is {status}; only a {expected_status} "
+            f"{'reference' if is_reference else 'runtime'} entry may update an "
+            "ASSETS.md row"
         )
-    if entry["source_layout"]["type"] in REFERENCE_LAYOUTS:
+    return is_reference
+
+
+def _assert_registered_reference(
+    entry: dict[str, Any], entry_path: Path, *, project_root: Path
+) -> None:
+    """Require a reference to pass the root-index gate before completion.
+
+    A reference has no runtime artifact, so its ``source_ready`` status is
+    enough only after the canonical entry is registered and the full root index
+    still validates its source files. The membership check prevents a valid but
+    unregistered entry from changing ASSETS.md directly.
+    """
+    index_path = project_root / ROOT_INDEX_RELATIVE
+    try:
+        check_index(index_path, project_root=project_root, check_files=True)
+    except GenerationIndexError as exc:
         raise AssetsMdUpdateError(
-            f"{entry_path} is a reference entry; a reference is not a runtime "
-            "asset, so /gm-asset updates its row directly instead"
+            f"Reference entry cannot pass the root-index gate: {exc}"
+        ) from exc
+
+    index_data = _load_json(index_path)
+    expected = {
+        "asset_id": entry["asset_id"],
+        "tag": entry["tag"],
+        "entry_path": entry_relative_path(entry["tag"], entry["asset_id"]),
+    }
+    if expected not in index_data["entries"]:
+        raise AssetsMdUpdateError(
+            f"{entry_path} is not registered in the root index as "
+            f"{expected['entry_path']}"
         )
 
 
@@ -84,7 +119,7 @@ def _load_entries(
             entry = validate_entry(data, project_root=project_root, check_files=True)
         except StableEntryError as exc:
             raise AssetsMdUpdateError(f"{entry_path}: {exc}") from exc
-        _assert_promotable(entry, entry_path)
+        is_reference = _assert_promotable(entry, entry_path)
         tag = entry["tag"]
         asset_id = entry["asset_id"]
         key = (tag, asset_id)
@@ -95,6 +130,10 @@ def _load_entries(
         if entry_path.resolve() != (project_root / canonical).resolve():
             raise AssetsMdUpdateError(
                 f"{entry_path} must be the canonical entry path {canonical}"
+            )
+        if is_reference:
+            _assert_registered_reference(
+                entry, entry_path, project_root=project_root
             )
         entries.append((canonical, entry))
     return entries


### PR DESCRIPTION
## Summary

Complete registered screen-reference ASSETS.md rows at `source_ready` after root-index validation, instead of leaving reference-only entries permanently `MISSING`.

## Motivation

Reference-only stable entries (e.g. `screen-reference`) correctly stop at `source_ready` and never produce a `godot_artifact` or reach worker runtime handoff. However, the previous ASSETS.md completion contract required every row to leave `MISSING` state, which reference rows could never satisfy — causing tags containing only reference rows to be permanently blocked from completion. This PR defines a deterministic completion path for reference-only rows that cannot be mistaken for runtime-ready assets.

## Changes

- [x] Allow a matching reference-only ASSETS.md row to move from `MISSING` to `generated` once the reference file exists, finalize/draft validation passes, the canonical stable entry is registered, and the root-index gate passes
- [x] Keep reference stable entries at `processing_status: source_ready` — no `godot_artifact` written, no worker handoff
- [x] Fail closed when the reference file is missing, the entry is unregistered, identity/tag mismatches, or no root-index pointer exists
- [x] Leave runtime/non-reference row rules unchanged — still require `ready` (L0-L4) before becoming `generated`
- [x] Update `gm-asset` completion prose, asset planner/runtime pipeline docs, and `docs/update/next.md`

## Testing

- [x] New or updated tests pass (`pytest`)
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable — no performance-sensitive change.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Not applicable — no migration script added or modified.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR

## Verification

- `python -m pytest`
- `python -m ruff check .`
