### PR TITLE
Add deterministic asset runtime resolver for ASSETS.md manifest entries

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,6 +17,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
+- Added a fail-closed `asset_runtime_resolver.py` that converts a canonical ASSETS.md `manifest_entry` or stable-entry pointer into the minimal ready worker runtime snapshot.
 - v1 generated-asset stable entry and root index schema: `tools/asset_stable_entry.py` (per-asset `production_family` / `source_layout` / minimal `godot_artifact` / `processing_status` entry written to `.godotmaker/asset-generation/entries/<tag>/<asset_id>.json`) and `tools/asset_generation_index.py` (pointer-only root index). Old `runtime_artifact` schema fails closed and must be regenerated through `/gm-asset`; no migration or compatibility read is provided.
 - Stable generated-asset output-path contract: deterministic `assets/generated/<production_family>/<asset_id>/` resolver (`tools/asset_output_path.py`), fail-closed stable-entry path validation, and a reusable `assert_within_output_dir` write guard.
 - Added a standalone asset-skill invocation and result contract under `skills/assets/_shared/` with declarative JSON schemas, valid samples, a dependency-free checker, and fail-closed tests (#98).

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,7 +17,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
-- Added a fail-closed `asset_runtime_resolver.py` that converts a canonical ASSETS.md `manifest_entry` or stable-entry pointer into the minimal ready worker runtime snapshot.
+- Added a fail-closed `asset_runtime_resolver.py` that converts a registered ASSETS.md `manifest_entry` into the minimal ready worker runtime snapshot (#106).
 - v1 generated-asset stable entry and root index schema: `tools/asset_stable_entry.py` (per-asset `production_family` / `source_layout` / minimal `godot_artifact` / `processing_status` entry written to `.godotmaker/asset-generation/entries/<tag>/<asset_id>.json`) and `tools/asset_generation_index.py` (pointer-only root index). Old `runtime_artifact` schema fails closed and must be regenerated through `/gm-asset`; no migration or compatibility read is provided.
 - Stable generated-asset output-path contract: deterministic `assets/generated/<production_family>/<asset_id>/` resolver (`tools/asset_output_path.py`), fail-closed stable-entry path validation, and a reusable `assert_within_output_dir` write guard.
 - Added a standalone asset-skill invocation and result contract under `skills/assets/_shared/` with declarative JSON schemas, valid samples, a dependency-free checker, and fail-closed tests (#98).

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -18,6 +18,7 @@ Primary pipeline tools:
 10. `asset_stable_entry.py`
 11. `asset_generation_index.py`
 12. `asset_assets_md_update.py`
+13. `asset_runtime_resolver.py`
 
 ## asset_source_generate.py
 
@@ -277,6 +278,24 @@ python tools/asset_assets_md_update.py \
   --entry-file .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
 ```
 
+## asset_runtime_resolver.py
+
+`asset_runtime_resolver.py` resolves one registered, generated ASSETS.md row
+into the minimal runtime snapshot: `asset_id`, `production_family`,
+`source_layout`, and `godot_artifact`. It requires the ASSETS.md pointer and
+the generated root index to agree, then validates the ready stable entry and all
+referenced files. Reference-only entries never produce a worker runtime
+snapshot.
+
+Manual entry points:
+
+```bash
+python tools/asset_runtime_resolver.py --project-root . \
+  --tag <tag> --asset-id <asset_id>
+python tools/asset_runtime_resolver.py --project-root . \
+  --manifest-entry .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
+```
+
 ## Calling these by hand
 
 You usually do not need to run these scripts directly. `/gm-asset` orchestrates
@@ -292,6 +311,7 @@ Manual use cases:
 6. Select one extracted candidate into a runtime asset path.
 7. Print or validate one asset's stable output directory.
 8. Validate and register one stable entry and its root-index pointer.
+9. Resolve one registered ASSETS.md entry into its minimal runtime snapshot.
 
 If you want to update visual targets used by `/gm-evaluate`, re-run
 `/gm-asset` rather than editing generated images directly.

--- a/docs/wiki/07-contributing/codebase-guide.md
+++ b/docs/wiki/07-contributing/codebase-guide.md
@@ -157,6 +157,7 @@ Python CLI scripts that contributors and users run directly.
 | `asset_stable_entry.py` | Validate and serialize one v1 generated-asset stable entry |
 | `asset_generation_index.py` | Validate and upsert the pointer-only generated-asset root index |
 | `asset_assets_md_update.py` | Update ASSETS.md rows from registered stable entries |
+| `asset_runtime_resolver.py` | Resolve one registered ASSETS.md pointer into a minimal ready runtime snapshot |
 | `migrate.py` | Apply pending migrations to a target on any non-MAJOR upgrade; also scaffolds new ones via `--new <slug>` |
 
 ### How publish.py wires everything together

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -16,6 +16,7 @@ GodotMaker 通过几个小型 Python 辅助脚本生成和处理 2D 美术资源
 10. `asset_stable_entry.py`
 11. `asset_generation_index.py`
 12. `asset_assets_md_update.py`
+13. `asset_runtime_resolver.py`
 
 ## asset_source_generate.py
 
@@ -223,6 +224,19 @@ python tools/asset_generation_index.py --project-root . --check-entries --check-
 ```bash
 python tools/asset_assets_md_update.py \
   --entry-file .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
+```
+
+## asset_runtime_resolver.py
+
+`asset_runtime_resolver.py` 将一个已注册且状态为 `generated` 的 ASSETS.md 行解析为最小 runtime snapshot：`asset_id`、`production_family`、`source_layout` 和 `godot_artifact`。它要求 ASSETS.md 指针与 generated root index 一致，并校验 ready stable entry 及其引用文件；reference-only entry 不会产生 worker runtime snapshot。
+
+手动入口：
+
+```bash
+python tools/asset_runtime_resolver.py --project-root . \
+  --tag <tag> --asset-id <asset_id>
+python tools/asset_runtime_resolver.py --project-root . \
+  --manifest-entry .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
 ```
 
 ## 手动调用这些脚本

--- a/docs/zh/wiki/07-contributing/codebase-guide.md
+++ b/docs/zh/wiki/07-contributing/codebase-guide.md
@@ -156,6 +156,7 @@ manifest 的 schema、添加/移除流程和调试技巧见 `docs/contributing/s
 | `asset_stable_entry.py` | 校验并序列化一个 v1 generated-asset stable entry |
 | `asset_generation_index.py` | 校验并 upsert pointer-only 的 generated-asset root index |
 | `asset_assets_md_update.py` | 根据已注册的 stable entry 更新 ASSETS.md 行 |
+| `asset_runtime_resolver.py` | 将已注册的 ASSETS.md 指针解析为最小 ready runtime snapshot |
 | `migrate.py` | 在任何非 MAJOR 升级时把未应用的迁移脚本应用到目标项目；也通过 `--new <slug>` 生成新脚本模板 |
 
 ### publish.py 如何串联一切

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -172,8 +172,13 @@ straight from the root index.
 
 ## Runtime Snapshot Resolution
 
-Managers do not copy fields from a stable entry into a worker brief by hand.
-Resolve either the current-tag ASSETS.md row:
+The resolver is the deterministic reader for one registered runtime asset. It
+does not by itself change the published worker-dispatch brief format; that
+integration remains a follow-up for WOR-233 because this v1 entry exposes only
+the four-field runtime contract, while the existing brief also requires target
+size, support metadata, frame data, and cwd-relative paths.
+
+Resolve the current-tag ASSETS.md row:
 
 ```bash
 python tools/asset_runtime_resolver.py \
@@ -183,7 +188,7 @@ python tools/asset_runtime_resolver.py \
   --asset-id <asset_id>
 ```
 
-or its canonical pointer directly:
+or provide its canonical pointer directly:
 
 ```bash
 python tools/asset_runtime_resolver.py \
@@ -191,11 +196,12 @@ python tools/asset_runtime_resolver.py \
   --manifest-entry .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
 ```
 
-The resolver verifies the canonical pointer, entry identity, v1 schema, `ready`
-status, and source/artifact file existence. It emits only `asset_id`,
-`production_family`, `source_layout`, and `godot_artifact`, in that order.
-Reference-only entries are valid manifest records but never produce a worker
-runtime snapshot.
+Both modes require the project-root ASSETS.md row to be `generated` and point to
+the same entry. The resolver also verifies the canonical pointer, root-index
+registration, entry identity, v1 schema, `ready` status, and source/artifact
+file existence. It emits only `asset_id`, `production_family`, `source_layout`,
+and `godot_artifact`, in that order. Reference-only entries are valid manifest
+records but never produce a worker runtime snapshot.
 
 ## Registration Commands
 

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -170,6 +170,33 @@ identity and one `entry_path` per asset and never duplicates an entry body:
 Consumers resolve `entry_path` and read the entry. Nothing reads runtime data
 straight from the root index.
 
+## Runtime Snapshot Resolution
+
+Managers do not copy fields from a stable entry into a worker brief by hand.
+Resolve either the current-tag ASSETS.md row:
+
+```bash
+python tools/asset_runtime_resolver.py \
+  --project-root . \
+  --assets-md ASSETS.md \
+  --tag <tag> \
+  --asset-id <asset_id>
+```
+
+or its canonical pointer directly:
+
+```bash
+python tools/asset_runtime_resolver.py \
+  --project-root . \
+  --manifest-entry .godotmaker/asset-generation/entries/<tag>/<asset_id>.json
+```
+
+The resolver verifies the canonical pointer, entry identity, v1 schema, `ready`
+status, and source/artifact file existence. It emits only `asset_id`,
+`production_family`, `source_layout`, and `godot_artifact`, in that order.
+Reference-only entries are valid manifest records but never produce a worker
+runtime snapshot.
+
 ## Registration Commands
 
 Build the entry draft with the deterministic builder for the production path.

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -553,6 +553,22 @@ def test_gm_asset_registers_through_the_stable_entry_tools_only():
     assert "Do not hand-edit" in skill
 
 
+def test_runtime_resolver_is_documented_as_a_registered_assets_reader():
+    runtime = _read("skills/core/gm-asset/references/asset-runtime-pipeline.md")
+    tools = _read("docs/wiki/05-tools/asset-tools.md")
+    tools_zh = _read("docs/zh/wiki/05-tools/asset-tools.md")
+    guide = _read("docs/wiki/07-contributing/codebase-guide.md")
+    guide_zh = _read("docs/zh/wiki/07-contributing/codebase-guide.md")
+
+    assert "## Runtime Snapshot Resolution" in runtime
+    assert "tools/asset_runtime_resolver.py" in runtime
+    assert "root-index" in runtime
+    assert "registration" in runtime
+    assert "Both modes require" in runtime
+    for doc in (tools, tools_zh, guide, guide_zh):
+        assert "asset_runtime_resolver.py" in doc
+
+
 def test_region_atlas_single_region_contract():
     worker = _read("agents/worker.md")
     worker_dispatch = _read("skills/core/_shared/worker-dispatch.md")

--- a/tests/tools/test_asset_runtime_resolver.py
+++ b/tests/tools/test_asset_runtime_resolver.py
@@ -1,0 +1,233 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_runtime_resolver import (  # noqa: E402
+    AssetRuntimeResolverError,
+    resolve_assets_row,
+    resolve_manifest_entry,
+)
+from asset_stable_entry import entry_relative_path, stable_output_dir  # noqa: E402
+
+TAG = "v0.1.0"
+ASSET_ID = "player_idle"
+FAMILY = "character-bundle"
+
+
+def source_relative(asset_id: str = ASSET_ID, family: str = FAMILY) -> str:
+    return f"{stable_output_dir(family, asset_id)}/{asset_id}_source.png"
+
+
+def artifact_relative(asset_id: str = ASSET_ID, family: str = FAMILY) -> str:
+    return f"{stable_output_dir(family, asset_id)}/{asset_id}.tres"
+
+
+def make_entry(**overrides):
+    entry = {
+        "version": 1,
+        "asset_id": ASSET_ID,
+        "tag": TAG,
+        "production_family": FAMILY,
+        "source_layout": {"type": "grid_sheet", "path": f"res://{source_relative()}"},
+        "godot_artifact": {"type": "SpriteFrames", "path": f"res://{artifact_relative()}"},
+        "processing_status": "ready",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def write_entry(project_root: Path, entry: dict) -> str:
+    pointer = entry_relative_path(entry["tag"], entry["asset_id"])
+    path = project_root / pointer
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(entry), encoding="utf-8")
+    return pointer
+
+
+def touch(project_root: Path, relative: str) -> None:
+    path = project_root / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"asset")
+
+
+def write_ready_entry(project_root: Path, **overrides) -> tuple[dict, str]:
+    entry = make_entry(**overrides)
+    touch(project_root, entry["source_layout"]["path"].removeprefix("res://"))
+    artifact = entry.get("godot_artifact")
+    if artifact is not None:
+        touch(project_root, artifact["path"].removeprefix("res://"))
+    return entry, write_entry(project_root, entry)
+
+
+def write_assets_md(project_root: Path, pointer: str, status: str = "generated") -> Path:
+    path = project_root / "ASSETS.md"
+    path.write_text(
+        "| ID | Tag | Name | Type | Size | Generation Params | Path | Status |\n"
+        "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
+        f"| 1 | {TAG} | {ASSET_ID} | sprite | 128x128 | prompt=hero; manifest_entry={pointer} | assets/generated/player.tres | {status} |\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def expected_snapshot() -> dict:
+    return {
+        "asset_id": ASSET_ID,
+        "production_family": FAMILY,
+        "source_layout": {"type": "grid_sheet", "path": f"res://{source_relative()}"},
+        "godot_artifact": {"type": "SpriteFrames", "path": f"res://{artifact_relative()}"},
+    }
+
+
+def test_resolves_canonical_manifest_entry_to_minimal_stable_snapshot(tmp_path):
+    _, pointer = write_ready_entry(tmp_path)
+
+    assert resolve_manifest_entry(pointer, project_root=tmp_path) == expected_snapshot()
+    assert list(resolve_manifest_entry(pointer, project_root=tmp_path)) == [
+        "asset_id",
+        "production_family",
+        "source_layout",
+        "godot_artifact",
+    ]
+
+
+def test_resolves_current_tag_assets_row_and_checks_pointer_identity(tmp_path):
+    _, pointer = write_ready_entry(tmp_path)
+    assets_md = write_assets_md(tmp_path, pointer)
+
+    assert resolve_assets_row(
+        assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path
+    ) == expected_snapshot()
+
+
+@pytest.mark.parametrize("status", ["pending", "source_ready", "compiled", "failed"])
+def test_rejects_non_ready_entries(tmp_path, status):
+    entry = make_entry(processing_status=status)
+    if status in {"pending", "source_ready", "failed"}:
+        entry.pop("godot_artifact")
+    _, pointer = write_ready_entry(tmp_path, **entry)
+
+    with pytest.raises(AssetRuntimeResolverError, match=f"processing_status is {status}"):
+        resolve_manifest_entry(pointer, project_root=tmp_path)
+
+
+def test_reference_entry_cannot_appear_as_a_worker_runtime_asset(tmp_path):
+    entry = {
+        "version": 1,
+        "asset_id": "scene_main",
+        "tag": TAG,
+        "production_family": "screen-reference",
+        "source_layout": {"type": "reference", "path": "res://references/scene_main.png"},
+        "processing_status": "ready",
+    }
+    touch(tmp_path, "references/scene_main.png")
+    pointer = write_entry(tmp_path, entry)
+
+    with pytest.raises(AssetRuntimeResolverError, match="reference-only"):
+        resolve_manifest_entry(pointer, project_root=tmp_path)
+
+
+def test_rejects_legacy_entry_before_returning_a_snapshot(tmp_path):
+    entry = make_entry(runtime_artifact="grid_sheet")
+    _, pointer = write_ready_entry(tmp_path, **entry)
+
+    with pytest.raises(AssetRuntimeResolverError, match="Legacy runtime_artifact schema"):
+        resolve_manifest_entry(pointer, project_root=tmp_path)
+
+
+def test_rejects_missing_entry_and_runtime_files(tmp_path):
+    with pytest.raises(AssetRuntimeResolverError, match="Entry file not found"):
+        resolve_manifest_entry(entry_relative_path(TAG, ASSET_ID), project_root=tmp_path)
+
+    entry, pointer = write_ready_entry(tmp_path)
+    (tmp_path / entry["source_layout"]["path"].removeprefix("res://")).unlink()
+    with pytest.raises(AssetRuntimeResolverError, match="source_layout.path not found"):
+        resolve_manifest_entry(pointer, project_root=tmp_path)
+
+    entry, pointer = write_ready_entry(tmp_path)
+    (tmp_path / entry["godot_artifact"]["path"].removeprefix("res://")).unlink()
+    with pytest.raises(AssetRuntimeResolverError, match="godot_artifact.path not found"):
+        resolve_manifest_entry(pointer, project_root=tmp_path)
+
+
+@pytest.mark.parametrize(
+    "pointer",
+    [
+        "../entry.json",
+        ".godotmaker/asset-generation/entries/v0.1.0/../player_idle.json",
+        ".godotmaker\\asset-generation\\entries\\v0.1.0\\player_idle.json",
+        "C:/outside/entry.json",
+    ],
+)
+def test_rejects_out_of_bounds_manifest_entry_paths(tmp_path, pointer):
+    with pytest.raises(AssetRuntimeResolverError):
+        resolve_manifest_entry(pointer, project_root=tmp_path)
+
+
+def test_rejects_noncanonical_pointer_and_assets_identity_mismatch(tmp_path):
+    _, pointer = write_ready_entry(tmp_path)
+    alternate = ".godotmaker/asset-generation/entries/v0.1.0/alias.json"
+    alias = tmp_path / alternate
+    alias.parent.mkdir(parents=True, exist_ok=True)
+    alias.write_text((tmp_path / pointer).read_text(encoding="utf-8"), encoding="utf-8")
+    with pytest.raises(AssetRuntimeResolverError, match="canonical entry path"):
+        resolve_manifest_entry(alternate, project_root=tmp_path)
+
+    other_entry = make_entry(
+        asset_id="other_asset",
+        source_layout={
+            "type": "grid_sheet",
+            "path": f"res://{source_relative('other_asset')}",
+        },
+        godot_artifact={
+            "type": "SpriteFrames",
+            "path": f"res://{artifact_relative('other_asset')}",
+        },
+    )
+    _, other_pointer = write_ready_entry(tmp_path, **other_entry)
+    assets_md = write_assets_md(tmp_path, other_pointer)
+    with pytest.raises(AssetRuntimeResolverError, match="does not match ASSETS.md asset_id"):
+        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
+
+
+def test_rejects_missing_or_unready_assets_row(tmp_path):
+    _, pointer = write_ready_entry(tmp_path)
+    assets_md = write_assets_md(tmp_path, pointer, status="MISSING")
+
+    with pytest.raises(AssetRuntimeResolverError, match="expected 'generated'"):
+        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
+
+    assets_md.write_text(
+        assets_md.read_text(encoding="utf-8")
+        .replace("manifest_entry=", "entry=")
+        .replace("| MISSING |", "| generated |"),
+        encoding="utf-8",
+    )
+    with pytest.raises(AssetRuntimeResolverError, match="missing manifest_entry"):
+        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
+
+
+def test_cli_outputs_only_the_snapshot_json(tmp_path):
+    _, pointer = write_ready_entry(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_runtime_resolver.py"),
+            "--project-root",
+            str(tmp_path),
+            "--manifest-entry",
+            pointer,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert json.loads(result.stdout) == expected_snapshot()

--- a/tests/tools/test_asset_runtime_resolver.py
+++ b/tests/tools/test_asset_runtime_resolver.py
@@ -211,6 +211,18 @@ def test_rejects_unregistered_or_missing_runtime_files(tmp_path):
         resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
 
 
+def test_ready_entry_resolves_when_a_registered_pending_sibling_has_no_files(tmp_path):
+    ready, pointer = register(tmp_path, make_entry(), assets=True)
+    pending = make_entry(asset_id="boss", processing_status="pending")
+    pending.pop("godot_artifact")
+    write_entry(tmp_path, pending)
+    write_index(tmp_path, [ready, pending])
+
+    assert resolve_manifest_entry(
+        pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md"
+    ) == expected_snapshot()
+
+
 @pytest.mark.parametrize(
     ("pointer", "message"),
     [

--- a/tests/tools/test_asset_runtime_resolver.py
+++ b/tests/tools/test_asset_runtime_resolver.py
@@ -10,6 +10,7 @@ sys.path.insert(0, str(TOOLS_DIR))
 
 from asset_runtime_resolver import (  # noqa: E402
     AssetRuntimeResolverError,
+    ROOT_INDEX_PATH,
     resolve_assets_row,
     resolve_manifest_entry,
 )
@@ -28,18 +29,35 @@ def artifact_relative(asset_id: str = ASSET_ID, family: str = FAMILY) -> str:
     return f"{stable_output_dir(family, asset_id)}/{asset_id}.tres"
 
 
-def make_entry(**overrides):
+def make_entry(asset_id: str = ASSET_ID, tag: str = TAG, **overrides) -> dict:
     entry = {
         "version": 1,
-        "asset_id": ASSET_ID,
-        "tag": TAG,
+        "asset_id": asset_id,
+        "tag": tag,
         "production_family": FAMILY,
-        "source_layout": {"type": "grid_sheet", "path": f"res://{source_relative()}"},
-        "godot_artifact": {"type": "SpriteFrames", "path": f"res://{artifact_relative()}"},
+        "source_layout": {
+            "type": "grid_sheet",
+            "path": f"res://{source_relative(asset_id)}",
+        },
+        "godot_artifact": {
+            "type": "SpriteFrames",
+            "path": f"res://{artifact_relative(asset_id)}",
+        },
         "processing_status": "ready",
     }
     entry.update(overrides)
     return entry
+
+
+def touch_declared_files(project_root: Path, entry: dict) -> None:
+    paths = [entry["source_layout"]["path"]]
+    artifact = entry.get("godot_artifact")
+    if artifact is not None:
+        paths.append(artifact["path"])
+    for res_path in paths:
+        target = project_root / res_path.removeprefix("res://")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"asset")
 
 
 def write_entry(project_root: Path, entry: dict) -> str:
@@ -50,30 +68,49 @@ def write_entry(project_root: Path, entry: dict) -> str:
     return pointer
 
 
-def touch(project_root: Path, relative: str) -> None:
-    path = project_root / relative
+def write_index(project_root: Path, entries: list[dict]) -> None:
+    path = project_root / ROOT_INDEX_PATH
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_bytes(b"asset")
-
-
-def write_ready_entry(project_root: Path, **overrides) -> tuple[dict, str]:
-    entry = make_entry(**overrides)
-    touch(project_root, entry["source_layout"]["path"].removeprefix("res://"))
-    artifact = entry.get("godot_artifact")
-    if artifact is not None:
-        touch(project_root, artifact["path"].removeprefix("res://"))
-    return entry, write_entry(project_root, entry)
-
-
-def write_assets_md(project_root: Path, pointer: str, status: str = "generated") -> Path:
-    path = project_root / "ASSETS.md"
     path.write_text(
-        "| ID | Tag | Name | Type | Size | Generation Params | Path | Status |\n"
-        "| --- | --- | --- | --- | --- | --- | --- | --- |\n"
-        f"| 1 | {TAG} | {ASSET_ID} | sprite | 128x128 | prompt=hero; manifest_entry={pointer} | assets/generated/player.tres | {status} |\n",
+        json.dumps(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "asset_id": entry["asset_id"],
+                        "tag": entry["tag"],
+                        "entry_path": entry_relative_path(entry["tag"], entry["asset_id"]),
+                    }
+                    for entry in entries
+                ],
+            }
+        ),
         encoding="utf-8",
     )
+
+
+def write_assets_md(project_root: Path, rows: list[tuple[str, str, str, str, str]]) -> Path:
+    path = project_root / "ASSETS.md"
+    body = [
+        "| ID | Tag | Name | Type | Size | Generation Params | Path | Status |\n",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |\n",
+    ]
+    for index, (tag, asset_id, pointer, status, params) in enumerate(rows, start=1):
+        generation_params = params or f"prompt=hero; manifest_entry={pointer}"
+        body.append(
+            f"| {index} | {tag} | {asset_id} | sprite | 128x128 | {generation_params} | assets/generated/{asset_id}.tres | {status} |\n"
+        )
+    path.write_text("".join(body), encoding="utf-8")
     return path
+
+
+def register(project_root: Path, entry: dict, *, assets: bool = False) -> tuple[dict, str]:
+    touch_declared_files(project_root, entry)
+    pointer = write_entry(project_root, entry)
+    write_index(project_root, [entry])
+    if assets:
+        write_assets_md(project_root, [(entry["tag"], entry["asset_id"], pointer, "generated", "")])
+    return entry, pointer
 
 
 def expected_snapshot() -> dict:
@@ -85,11 +122,14 @@ def expected_snapshot() -> dict:
     }
 
 
-def test_resolves_canonical_manifest_entry_to_minimal_stable_snapshot(tmp_path):
-    _, pointer = write_ready_entry(tmp_path)
+def test_resolves_registered_canonical_entry_to_minimal_stable_snapshot(tmp_path):
+    _, pointer = register(tmp_path, make_entry(), assets=True)
 
-    assert resolve_manifest_entry(pointer, project_root=tmp_path) == expected_snapshot()
-    assert list(resolve_manifest_entry(pointer, project_root=tmp_path)) == [
+    snapshot = resolve_manifest_entry(
+        pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md"
+    )
+    assert snapshot == expected_snapshot()
+    assert list(snapshot) == [
         "asset_id",
         "production_family",
         "source_layout",
@@ -97,124 +137,12 @@ def test_resolves_canonical_manifest_entry_to_minimal_stable_snapshot(tmp_path):
     ]
 
 
-def test_resolves_current_tag_assets_row_and_checks_pointer_identity(tmp_path):
-    _, pointer = write_ready_entry(tmp_path)
-    assets_md = write_assets_md(tmp_path, pointer)
+def test_resolves_assets_row_and_direct_cli_with_the_same_handoff_gates(tmp_path):
+    _, pointer = register(tmp_path, make_entry(), assets=True)
 
     assert resolve_assets_row(
-        assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path
+        tmp_path / "ASSETS.md", tag=TAG, asset_id=ASSET_ID, project_root=tmp_path
     ) == expected_snapshot()
-
-
-@pytest.mark.parametrize("status", ["pending", "source_ready", "compiled", "failed"])
-def test_rejects_non_ready_entries(tmp_path, status):
-    entry = make_entry(processing_status=status)
-    if status in {"pending", "source_ready", "failed"}:
-        entry.pop("godot_artifact")
-    _, pointer = write_ready_entry(tmp_path, **entry)
-
-    with pytest.raises(AssetRuntimeResolverError, match=f"processing_status is {status}"):
-        resolve_manifest_entry(pointer, project_root=tmp_path)
-
-
-def test_reference_entry_cannot_appear_as_a_worker_runtime_asset(tmp_path):
-    entry = {
-        "version": 1,
-        "asset_id": "scene_main",
-        "tag": TAG,
-        "production_family": "screen-reference",
-        "source_layout": {"type": "reference", "path": "res://references/scene_main.png"},
-        "processing_status": "ready",
-    }
-    touch(tmp_path, "references/scene_main.png")
-    pointer = write_entry(tmp_path, entry)
-
-    with pytest.raises(AssetRuntimeResolverError, match="reference-only"):
-        resolve_manifest_entry(pointer, project_root=tmp_path)
-
-
-def test_rejects_legacy_entry_before_returning_a_snapshot(tmp_path):
-    entry = make_entry(runtime_artifact="grid_sheet")
-    _, pointer = write_ready_entry(tmp_path, **entry)
-
-    with pytest.raises(AssetRuntimeResolverError, match="Legacy runtime_artifact schema"):
-        resolve_manifest_entry(pointer, project_root=tmp_path)
-
-
-def test_rejects_missing_entry_and_runtime_files(tmp_path):
-    with pytest.raises(AssetRuntimeResolverError, match="Entry file not found"):
-        resolve_manifest_entry(entry_relative_path(TAG, ASSET_ID), project_root=tmp_path)
-
-    entry, pointer = write_ready_entry(tmp_path)
-    (tmp_path / entry["source_layout"]["path"].removeprefix("res://")).unlink()
-    with pytest.raises(AssetRuntimeResolverError, match="source_layout.path not found"):
-        resolve_manifest_entry(pointer, project_root=tmp_path)
-
-    entry, pointer = write_ready_entry(tmp_path)
-    (tmp_path / entry["godot_artifact"]["path"].removeprefix("res://")).unlink()
-    with pytest.raises(AssetRuntimeResolverError, match="godot_artifact.path not found"):
-        resolve_manifest_entry(pointer, project_root=tmp_path)
-
-
-@pytest.mark.parametrize(
-    "pointer",
-    [
-        "../entry.json",
-        ".godotmaker/asset-generation/entries/v0.1.0/../player_idle.json",
-        ".godotmaker\\asset-generation\\entries\\v0.1.0\\player_idle.json",
-        "C:/outside/entry.json",
-    ],
-)
-def test_rejects_out_of_bounds_manifest_entry_paths(tmp_path, pointer):
-    with pytest.raises(AssetRuntimeResolverError):
-        resolve_manifest_entry(pointer, project_root=tmp_path)
-
-
-def test_rejects_noncanonical_pointer_and_assets_identity_mismatch(tmp_path):
-    _, pointer = write_ready_entry(tmp_path)
-    alternate = ".godotmaker/asset-generation/entries/v0.1.0/alias.json"
-    alias = tmp_path / alternate
-    alias.parent.mkdir(parents=True, exist_ok=True)
-    alias.write_text((tmp_path / pointer).read_text(encoding="utf-8"), encoding="utf-8")
-    with pytest.raises(AssetRuntimeResolverError, match="canonical entry path"):
-        resolve_manifest_entry(alternate, project_root=tmp_path)
-
-    other_entry = make_entry(
-        asset_id="other_asset",
-        source_layout={
-            "type": "grid_sheet",
-            "path": f"res://{source_relative('other_asset')}",
-        },
-        godot_artifact={
-            "type": "SpriteFrames",
-            "path": f"res://{artifact_relative('other_asset')}",
-        },
-    )
-    _, other_pointer = write_ready_entry(tmp_path, **other_entry)
-    assets_md = write_assets_md(tmp_path, other_pointer)
-    with pytest.raises(AssetRuntimeResolverError, match="does not match ASSETS.md asset_id"):
-        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
-
-
-def test_rejects_missing_or_unready_assets_row(tmp_path):
-    _, pointer = write_ready_entry(tmp_path)
-    assets_md = write_assets_md(tmp_path, pointer, status="MISSING")
-
-    with pytest.raises(AssetRuntimeResolverError, match="expected 'generated'"):
-        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
-
-    assets_md.write_text(
-        assets_md.read_text(encoding="utf-8")
-        .replace("manifest_entry=", "entry=")
-        .replace("| MISSING |", "| generated |"),
-        encoding="utf-8",
-    )
-    with pytest.raises(AssetRuntimeResolverError, match="missing manifest_entry"):
-        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
-
-
-def test_cli_outputs_only_the_snapshot_json(tmp_path):
-    _, pointer = write_ready_entry(tmp_path)
     result = subprocess.run(
         [
             sys.executable,
@@ -228,6 +156,171 @@ def test_cli_outputs_only_the_snapshot_json(tmp_path):
         text=True,
         check=False,
     )
-
     assert result.returncode == 0, result.stdout + result.stderr
     assert json.loads(result.stdout) == expected_snapshot()
+
+
+@pytest.mark.parametrize("status", ["pending", "source_ready", "compiled", "failed"])
+def test_rejects_non_ready_entries_even_when_registered(tmp_path, status):
+    entry = make_entry(processing_status=status)
+    if status in {"pending", "source_ready", "failed"}:
+        entry.pop("godot_artifact")
+    _, pointer = register(tmp_path, entry, assets=True)
+
+    with pytest.raises(AssetRuntimeResolverError, match=f"processing_status is {status}"):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
+
+
+def test_reference_entry_cannot_appear_as_a_worker_runtime_asset(tmp_path):
+    entry = {
+        "version": 1,
+        "asset_id": "scene_main",
+        "tag": TAG,
+        "production_family": "screen-reference",
+        "source_layout": {"type": "reference", "path": "res://references/scene_main.png"},
+        "processing_status": "ready",
+    }
+    _, pointer = register(tmp_path, entry, assets=True)
+
+    with pytest.raises(AssetRuntimeResolverError, match="reference-only"):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
+
+
+def test_rejects_legacy_entry_before_returning_a_snapshot(tmp_path):
+    entry = make_entry(runtime_artifact="grid_sheet")
+    touch_declared_files(tmp_path, entry)
+    pointer = write_entry(tmp_path, entry)
+    write_assets_md(tmp_path, [(TAG, ASSET_ID, pointer, "generated", "")])
+
+    with pytest.raises(AssetRuntimeResolverError, match="Legacy runtime_artifact schema"):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
+
+
+def test_rejects_unregistered_or_missing_runtime_files(tmp_path):
+    entry = make_entry()
+    touch_declared_files(tmp_path, entry)
+    pointer = write_entry(tmp_path, entry)
+    write_index(tmp_path, [])
+    write_assets_md(tmp_path, [(TAG, ASSET_ID, pointer, "generated", "")])
+    with pytest.raises(AssetRuntimeResolverError, match="not registered"):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
+
+    entry, pointer = register(tmp_path, make_entry(), assets=True)
+    (tmp_path / entry["source_layout"]["path"].removeprefix("res://")).unlink()
+    with pytest.raises(AssetRuntimeResolverError, match="source_layout.path not found"):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
+
+
+@pytest.mark.parametrize(
+    ("pointer", "message"),
+    [
+        ("../entry.json", "must not contain"),
+        (".godotmaker/asset-generation/entries/v0.1.0/../player_idle.json", "must not contain"),
+        (".godotmaker\\asset-generation\\entries\\v0.1.0\\player_idle.json", "forward slashes"),
+        ("C:/outside/entry.json", "canonical entries"),
+        ("some/other.json", "canonical entries"),
+    ],
+)
+def test_rejects_noncanonical_or_out_of_bounds_manifest_entry_paths(tmp_path, pointer, message):
+    with pytest.raises(AssetRuntimeResolverError, match=message):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
+
+
+def test_rejects_tag_and_asset_identity_mismatches(tmp_path):
+    _, pointer = register(tmp_path, make_entry(), assets=True)
+
+    with pytest.raises(AssetRuntimeResolverError, match="does not match ASSETS.md tag"):
+        resolve_manifest_entry(
+            pointer,
+            project_root=tmp_path,
+            assets_md=tmp_path / "ASSETS.md",
+            expected_tag="v9.9.9",
+        )
+    with pytest.raises(AssetRuntimeResolverError, match="does not match ASSETS.md asset_id"):
+        resolve_manifest_entry(
+            pointer,
+            project_root=tmp_path,
+            assets_md=tmp_path / "ASSETS.md",
+            expected_asset_id="other",
+        )
+
+
+def test_assets_row_rejects_missing_unready_duplicate_and_ambiguous_pointers(tmp_path):
+    _, pointer = register(tmp_path, make_entry())
+    assets_md = write_assets_md(tmp_path, [(TAG, ASSET_ID, pointer, "MISSING", "")])
+    with pytest.raises(AssetRuntimeResolverError, match="expected 'generated'"):
+        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
+
+    assets_md = write_assets_md(tmp_path, [(TAG, ASSET_ID, pointer, "generated", "prompt=x")])
+    with pytest.raises(AssetRuntimeResolverError, match="missing manifest_entry"):
+        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
+
+    assets_md = write_assets_md(
+        tmp_path,
+        [(TAG, ASSET_ID, pointer, "generated", "manifest_entry=; prompt=x")],
+    )
+    with pytest.raises(AssetRuntimeResolverError, match="must not be empty"):
+        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
+
+    assets_md = write_assets_md(
+        tmp_path,
+        [(TAG, ASSET_ID, pointer, "generated", f"manifest_entry={pointer}; manifest_entry={pointer}")],
+    )
+    with pytest.raises(AssetRuntimeResolverError, match="exactly one manifest_entry"):
+        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
+
+    assets_md = write_assets_md(
+        tmp_path,
+        [(TAG, ASSET_ID, pointer, "generated", ""), (TAG, ASSET_ID, pointer, "generated", "")],
+    )
+    with pytest.raises(AssetRuntimeResolverError, match="multiple rows"):
+        resolve_assets_row(assets_md, tag=TAG, asset_id=ASSET_ID, project_root=tmp_path)
+
+
+def test_direct_mode_requires_the_matching_generated_assets_row(tmp_path):
+    _, pointer = register(tmp_path, make_entry(), assets=True)
+    assets_md = tmp_path / "ASSETS.md"
+    assets_md.write_text(assets_md.read_text(encoding="utf-8").replace("generated", "MISSING"), encoding="utf-8")
+    with pytest.raises(AssetRuntimeResolverError, match="expected 'generated'"):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=assets_md)
+
+    assets_md.unlink()
+    with pytest.raises(AssetRuntimeResolverError, match="Cannot read ASSETS.md"):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=assets_md)
+
+
+def test_rejects_assets_file_from_another_project_root(tmp_path, tmp_path_factory):
+    _, pointer = register(tmp_path, make_entry())
+    other_root = tmp_path_factory.mktemp("other-project")
+    other_assets = write_assets_md(other_root, [(TAG, ASSET_ID, pointer, "generated", "")])
+
+    with pytest.raises(AssetRuntimeResolverError, match="project root"):
+        resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=other_assets)
+
+
+@pytest.mark.parametrize(
+    ("args", "message"),
+    [
+        (["--manifest-entry", ""], "manifest_entry must be a non-empty path"),
+        (["--tag", TAG, "--asset-id", ASSET_ID], "Cannot read ASSETS.md"),
+    ],
+)
+def test_cli_failures_use_machine_readable_json(tmp_path, args, message):
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_runtime_resolver.py"),
+            "--project-root",
+            str(tmp_path),
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stderr == ""
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is False
+    assert message in payload["error"]

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -210,6 +210,15 @@ def test_write_entry_rejects_unsafe_tag(tmp_path):
     assert not (tmp_path / ".godotmaker/asset-generation/entries/player.json").exists()
 
 
+@pytest.mark.parametrize("field", ["asset_id", "tag"])
+def test_stable_identifiers_reject_generation_param_delimiters(field):
+    entry = valid_entry()
+    entry[field] = "unsafe;identifier"
+
+    with pytest.raises(StableEntryError, match="reserved characters"):
+        validate_entry(entry)
+
+
 @pytest.mark.parametrize("version", [True, False, 1.0, "1", None, 2])
 def test_version_must_be_strict_integer(version):
     entry = valid_entry(version=version)

--- a/tools/asset_assets_md_update.py
+++ b/tools/asset_assets_md_update.py
@@ -30,6 +30,12 @@ from asset_stable_entry import (
 
 # The only readiness state that means "a worker can load this asset now".
 PROMOTABLE_STATUS = "ready"
+GENERATED_ROW_STATUS = "generated"
+ASSETS_MD_MIN_CELLS = 8
+ASSETS_MD_TAG_COLUMN = 1
+ASSETS_MD_ASSET_ID_COLUMN = 2
+ASSETS_MD_PARAMS_COLUMN = 5
+ASSETS_MD_STATUS_COLUMN = 7
 
 
 class AssetsMdUpdateError(Exception):
@@ -100,12 +106,13 @@ def _load_entries(
     return entries
 
 
-def _split_markdown_row(line: str) -> list[str] | None:
+def split_assets_md_row(line: str) -> list[str] | None:
+    """Return one contract-shaped ASSETS.md row, or ``None`` otherwise."""
     stripped = line.strip()
     if not stripped.startswith("|") or not stripped.endswith("|"):
         return None
     cells = [cell.strip() for cell in stripped.strip("|").split("|")]
-    if len(cells) < 8:
+    if len(cells) < ASSETS_MD_MIN_CELLS:
         return None
     return cells
 
@@ -161,21 +168,21 @@ def update_assets_md(
     row_re = re.compile(r"^\s*\|")
 
     for line in lines:
-        cells = _split_markdown_row(line) if row_re.match(line) else None
-        if cells is None or len(cells) < 8:
+        cells = split_assets_md_row(line) if row_re.match(line) else None
+        if cells is None:
             output.append(line)
             continue
-        tag = cells[1]
-        asset_id = cells[2]
+        tag = cells[ASSETS_MD_TAG_COLUMN]
+        asset_id = cells[ASSETS_MD_ASSET_ID_COLUMN]
         key = (tag, asset_id)
         if key not in entries_by_key:
             output.append(line)
             continue
 
-        cells[5] = _merge_generation_params(
-            cells[5], _entry_params(entries_by_key[key])
+        cells[ASSETS_MD_PARAMS_COLUMN] = _merge_generation_params(
+            cells[ASSETS_MD_PARAMS_COLUMN], _entry_params(entries_by_key[key])
         )
-        cells[7] = status
+        cells[ASSETS_MD_STATUS_COLUMN] = status
         output.append(_format_markdown_row(cells))
         updated.append(asset_id)
         remaining.discard(key)

--- a/tools/asset_runtime_resolver.py
+++ b/tools/asset_runtime_resolver.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Resolve one v1 stable entry into a worker runtime snapshot.
+
+The generated-asset root index and ASSETS.md deliberately retain only stable
+identity and a ``manifest_entry`` pointer.  This tool is the single,
+fail-closed reader for that pointer: it validates the entry, proves its files
+still exist, and emits the small runtime contract a worker may consume.
+
+Reference-only entries remain valid stable entries, but they are never worker
+runtime assets and therefore cannot produce a runtime snapshot.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from asset_stable_entry import (
+    REFERENCE_LAYOUTS,
+    StableEntryError,
+    _load_json,
+    entry_relative_path,
+    validate_entry,
+)
+
+
+class AssetRuntimeResolverError(Exception):
+    """Raised when a stable entry cannot safely become a runtime snapshot."""
+
+
+def _split_markdown_row(line: str) -> list[str] | None:
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|"):
+        return None
+    return [cell.strip() for cell in stripped.strip("|").split("|")]
+
+
+def _manifest_entry_from_params(value: str) -> str:
+    """Read exactly one ``manifest_entry`` value from ASSETS generation params."""
+    matches: list[str] = []
+    for item in value.split(";"):
+        key, separator, candidate = item.strip().partition("=")
+        if key == "manifest_entry" and separator:
+            candidate = candidate.strip()
+            if not candidate:
+                raise AssetRuntimeResolverError("ASSETS.md manifest_entry must not be empty")
+            matches.append(candidate)
+    if not matches:
+        raise AssetRuntimeResolverError("ASSETS.md row is missing manifest_entry")
+    if len(matches) != 1:
+        raise AssetRuntimeResolverError("ASSETS.md row must contain exactly one manifest_entry")
+    return matches[0]
+
+
+def manifest_entry_from_assets_row(
+    assets_md: Path,
+    *,
+    tag: str,
+    asset_id: str,
+) -> str:
+    """Return the manifest pointer from one unambiguous ASSETS.md row."""
+    assets_md = Path(assets_md)
+    if not assets_md.exists():
+        raise AssetRuntimeResolverError(f"ASSETS.md not found: {assets_md}")
+
+    matches: list[list[str]] = []
+    for line in assets_md.read_text(encoding="utf-8").splitlines():
+        cells = _split_markdown_row(line)
+        if cells is None or len(cells) < 8:
+            continue
+        if cells[1] == tag and cells[2] == asset_id:
+            matches.append(cells)
+
+    if not matches:
+        raise AssetRuntimeResolverError(f"ASSETS.md row not found for {tag}/{asset_id}")
+    if len(matches) != 1:
+        raise AssetRuntimeResolverError(f"ASSETS.md has multiple rows for {tag}/{asset_id}")
+
+    row = matches[0]
+    if row[7] != "generated":
+        raise AssetRuntimeResolverError(
+            f"ASSETS.md row for {tag}/{asset_id} has status {row[7]!r}; expected 'generated'"
+        )
+    return _manifest_entry_from_params(row[5])
+
+
+def _canonical_entry_path(project_root: Path, pointer: str) -> Path:
+    """Resolve a project-relative pointer without permitting path traversal."""
+    if not isinstance(pointer, str) or not pointer.strip():
+        raise AssetRuntimeResolverError("manifest_entry must be a non-empty path")
+    if "\\" in pointer:
+        raise AssetRuntimeResolverError("manifest_entry must use forward slashes")
+    raw_parts = pointer.split("/")
+    if any(part in {"", ".", ".."} for part in raw_parts):
+        raise AssetRuntimeResolverError(
+            "manifest_entry must not contain empty, '.' or '..' segments"
+        )
+    relative = Path(pointer)
+    if relative.is_absolute() or relative.drive:
+        raise AssetRuntimeResolverError("manifest_entry must be project-relative")
+
+    root = Path(project_root).resolve()
+    resolved = (root / relative).resolve()
+    if not resolved.is_relative_to(root):
+        raise AssetRuntimeResolverError("manifest_entry resolves outside the project root")
+    if not resolved.exists():
+        raise AssetRuntimeResolverError(f"Entry file not found: {pointer}")
+    return resolved
+
+
+def resolve_manifest_entry(
+    manifest_entry: str,
+    *,
+    project_root: Path,
+    expected_tag: str | None = None,
+    expected_asset_id: str | None = None,
+) -> dict[str, Any]:
+    """Return a stable, minimal runtime snapshot from one canonical pointer."""
+    root = Path(project_root).resolve()
+    entry_path = _canonical_entry_path(root, manifest_entry)
+    try:
+        entry = validate_entry(_load_json(entry_path), project_root=root, check_files=True)
+    except StableEntryError as exc:
+        raise AssetRuntimeResolverError(f"{manifest_entry}: {exc}") from exc
+
+    tag = entry["tag"]
+    asset_id = entry["asset_id"]
+    canonical = entry_relative_path(tag, asset_id)
+    if manifest_entry != canonical:
+        raise AssetRuntimeResolverError(
+            f"manifest_entry must be the canonical entry path {canonical}"
+        )
+    if entry_path != (root / canonical).resolve():
+        raise AssetRuntimeResolverError("manifest_entry resolves outside the canonical entry location")
+    if expected_tag is not None and tag != expected_tag:
+        raise AssetRuntimeResolverError(
+            f"manifest_entry tag {tag!r} does not match ASSETS.md tag {expected_tag!r}"
+        )
+    if expected_asset_id is not None and asset_id != expected_asset_id:
+        raise AssetRuntimeResolverError(
+            "manifest_entry asset_id "
+            f"{asset_id!r} does not match ASSETS.md asset_id {expected_asset_id!r}"
+        )
+    if entry["processing_status"] != "ready":
+        raise AssetRuntimeResolverError(
+            f"{manifest_entry} processing_status is {entry['processing_status']}; expected ready"
+        )
+    if entry["source_layout"]["type"] in REFERENCE_LAYOUTS:
+        raise AssetRuntimeResolverError(
+            f"{manifest_entry} is reference-only and cannot produce a worker runtime snapshot"
+        )
+
+    artifact = entry.get("godot_artifact")
+    if not isinstance(artifact, dict):
+        raise AssetRuntimeResolverError(
+            f"{manifest_entry} has no godot_artifact for a runtime asset"
+        )
+
+    # Construct fresh dictionaries rather than returning the entry body so the
+    # output has no internal fields and keeps a deterministic field order.
+    return {
+        "asset_id": asset_id,
+        "production_family": entry["production_family"],
+        "source_layout": {
+            "type": entry["source_layout"]["type"],
+            "path": entry["source_layout"]["path"],
+        },
+        "godot_artifact": {
+            "type": artifact["type"],
+            "path": artifact["path"],
+        },
+    }
+
+
+def resolve_assets_row(
+    assets_md: Path,
+    *,
+    tag: str,
+    asset_id: str,
+    project_root: Path,
+) -> dict[str, Any]:
+    """Resolve the pointer in one current-tag ASSETS.md row."""
+    pointer = manifest_entry_from_assets_row(assets_md, tag=tag, asset_id=asset_id)
+    return resolve_manifest_entry(
+        pointer,
+        project_root=project_root,
+        expected_tag=tag,
+        expected_asset_id=asset_id,
+    )
+
+
+def _main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Resolve a v1 manifest_entry into a worker runtime snapshot"
+    )
+    parser.add_argument("--project-root", default=".", type=Path)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--manifest-entry", help="Canonical stable entry pointer")
+    source.add_argument(
+        "--assets-md",
+        type=Path,
+        help="ASSETS.md from which to read a manifest_entry pointer",
+    )
+    parser.add_argument("--tag", help="ASSETS.md tag (required with --assets-md)")
+    parser.add_argument("--asset-id", help="ASSETS.md asset ID (required with --assets-md)")
+    args = parser.parse_args()
+
+    try:
+        if args.manifest_entry:
+            if args.tag is not None or args.asset_id is not None:
+                parser.error("--tag and --asset-id are only valid with --assets-md")
+            snapshot = resolve_manifest_entry(
+                args.manifest_entry, project_root=args.project_root
+            )
+        else:
+            if not args.tag or not args.asset_id:
+                parser.error("--assets-md requires --tag and --asset-id")
+            snapshot = resolve_assets_row(
+                args.assets_md,
+                tag=args.tag,
+                asset_id=args.asset_id,
+                project_root=args.project_root,
+            )
+    except AssetRuntimeResolverError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}))
+        return 1
+
+    print(json.dumps(snapshot, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_main())

--- a/tools/asset_runtime_resolver.py
+++ b/tools/asset_runtime_resolver.py
@@ -1,13 +1,10 @@
 #!/usr/bin/env python3
-"""Resolve one v1 stable entry into a worker runtime snapshot.
+"""Resolve one registered v1 stable entry into a worker runtime snapshot.
 
-The generated-asset root index and ASSETS.md deliberately retain only stable
-identity and a ``manifest_entry`` pointer.  This tool is the single,
-fail-closed reader for that pointer: it validates the entry, proves its files
-still exist, and emits the small runtime contract a worker may consume.
-
-Reference-only entries remain valid stable entries, but they are never worker
-runtime assets and therefore cannot produce a runtime snapshot.
+ASSETS.md keeps an asset's ``manifest_entry`` pointer while the generated root
+index records which canonical entries are registered. This tool requires both
+records to agree, validates the ready entry and its files, then emits only the
+worker-facing runtime contract.
 """
 from __future__ import annotations
 
@@ -17,24 +14,37 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from asset_assets_md_update import (
+    ASSETS_MD_ASSET_ID_COLUMN,
+    ASSETS_MD_PARAMS_COLUMN,
+    ASSETS_MD_STATUS_COLUMN,
+    ASSETS_MD_TAG_COLUMN,
+    GENERATED_ROW_STATUS,
+    split_assets_md_row,
+)
+from asset_generation_index import GenerationIndexError, check_index
 from asset_stable_entry import (
+    ENTRIES_ROOT,
     REFERENCE_LAYOUTS,
+    WORK_ROOT,
     StableEntryError,
     _load_json,
     entry_relative_path,
     validate_entry,
 )
 
+ROOT_INDEX_PATH = ".godotmaker/asset-generation/manifest.json"
+
 
 class AssetRuntimeResolverError(Exception):
     """Raised when a stable entry cannot safely become a runtime snapshot."""
 
 
-def _split_markdown_row(line: str) -> list[str] | None:
-    stripped = line.strip()
-    if not stripped.startswith("|") or not stripped.endswith("|"):
-        return None
-    return [cell.strip() for cell in stripped.strip("|").split("|")]
+def _read_assets_md(assets_md: Path) -> str:
+    try:
+        return assets_md.read_text(encoding="utf-8")
+    except (OSError, UnicodeError) as exc:
+        raise AssetRuntimeResolverError(f"Cannot read ASSETS.md: {assets_md}") from exc
 
 
 def _manifest_entry_from_params(value: str) -> str:
@@ -60,17 +70,17 @@ def manifest_entry_from_assets_row(
     tag: str,
     asset_id: str,
 ) -> str:
-    """Return the manifest pointer from one unambiguous ASSETS.md row."""
+    """Return the registered pointer from one generated ASSETS.md row."""
     assets_md = Path(assets_md)
-    if not assets_md.exists():
-        raise AssetRuntimeResolverError(f"ASSETS.md not found: {assets_md}")
-
     matches: list[list[str]] = []
-    for line in assets_md.read_text(encoding="utf-8").splitlines():
-        cells = _split_markdown_row(line)
-        if cells is None or len(cells) < 8:
+    for line in _read_assets_md(assets_md).splitlines():
+        cells = split_assets_md_row(line)
+        if cells is None:
             continue
-        if cells[1] == tag and cells[2] == asset_id:
+        if (
+            cells[ASSETS_MD_TAG_COLUMN] == tag
+            and cells[ASSETS_MD_ASSET_ID_COLUMN] == asset_id
+        ):
             matches.append(cells)
 
     if not matches:
@@ -79,23 +89,34 @@ def manifest_entry_from_assets_row(
         raise AssetRuntimeResolverError(f"ASSETS.md has multiple rows for {tag}/{asset_id}")
 
     row = matches[0]
-    if row[7] != "generated":
+    if row[ASSETS_MD_STATUS_COLUMN] != GENERATED_ROW_STATUS:
         raise AssetRuntimeResolverError(
-            f"ASSETS.md row for {tag}/{asset_id} has status {row[7]!r}; expected 'generated'"
+            f"ASSETS.md row for {tag}/{asset_id} has status "
+            f"{row[ASSETS_MD_STATUS_COLUMN]!r}; expected {GENERATED_ROW_STATUS!r}"
         )
-    return _manifest_entry_from_params(row[5])
+    return _manifest_entry_from_params(row[ASSETS_MD_PARAMS_COLUMN])
 
 
 def _canonical_entry_path(project_root: Path, pointer: str) -> Path:
-    """Resolve a project-relative pointer without permitting path traversal."""
+    """Resolve only the exact v1 entry-path shape, before reading JSON."""
     if not isinstance(pointer, str) or not pointer.strip():
         raise AssetRuntimeResolverError("manifest_entry must be a non-empty path")
     if "\\" in pointer:
         raise AssetRuntimeResolverError("manifest_entry must use forward slashes")
-    raw_parts = pointer.split("/")
-    if any(part in {"", ".", ".."} for part in raw_parts):
+    parts = pointer.split("/")
+    if any(part in {"", ".", ".."} for part in parts):
         raise AssetRuntimeResolverError(
             "manifest_entry must not contain empty, '.' or '..' segments"
+        )
+    expected_prefix = ENTRIES_ROOT.split("/")
+    if (
+        len(parts) != len(expected_prefix) + 2
+        or parts[: len(expected_prefix)] != expected_prefix
+        or not parts[-1].endswith(".json")
+        or parts[-1] == ".json"
+    ):
+        raise AssetRuntimeResolverError(
+            "manifest_entry must be a canonical entries/<tag>/<asset_id>.json path"
         )
     relative = Path(pointer)
     if relative.is_absolute() or relative.drive:
@@ -105,19 +126,52 @@ def _canonical_entry_path(project_root: Path, pointer: str) -> Path:
     resolved = (root / relative).resolve()
     if not resolved.is_relative_to(root):
         raise AssetRuntimeResolverError("manifest_entry resolves outside the project root")
-    if not resolved.exists():
+    if resolved.is_relative_to((root / WORK_ROOT).resolve()):
+        raise AssetRuntimeResolverError("manifest_entry must not resolve into the generation work/ workspace")
+    if not resolved.is_file():
         raise AssetRuntimeResolverError(f"Entry file not found: {pointer}")
     return resolved
+
+
+def _assert_registered(
+    *, project_root: Path, manifest_entry: str, tag: str, asset_id: str
+) -> None:
+    """Require the root index to pass its full gate and point at this entry."""
+    index_path = project_root / ROOT_INDEX_PATH
+    try:
+        check_index(index_path, project_root=project_root, check_files=True)
+        index = json.loads(index_path.read_text(encoding="utf-8"))
+    except (GenerationIndexError, OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise AssetRuntimeResolverError(f"Generated root index is invalid: {exc}") from exc
+
+    registered = any(
+        item.get("tag") == tag
+        and item.get("asset_id") == asset_id
+        and item.get("entry_path") == manifest_entry
+        for item in index["entries"]
+    )
+    if not registered:
+        raise AssetRuntimeResolverError(
+            f"manifest_entry is not registered in {ROOT_INDEX_PATH}: {manifest_entry}"
+        )
+
+
+def _assert_assets_root(assets_md: Path, project_root: Path) -> Path:
+    assets_path = Path(assets_md).resolve()
+    if assets_path.parent != project_root:
+        raise AssetRuntimeResolverError("ASSETS.md must be located at the project root")
+    return assets_path
 
 
 def resolve_manifest_entry(
     manifest_entry: str,
     *,
     project_root: Path,
+    assets_md: Path,
     expected_tag: str | None = None,
     expected_asset_id: str | None = None,
 ) -> dict[str, Any]:
-    """Return a stable, minimal runtime snapshot from one canonical pointer."""
+    """Return a registered, minimal runtime snapshot from one canonical pointer."""
     root = Path(project_root).resolve()
     entry_path = _canonical_entry_path(root, manifest_entry)
     try:
@@ -132,8 +186,6 @@ def resolve_manifest_entry(
         raise AssetRuntimeResolverError(
             f"manifest_entry must be the canonical entry path {canonical}"
         )
-    if entry_path != (root / canonical).resolve():
-        raise AssetRuntimeResolverError("manifest_entry resolves outside the canonical entry location")
     if expected_tag is not None and tag != expected_tag:
         raise AssetRuntimeResolverError(
             f"manifest_entry tag {tag!r} does not match ASSETS.md tag {expected_tag!r}"
@@ -142,6 +194,18 @@ def resolve_manifest_entry(
         raise AssetRuntimeResolverError(
             "manifest_entry asset_id "
             f"{asset_id!r} does not match ASSETS.md asset_id {expected_asset_id!r}"
+        )
+    _assert_registered(
+        project_root=root,
+        manifest_entry=manifest_entry,
+        tag=tag,
+        asset_id=asset_id,
+    )
+    assets_path = _assert_assets_root(assets_md, root)
+    row_pointer = manifest_entry_from_assets_row(assets_path, tag=tag, asset_id=asset_id)
+    if row_pointer != manifest_entry:
+        raise AssetRuntimeResolverError(
+            "ASSETS.md manifest_entry does not match the requested pointer"
         )
     if entry["processing_status"] != "ready":
         raise AssetRuntimeResolverError(
@@ -152,14 +216,7 @@ def resolve_manifest_entry(
             f"{manifest_entry} is reference-only and cannot produce a worker runtime snapshot"
         )
 
-    artifact = entry.get("godot_artifact")
-    if not isinstance(artifact, dict):
-        raise AssetRuntimeResolverError(
-            f"{manifest_entry} has no godot_artifact for a runtime asset"
-        )
-
-    # Construct fresh dictionaries rather than returning the entry body so the
-    # output has no internal fields and keeps a deterministic field order.
+    artifact = entry["godot_artifact"]
     return {
         "asset_id": asset_id,
         "production_family": entry["production_family"],
@@ -181,11 +238,14 @@ def resolve_assets_row(
     asset_id: str,
     project_root: Path,
 ) -> dict[str, Any]:
-    """Resolve the pointer in one current-tag ASSETS.md row."""
-    pointer = manifest_entry_from_assets_row(assets_md, tag=tag, asset_id=asset_id)
+    """Resolve one current-tag ASSETS.md row through all handoff gates."""
+    root = Path(project_root).resolve()
+    assets_path = _assert_assets_root(assets_md, root)
+    pointer = manifest_entry_from_assets_row(assets_path, tag=tag, asset_id=asset_id)
     return resolve_manifest_entry(
         pointer,
-        project_root=project_root,
+        project_root=root,
+        assets_md=assets_path,
         expected_tag=tag,
         expected_asset_id=asset_id,
     )
@@ -193,35 +253,37 @@ def resolve_assets_row(
 
 def _main() -> int:
     parser = argparse.ArgumentParser(
-        description="Resolve a v1 manifest_entry into a worker runtime snapshot"
+        description="Resolve one registered v1 manifest_entry into a worker runtime snapshot"
     )
     parser.add_argument("--project-root", default=".", type=Path)
-    source = parser.add_mutually_exclusive_group(required=True)
-    source.add_argument("--manifest-entry", help="Canonical stable entry pointer")
-    source.add_argument(
+    parser.add_argument(
         "--assets-md",
+        default=Path("ASSETS.md"),
         type=Path,
-        help="ASSETS.md from which to read a manifest_entry pointer",
+        help="Project-root ASSETS.md used by both input modes",
     )
-    parser.add_argument("--tag", help="ASSETS.md tag (required with --assets-md)")
-    parser.add_argument("--asset-id", help="ASSETS.md asset ID (required with --assets-md)")
+    parser.add_argument("--manifest-entry", help="Canonical stable entry pointer")
+    parser.add_argument("--tag", help="ASSETS.md tag (used with --asset-id)")
+    parser.add_argument("--asset-id", help="ASSETS.md asset ID (used with --tag)")
     args = parser.parse_args()
 
     try:
-        if args.manifest_entry:
+        root = args.project_root.resolve()
+        assets_md = args.assets_md if args.assets_md.is_absolute() else root / args.assets_md
+        if args.manifest_entry is not None:
             if args.tag is not None or args.asset_id is not None:
-                parser.error("--tag and --asset-id are only valid with --assets-md")
+                parser.error("--tag and --asset-id are not valid with --manifest-entry")
             snapshot = resolve_manifest_entry(
-                args.manifest_entry, project_root=args.project_root
+                args.manifest_entry, project_root=root, assets_md=assets_md
             )
         else:
             if not args.tag or not args.asset_id:
-                parser.error("--assets-md requires --tag and --asset-id")
+                parser.error("provide --manifest-entry or both --tag and --asset-id")
             snapshot = resolve_assets_row(
-                args.assets_md,
+                assets_md,
                 tag=args.tag,
                 asset_id=args.asset_id,
-                project_root=args.project_root,
+                project_root=root,
             )
     except AssetRuntimeResolverError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}))

--- a/tools/asset_runtime_resolver.py
+++ b/tools/asset_runtime_resolver.py
@@ -136,10 +136,15 @@ def _canonical_entry_path(project_root: Path, pointer: str) -> Path:
 def _assert_registered(
     *, project_root: Path, manifest_entry: str, tag: str, asset_id: str
 ) -> None:
-    """Require the root index to pass its full gate and point at this entry."""
+    """Require a structurally valid root index that points at this entry.
+
+    The resolver proves the requested entry's files below. Other entries may
+    legitimately still be ``pending`` or ``source_ready`` without files, so the
+    root index's all-entry file gate remains an explicit batch validation.
+    """
     index_path = project_root / ROOT_INDEX_PATH
     try:
-        check_index(index_path, project_root=project_root, check_files=True)
+        check_index(index_path, project_root=project_root, check_entries=True)
         index = json.loads(index_path.read_text(encoding="utf-8"))
     except (GenerationIndexError, OSError, UnicodeError, json.JSONDecodeError) as exc:
         raise AssetRuntimeResolverError(f"Generated root index is invalid: {exc}") from exc

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -102,7 +102,7 @@ LEGACY_FIELDS = {
 
 # Characters that are illegal in a Windows filename or act as path separators /
 # drive markers / alternate-data-stream selectors across platforms.
-_RESERVED_PATH_CHARS = set('<>:"/\\|?*')
+_RESERVED_PATH_CHARS = set('<>:"/\\|?*;')
 
 # Windows reserved device basenames (case-insensitive, any extension).
 _RESERVED_DEVICE_NAMES = {
@@ -183,7 +183,7 @@ def _safe_identifier(value: str, label: str) -> str:
         if char in _RESERVED_PATH_CHARS or ord(char) < 32:
             raise StableEntryError(
                 f"{label} must be a single safe path segment "
-                "(no path separators, ':' or reserved characters)"
+                "(no path separators, ':', ';' or reserved characters)"
             )
     if value != value.strip() or value.endswith("."):
         raise StableEntryError(


### PR DESCRIPTION
## Summary

Add a deterministic `manifest_entry` runtime resolver for ASSETS.md: given a registered, `generated` manifest entry pointer, resolve it into the minimal four-field ready runtime snapshot (`asset_id`, `production_family`, `source_layout`, `godot_artifact`) required by downstream consumers.

## Motivation

ASSETS.md already stores `manifest_entry` pointers, but no deterministic tool followed a pointer, validated identity/ready state, and emitted a stable, worker-consumable snapshot. This closes that gap for the v1 resolver contract (a breaking change from the older `runtime_artifact` schema; no migration/compat reader is provided by design).

## Changes

- [x] Add `tools/asset_runtime_resolver.py`: resolves a `manifest_entry` pointer against the ASSETS.md row, the generated root index, and the canonical stable entry, cross-checking tag, `asset_id`, `production_family`, `processing_status`, `source_layout`, and `godot_artifact`.
- [x] Fail closed on: missing pointers, out-of-bounds paths, identity mismatches, legacy `runtime_artifact` schema, non-ready status, and missing on-disk files.
- [x] Emit stable, ordered output fields for runtime assets; reference-only assets may omit `godot_artifact` but cannot be mistaken for worker runtime assets.
- [x] Document the resolver in the tool indexes and wiki (`docs/wiki/05-tools/asset-tools.md`, `docs/wiki/07-contributing/codebase-guide.md`, and `zh` mirrors) and in `skills/core/gm-asset/references/asset-runtime-pipeline.md`.
- [x] Add resolver unit tests and a runtime-pipeline contract test.

## Scope boundary

This PR intentionally stops at the resolver boundary:

- The real worker-dispatch wiring for this resolver is owned by **WOR-233**; this PR does not add or claim a real pipeline caller.
- Verification is Python-only — there is no Godot runtime/compiler exercised as part of this change or its tests.
- No other blocking residual risks were identified; see the reviewer thread on PR #106 for the three rounds of review that were closed against this PR.

## Testing

- [x] New or updated tests pass:
  `python -m pytest tests/tools/test_asset_runtime_resolver.py tests/tools/test_asset_stable_entry.py tests/tools/test_asset_assets_md_update.py tests/tools/test_asset_generation_index.py tests/tools/test_asset_generation_handoff.py tests/test_asset_runtime_contract_docs.py -q`
- [x] Lint: `python -m ruff check tools/asset_runtime_resolver.py tools/asset_assets_md_update.py tools/asset_stable_entry.py tests/tools/test_asset_runtime_resolver.py tests/tools/test_asset_stable_entry.py tests/test_asset_runtime_contract_docs.py`
- [x] Full suite: `python -m pytest`
- [x] Gitleaks passes / no secret-bearing files were touched
- [ ] Manual testing completed, if applicable — not applicable; no Godot runtime/compiler in this change's verification boundary (see Scope boundary above)

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed (new resolver tool only; no existing target-project files, config keys, or behavior are changed)

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — not applicable, no ECS systems touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
