### PR TITLE
feat(assets): add shared Godot artifact compiler registry

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -25,7 +25,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Added `tools/asset_action_entry_draft.py`, which builds action support metadata and a v1 stable-entry draft while enforcing frame count, empty edge-touch frames, a recorded scale reference, and stable-path containment.
 - Added `tools/asset_curation_entry_draft.py`, which builds a v1 stable-entry draft from a selected curation candidate while enforcing candidate selection, unambiguous naming, coherent selection counts, and stable-path containment.
 - Added `tools/asset_finalize_entry_draft.py`, which builds a v1 stable-entry draft from an `asset_image_finalize.py` report for screen references, backgrounds, and single card or portrait frames while enforcing aspect validation, asset-label binding, and path containment.
-- Added a shared Godot artifact compiler interface and registry under `skills/assets/_shared/` that routes on the frozen source-layout to artifact-type compatibility set, keeps compiler receipts out of the worker-facing artifact, serves `Texture2D` through Godot's default import, and fails closed on unregistered or mismatched combinations.
+- Added a shared Godot artifact compiler interface and registry under `skills/assets/_shared/` that routes on the frozen source-layout to artifact-type compatibility set, keeps compiler receipts out of the worker-facing artifact, requires each compiler to actually rebuild an artifact distinct from its source image, serves `Texture2D` through Godot's default import, and fails closed on unregistered or mismatched combinations (#107).
 
 ## Changed
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -25,6 +25,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Added `tools/asset_action_entry_draft.py`, which builds action support metadata and a v1 stable-entry draft while enforcing frame count, empty edge-touch frames, a recorded scale reference, and stable-path containment.
 - Added `tools/asset_curation_entry_draft.py`, which builds a v1 stable-entry draft from a selected curation candidate while enforcing candidate selection, unambiguous naming, coherent selection counts, and stable-path containment.
 - Added `tools/asset_finalize_entry_draft.py`, which builds a v1 stable-entry draft from an `asset_image_finalize.py` report for screen references, backgrounds, and single card or portrait frames while enforcing aspect validation, asset-label binding, and path containment.
+- Added a shared Godot artifact compiler interface and registry under `skills/assets/_shared/` that routes on the frozen source-layout to artifact-type compatibility set, keeps compiler receipts out of the worker-facing artifact, serves `Texture2D` through Godot's default import, and fails closed on unregistered or mismatched combinations.
 
 ## Changed
 

--- a/skills/assets/_shared/asset_compiler/__init__.py
+++ b/skills/assets/_shared/asset_compiler/__init__.py
@@ -1,0 +1,44 @@
+"""Shared Godot artifact compiler interface and registry for asset skills.
+
+See ``godot-artifact-compiler-contract.md`` next to this package for the
+contract this code implements. Concrete family compilers (``AtlasTexture``,
+``SpriteFrames``, ``Theme``, ``StyleBoxTexture``, ``TileSet``) live outside the
+registry and register themselves into it.
+"""
+from __future__ import annotations
+
+from . import texture2d
+from .contract import (
+    CompileReceipt,
+    CompileRequest,
+    CompileResult,
+    CompilerError,
+    GodotArtifact,
+    require_text,
+)
+from .registry import Compiler, CompilerRegistry, CompilerRoute
+
+
+def build_default_registry() -> CompilerRegistry:
+    """Return a registry holding every compiler the shared layer ships."""
+    registry = CompilerRegistry()
+    texture2d.register_into(registry)
+    return registry
+
+
+DEFAULT_REGISTRY = build_default_registry()
+
+__all__ = [
+    "DEFAULT_REGISTRY",
+    "CompileReceipt",
+    "CompileRequest",
+    "CompileResult",
+    "Compiler",
+    "CompilerError",
+    "CompilerRegistry",
+    "CompilerRoute",
+    "GodotArtifact",
+    "build_default_registry",
+    "require_text",
+    "texture2d",
+]

--- a/skills/assets/_shared/asset_compiler/__init__.py
+++ b/skills/assets/_shared/asset_compiler/__init__.py
@@ -4,6 +4,13 @@ See ``godot-artifact-compiler-contract.md`` next to this package for the
 contract this code implements. Concrete family compilers (``AtlasTexture``,
 ``SpriteFrames``, ``Theme``, ``StyleBoxTexture``, ``TileSet``) live outside the
 registry and register themselves into it.
+
+There is deliberately no module-level default registry instance. A caller builds
+one with :func:`build_default_registry` and every family compiler for that run
+registers into that instance. A process-global would let one caller's
+registrations be invisible to a second caller holding a freshly built registry,
+and — because ``register()`` rejects a duplicate pair outright — would turn a
+re-imported self-registering module into an import-time crash.
 """
 from __future__ import annotations
 
@@ -16,20 +23,23 @@ from .contract import (
     GodotArtifact,
     require_text,
 )
-from .registry import Compiler, CompilerRegistry, CompilerRoute
+from .registry import (
+    SOURCE_IS_ARTIFACT_TYPES,
+    Compiler,
+    CompilerRegistry,
+    CompilerRoute,
+)
 
 
 def build_default_registry() -> CompilerRegistry:
-    """Return a registry holding every compiler the shared layer ships."""
+    """Return a new registry holding every compiler the shared layer ships."""
     registry = CompilerRegistry()
     texture2d.register_into(registry)
     return registry
 
 
-DEFAULT_REGISTRY = build_default_registry()
-
 __all__ = [
-    "DEFAULT_REGISTRY",
+    "SOURCE_IS_ARTIFACT_TYPES",
     "CompileReceipt",
     "CompileRequest",
     "CompileResult",

--- a/skills/assets/_shared/asset_compiler/_stable_entry.py
+++ b/skills/assets/_shared/asset_compiler/_stable_entry.py
@@ -1,0 +1,40 @@
+"""Import bridge to the repository's stable-entry contract module.
+
+The compiler registry must route on exactly the layout/artifact compatibility
+set the stable-entry validator enforces. Re-declaring that set here would let
+the two drift, and an artifact could compile that a stable entry then rejects.
+So the registry imports the frozen relation instead of copying it.
+
+``tools/`` is a flat script directory rather than an installed package, so it is
+resolved relative to this file the same way the repository's tests do.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parents[4] / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from asset_stable_entry import (  # noqa: E402
+    LAYOUT_ARTIFACT_TYPES,
+    PRODUCTION_FAMILIES,
+    REFERENCE_FAMILIES,
+    REFERENCE_LAYOUTS,
+    SOURCE_LAYOUT_TYPES,
+    StableEntryError,
+    assert_within_output_dir,
+    check_output_path,
+)
+
+__all__ = [
+    "LAYOUT_ARTIFACT_TYPES",
+    "PRODUCTION_FAMILIES",
+    "REFERENCE_FAMILIES",
+    "REFERENCE_LAYOUTS",
+    "SOURCE_LAYOUT_TYPES",
+    "StableEntryError",
+    "assert_within_output_dir",
+    "check_output_path",
+]

--- a/skills/assets/_shared/asset_compiler/_stable_entry.py
+++ b/skills/assets/_shared/asset_compiler/_stable_entry.py
@@ -6,7 +6,10 @@ the two drift, and an artifact could compile that a stable entry then rejects.
 So the registry imports the frozen relation instead of copying it.
 
 ``tools/`` is a flat script directory rather than an installed package, so it is
-resolved relative to this file the same way the repository's tests do.
+resolved relative to this file the same way the repository's tests do. That
+makes this package importable from a source checkout only: ``skills/assets/`` is
+not part of the publish layout yet, so the location is asserted with a
+diagnosable message instead of failing as a bare ``ModuleNotFoundError``.
 """
 from __future__ import annotations
 
@@ -14,8 +17,20 @@ import sys
 from pathlib import Path
 
 _TOOLS_DIR = Path(__file__).resolve().parents[4] / "tools"
+
+if not _TOOLS_DIR.is_dir():
+    raise ImportError(
+        "the shared Godot artifact compiler expects the repository tools/ "
+        f"directory at {_TOOLS_DIR}, resolved from {__file__}. It is importable "
+        "from a source checkout only; skills/assets/ is not deployed by "
+        "tools/publish.py yet."
+    )
+
+# Appended, never inserted: tools/ is a flat directory of scripts, and putting it
+# ahead of the standard library would let a future tools/<stdlib name>.py shadow
+# a real module for every later import in the process.
 if str(_TOOLS_DIR) not in sys.path:
-    sys.path.insert(0, str(_TOOLS_DIR))
+    sys.path.append(str(_TOOLS_DIR))
 
 from asset_stable_entry import (  # noqa: E402
     LAYOUT_ARTIFACT_TYPES,
@@ -24,9 +39,15 @@ from asset_stable_entry import (  # noqa: E402
     REFERENCE_LAYOUTS,
     SOURCE_LAYOUT_TYPES,
     StableEntryError,
+    _resolve_res_path,
     assert_within_output_dir,
     check_output_path,
 )
+
+# ``_resolve_res_path`` is private to the stable-entry module, but sharing it is
+# the point of this bridge: the compiler must turn a ``res://`` path into a file
+# exactly the way the validator that will later accept the entry does.
+resolve_res_path = _resolve_res_path
 
 __all__ = [
     "LAYOUT_ARTIFACT_TYPES",
@@ -37,4 +58,5 @@ __all__ = [
     "StableEntryError",
     "assert_within_output_dir",
     "check_output_path",
+    "resolve_res_path",
 ]

--- a/skills/assets/_shared/asset_compiler/_stable_entry.py
+++ b/skills/assets/_shared/asset_compiler/_stable_entry.py
@@ -39,15 +39,32 @@ from asset_stable_entry import (  # noqa: E402
     REFERENCE_LAYOUTS,
     SOURCE_LAYOUT_TYPES,
     StableEntryError,
+    _check_res_path,
     _resolve_res_path,
     assert_within_output_dir,
     check_output_path,
 )
 
-# ``_resolve_res_path`` is private to the stable-entry module, but sharing it is
-# the point of this bridge: the compiler must turn a ``res://`` path into a file
-# exactly the way the validator that will later accept the entry does.
-resolve_res_path = _resolve_res_path
+
+def resolve_res_path(project_root: Path, res_path: str, *, label: str = "path") -> Path:
+    """Resolve a ``res://`` path to an absolute file under ``project_root``.
+
+    Both halves of this wrapper exist to make the stable-entry resolver safe to
+    share rather than to copy:
+
+    - it slices the prefix without checking it, so a path that carries none is
+      silently corrupted (``/etc/passwd`` becomes ``<root>/asswd``). That is
+      sound where it lives, because every caller validates first, but not as an
+      exported "turn a res:// path into a file" helper. The prefix is checked
+      here with the same checker the validator uses.
+    - the root is resolved first so the result is absolute.
+      ``assert_within_output_dir`` re-anchors a relative target against the
+      project root, so handing it a relative root joined path would join the
+      root twice.
+    """
+    _check_res_path(res_path, label)
+    return _resolve_res_path(Path(project_root).resolve(), res_path)
+
 
 __all__ = [
     "LAYOUT_ARTIFACT_TYPES",

--- a/skills/assets/_shared/asset_compiler/contract.py
+++ b/skills/assets/_shared/asset_compiler/contract.py
@@ -1,0 +1,185 @@
+"""The stable input, output, error, and receipt boundary of a Godot compiler.
+
+Every deterministic Godot artifact compiler an asset skill runs takes a
+:class:`CompileRequest`, raises :class:`CompilerError` when it cannot produce a
+legal artifact, and returns receipt details. The registry — not the compiler —
+assembles the :class:`CompileResult`, so the worker-facing
+:class:`GodotArtifact` can only ever hold the requested type and path.
+
+That asymmetry is deliberate. Compiler identity, versions, hashes, and internal
+findings belong in :class:`CompileReceipt`; they are useful for debugging a
+generation run and must never reach the worker snapshot, which stays exactly
+``{type, path}``.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ._stable_entry import (
+    LAYOUT_ARTIFACT_TYPES,
+    PRODUCTION_FAMILIES,
+    REFERENCE_FAMILIES,
+    REFERENCE_LAYOUTS,
+    SOURCE_LAYOUT_TYPES,
+    StableEntryError,
+    assert_within_output_dir,
+    check_output_path,
+)
+
+RES_PREFIX = "res://"
+
+
+class CompilerError(Exception):
+    """Raised when a Godot artifact cannot be compiled."""
+
+
+def require_text(value: Any, label: str) -> str:
+    """Return ``value`` when it is a non-empty string, else fail closed."""
+    if not isinstance(value, str) or not value.strip():
+        raise CompilerError(f"{label} must be a non-empty string")
+    return value
+
+
+@dataclass(frozen=True)
+class GodotArtifact:
+    """The worker-facing result of a compile: exactly a type and a path."""
+
+    type: str
+    path: str
+
+    def to_dict(self) -> dict[str, str]:
+        """Return the ``godot_artifact`` object of a stable entry, nothing more."""
+        return {"type": self.type, "path": self.path}
+
+
+@dataclass(frozen=True)
+class CompileRequest:
+    """Everything a compiler is allowed to know about one artifact to build.
+
+    ``spec`` carries family-specific parameters (animation timing, nine-slice
+    margins, tile semantics). Its inner shape is owned by the concrete compiler;
+    the registry only requires that it is a mapping.
+    """
+
+    production_family: str
+    asset_id: str
+    source_layout_type: str
+    source_path: str
+    artifact_type: str
+    artifact_path: str
+    project_root: Path
+    spec: Mapping[str, Any] = field(default_factory=dict)
+
+    def validate(self) -> None:
+        """Fail closed on anything the frozen compatibility contract forbids."""
+        family = require_text(self.production_family, "production_family")
+        if family not in PRODUCTION_FAMILIES:
+            raise CompilerError(f"production_family is not allowed: {family}")
+        if family in REFERENCE_FAMILIES:
+            raise CompilerError(
+                f"production_family {family} is reference-only and compiles no "
+                "Godot artifact"
+            )
+        require_text(self.asset_id, "asset_id")
+
+        layout = require_text(self.source_layout_type, "source_layout_type")
+        if layout not in SOURCE_LAYOUT_TYPES:
+            raise CompilerError(f"source_layout_type is not allowed: {layout}")
+        if layout in REFERENCE_LAYOUTS:
+            raise CompilerError(
+                "a reference source_layout is never handed to a worker as a "
+                "runtime game asset and compiles no Godot artifact"
+            )
+
+        artifact_type = require_text(self.artifact_type, "artifact_type")
+        allowed = LAYOUT_ARTIFACT_TYPES[layout]
+        if artifact_type not in allowed:
+            raise CompilerError(
+                f"artifact_type for a {layout} source_layout must be one of: "
+                f"{', '.join(allowed)}; not {artifact_type}"
+            )
+
+        if not isinstance(self.project_root, Path):
+            raise CompilerError("project_root must be a Path")
+        if not isinstance(self.spec, Mapping):
+            raise CompilerError("spec must be a mapping")
+
+        for label, value in (
+            ("source_path", self.source_path),
+            ("artifact_path", self.artifact_path),
+        ):
+            require_text(value, label)
+            try:
+                check_output_path(
+                    value,
+                    production_family=family,
+                    asset_id=self.asset_id,
+                    label=label,
+                )
+            except StableEntryError as exc:
+                raise CompilerError(str(exc)) from exc
+
+    def _resolve(self, res_path: str, label: str) -> Path:
+        try:
+            return assert_within_output_dir(
+                self.project_root,
+                res_path[len(RES_PREFIX):],
+                production_family=self.production_family,
+                asset_id=self.asset_id,
+                label=label,
+            )
+        except StableEntryError as exc:
+            raise CompilerError(str(exc)) from exc
+
+    def source_file(self) -> Path:
+        """Resolve ``source_path`` on disk. Call only after :meth:`validate`."""
+        return self._resolve(self.source_path, "source_path")
+
+    def artifact_file(self) -> Path:
+        """Resolve ``artifact_path`` on disk. Call only after :meth:`validate`."""
+        return self._resolve(self.artifact_path, "artifact_path")
+
+
+@dataclass(frozen=True)
+class CompileReceipt:
+    """Internal record of one compile. Never part of the worker snapshot."""
+
+    compiler_id: str
+    compiler_version: int
+    production_family: str
+    asset_id: str
+    source_layout_type: str
+    source_path: str
+    artifact_type: str
+    artifact_path: str
+    details: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "compiler_id": self.compiler_id,
+            "compiler_version": self.compiler_version,
+            "production_family": self.production_family,
+            "asset_id": self.asset_id,
+            "source_layout_type": self.source_layout_type,
+            "source_path": self.source_path,
+            "artifact_type": self.artifact_type,
+            "artifact_path": self.artifact_path,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class CompileResult:
+    """A compiled artifact plus the receipt that stays behind it."""
+
+    godot_artifact: GodotArtifact
+    receipt: CompileReceipt
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "godot_artifact": self.godot_artifact.to_dict(),
+            "receipt": self.receipt.to_dict(),
+        }

--- a/skills/assets/_shared/asset_compiler/contract.py
+++ b/skills/assets/_shared/asset_compiler/contract.py
@@ -14,8 +14,10 @@ generation run and must never reach the worker snapshot, which stays exactly
 from __future__ import annotations
 
 from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any
 
 from ._stable_entry import (
@@ -27,9 +29,8 @@ from ._stable_entry import (
     StableEntryError,
     assert_within_output_dir,
     check_output_path,
+    resolve_res_path,
 )
-
-RES_PREFIX = "res://"
 
 
 class CompilerError(Exception):
@@ -41,6 +42,24 @@ def require_text(value: Any, label: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise CompilerError(f"{label} must be a non-empty string")
     return value
+
+
+def _frozen_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    """Return an unshared, read-only copy of a caller-supplied mapping.
+
+    Both mapping fields sit on frozen dataclasses that a compiler, its caller,
+    and a stored receipt all hold at once. A plain reference would make the
+    freeze decorative: the caller could still mutate a nested list and change
+    what a finished receipt says was produced. Deep-copying behind a
+    ``MappingProxyType`` makes the snapshot real.
+    """
+    if not isinstance(value, Mapping):
+        raise CompilerError(f"{label} must be a mapping")
+    try:
+        copied = deepcopy(dict(value))
+    except Exception as exc:  # noqa: BLE001 - surfaced as a compiler error
+        raise CompilerError(f"{label} must hold copyable plain data: {exc}") from exc
+    return MappingProxyType(copied)
 
 
 @dataclass(frozen=True)
@@ -61,7 +80,10 @@ class CompileRequest:
 
     ``spec`` carries family-specific parameters (animation timing, nine-slice
     margins, tile semantics). Its inner shape is owned by the concrete compiler;
-    the registry only requires that it is a mapping.
+    this layer only requires a mapping, and snapshots it at construction.
+
+    ``spec`` is excluded from ``__hash__`` because a mapping is unhashable; the
+    remaining fields identify the request, and ``__eq__`` still compares it.
     """
 
     production_family: str
@@ -71,7 +93,10 @@ class CompileRequest:
     artifact_type: str
     artifact_path: str
     project_root: Path
-    spec: Mapping[str, Any] = field(default_factory=dict)
+    spec: Mapping[str, Any] = field(default_factory=dict, hash=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "spec", _frozen_mapping(self.spec, "spec"))
 
     def validate(self) -> None:
         """Fail closed on anything the frozen compatibility contract forbids."""
@@ -104,8 +129,6 @@ class CompileRequest:
 
         if not isinstance(self.project_root, Path):
             raise CompilerError("project_root must be a Path")
-        if not isinstance(self.spec, Mapping):
-            raise CompilerError("spec must be a mapping")
 
         for label, value in (
             ("source_path", self.source_path),
@@ -126,7 +149,7 @@ class CompileRequest:
         try:
             return assert_within_output_dir(
                 self.project_root,
-                res_path[len(RES_PREFIX):],
+                resolve_res_path(self.project_root, res_path),
                 production_family=self.production_family,
                 asset_id=self.asset_id,
                 label=label,
@@ -139,13 +162,23 @@ class CompileRequest:
         return self._resolve(self.source_path, "source_path")
 
     def artifact_file(self) -> Path:
-        """Resolve ``artifact_path`` on disk. Call only after :meth:`validate`."""
+        """Resolve ``artifact_path`` on disk. Call only after :meth:`validate`.
+
+        Resolution follows symlinks, so it is re-run after a compiler returns
+        rather than reused: containment was first checked against a path whose
+        parent directories did not exist yet.
+        """
         return self._resolve(self.artifact_path, "artifact_path")
 
 
 @dataclass(frozen=True)
 class CompileReceipt:
-    """Internal record of one compile. Never part of the worker snapshot."""
+    """Internal record of one compile. Never part of the worker snapshot.
+
+    ``details`` is snapshotted at construction: the receipt records what one run
+    produced, so a compiler must not be able to edit it afterwards. It is
+    excluded from ``__hash__`` for the same reason as ``CompileRequest.spec``.
+    """
 
     compiler_id: str
     compiler_version: int
@@ -155,7 +188,10 @@ class CompileReceipt:
     source_path: str
     artifact_type: str
     artifact_path: str
-    details: Mapping[str, Any]
+    details: Mapping[str, Any] = field(hash=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "details", _frozen_mapping(self.details, "details"))
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -167,7 +203,7 @@ class CompileReceipt:
             "source_path": self.source_path,
             "artifact_type": self.artifact_type,
             "artifact_path": self.artifact_path,
-            "details": dict(self.details),
+            "details": deepcopy(dict(self.details)),
         }
 
 

--- a/skills/assets/_shared/asset_compiler/contract.py
+++ b/skills/assets/_shared/asset_compiler/contract.py
@@ -17,7 +17,6 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from types import MappingProxyType
 from typing import Any
 
 from ._stable_entry import (
@@ -44,22 +43,26 @@ def require_text(value: Any, label: str) -> str:
     return value
 
 
-def _frozen_mapping(value: Any, label: str) -> Mapping[str, Any]:
-    """Return an unshared, read-only copy of a caller-supplied mapping.
+def _snapshot_mapping(value: Any, label: str) -> dict[str, Any]:
+    """Return an unshared deep copy of a caller-supplied mapping.
 
-    Both mapping fields sit on frozen dataclasses that a compiler, its caller,
-    and a stored receipt all hold at once. A plain reference would make the
-    freeze decorative: the caller could still mutate a nested list and change
-    what a finished receipt says was produced. Deep-copying behind a
-    ``MappingProxyType`` makes the snapshot real.
+    The copy is what does the work: both mapping fields sit on frozen
+    dataclasses that a compiler, its caller, and a stored receipt all hold at
+    once, and copying is what stops a compiler from editing what a finished
+    receipt says it produced.
+
+    A plain dict, not a read-only view. Wrapping it in a ``MappingProxyType``
+    would only block rebinding a top-level key — a nested list stays mutable
+    through the proxy either way — while breaking ``deepcopy``, ``pickle``, and
+    ``dataclasses.asdict`` on every object that holds one, with a bare
+    ``TypeError`` that escapes this layer's ``CompilerError`` contract.
     """
     if not isinstance(value, Mapping):
         raise CompilerError(f"{label} must be a mapping")
     try:
-        copied = deepcopy(dict(value))
+        return deepcopy(dict(value))
     except Exception as exc:  # noqa: BLE001 - surfaced as a compiler error
         raise CompilerError(f"{label} must hold copyable plain data: {exc}") from exc
-    return MappingProxyType(copied)
 
 
 @dataclass(frozen=True)
@@ -80,7 +83,7 @@ class CompileRequest:
 
     ``spec`` carries family-specific parameters (animation timing, nine-slice
     margins, tile semantics). Its inner shape is owned by the concrete compiler;
-    this layer only requires a mapping, and snapshots it at construction.
+    this layer only requires a mapping, and deep-copies it at construction.
 
     ``spec`` is excluded from ``__hash__`` because a mapping is unhashable; the
     remaining fields identify the request, and ``__eq__`` still compares it.
@@ -96,7 +99,7 @@ class CompileRequest:
     spec: Mapping[str, Any] = field(default_factory=dict, hash=False)
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "spec", _frozen_mapping(self.spec, "spec"))
+        object.__setattr__(self, "spec", _snapshot_mapping(self.spec, "spec"))
 
     def validate(self) -> None:
         """Fail closed on anything the frozen compatibility contract forbids."""
@@ -149,7 +152,7 @@ class CompileRequest:
         try:
             return assert_within_output_dir(
                 self.project_root,
-                resolve_res_path(self.project_root, res_path),
+                resolve_res_path(self.project_root, res_path, label=label),
                 production_family=self.production_family,
                 asset_id=self.asset_id,
                 label=label,
@@ -175,7 +178,7 @@ class CompileRequest:
 class CompileReceipt:
     """Internal record of one compile. Never part of the worker snapshot.
 
-    ``details`` is snapshotted at construction: the receipt records what one run
+    ``details`` is deep-copied at construction: the receipt records what one run
     produced, so a compiler must not be able to edit it afterwards. It is
     excluded from ``__hash__`` for the same reason as ``CompileRequest.spec``.
     """
@@ -191,7 +194,7 @@ class CompileReceipt:
     details: Mapping[str, Any] = field(hash=False)
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "details", _frozen_mapping(self.details, "details"))
+        object.__setattr__(self, "details", _snapshot_mapping(self.details, "details"))
 
     def to_dict(self) -> dict[str, Any]:
         return {

--- a/skills/assets/_shared/asset_compiler/registry.py
+++ b/skills/assets/_shared/asset_compiler/registry.py
@@ -1,0 +1,162 @@
+"""Deterministic routing from a source layout and artifact type to a compiler.
+
+A route is keyed by the ``(source_layout.type, godot_artifact.type)`` pair, not
+by the layout alone: ``StyleBoxTexture`` is reachable from both ``single`` and
+``region_atlas``, and ``single`` also compiles to ``Texture2D``. A one-to-one
+layout-to-compiler map would reject those legal routes.
+
+Registration is checked against the frozen ``LAYOUT_ARTIFACT_TYPES`` relation,
+so a compiler cannot claim a pair the stable-entry schema would later refuse.
+Everything else fails closed: an unregistered pair, a mismatched type, a missing
+source, a compiler that raises, and a compiler that returns without writing its
+artifact are all a :class:`CompilerError`.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from ._stable_entry import LAYOUT_ARTIFACT_TYPES
+from .contract import (
+    CompileReceipt,
+    CompileRequest,
+    CompileResult,
+    CompilerError,
+    GodotArtifact,
+    require_text,
+)
+
+# A compiler produces its artifact on disk and returns its receipt details. It
+# does not build the worker-facing artifact object; the registry does, so no
+# compiler can widen the worker snapshot.
+Compiler = Callable[[CompileRequest], Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class CompilerRoute:
+    """One registered ``(layout, artifact type)`` to compiler binding."""
+
+    source_layout_type: str
+    artifact_type: str
+    compiler_id: str
+    compiler_version: int
+    compiler: Compiler
+
+    @property
+    def key(self) -> tuple[str, str]:
+        return (self.source_layout_type, self.artifact_type)
+
+
+class CompilerRegistry:
+    """Holds the routes an asset skill may compile through."""
+
+    def __init__(self) -> None:
+        self._routes: dict[tuple[str, str], CompilerRoute] = {}
+
+    def register(
+        self,
+        *,
+        source_layout_type: str,
+        artifact_type: str,
+        compiler_id: str,
+        compiler_version: int,
+        compiler: Compiler,
+    ) -> CompilerRoute:
+        """Bind one compiler to one layout/artifact pair."""
+        require_text(source_layout_type, "source_layout_type")
+        require_text(artifact_type, "artifact_type")
+        require_text(compiler_id, "compiler_id")
+        allowed = LAYOUT_ARTIFACT_TYPES.get(source_layout_type)
+        if allowed is None:
+            raise CompilerError(
+                f"source_layout_type compiles no Godot artifact: {source_layout_type}"
+            )
+        if artifact_type not in allowed:
+            raise CompilerError(
+                f"a {source_layout_type} source_layout may not compile to "
+                f"{artifact_type}; allowed: {', '.join(allowed)}"
+            )
+        if type(compiler_version) is not int or compiler_version < 1:
+            raise CompilerError("compiler_version must be a positive integer")
+        if not callable(compiler):
+            raise CompilerError("compiler must be callable")
+
+        key = (source_layout_type, artifact_type)
+        existing = self._routes.get(key)
+        if existing is not None:
+            raise CompilerError(
+                f"{source_layout_type} -> {artifact_type} is already registered to "
+                f"{existing.compiler_id}"
+            )
+
+        route = CompilerRoute(
+            source_layout_type=source_layout_type,
+            artifact_type=artifact_type,
+            compiler_id=compiler_id,
+            compiler_version=compiler_version,
+            compiler=compiler,
+        )
+        self._routes[key] = route
+        return route
+
+    def routes(self) -> tuple[CompilerRoute, ...]:
+        """Return every registered route, ordered by its routing key."""
+        return tuple(self._routes[key] for key in sorted(self._routes))
+
+    def resolve(self, source_layout_type: str, artifact_type: str) -> CompilerRoute:
+        """Return the route for one pair, or fail closed."""
+        route = self._routes.get((source_layout_type, artifact_type))
+        if route is None:
+            registered = ", ".join(
+                f"{key[0]} -> {key[1]}" for key in sorted(self._routes)
+            )
+            raise CompilerError(
+                f"no compiler is registered for {source_layout_type} -> "
+                f"{artifact_type}; registered: {registered or 'none'}"
+            )
+        return route
+
+    def compile(self, request: CompileRequest) -> CompileResult:
+        """Validate, route, run one compiler, and receipt the result."""
+        request.validate()
+        route = self.resolve(request.source_layout_type, request.artifact_type)
+
+        source_file = request.source_file()
+        if not source_file.is_file():
+            raise CompilerError(f"source_path not found: {request.source_path}")
+        artifact_file = request.artifact_file()
+
+        try:
+            details = route.compiler(request)
+        except CompilerError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - surfaced as a compiler error
+            raise CompilerError(f"{route.compiler_id} failed: {exc}") from exc
+
+        if not isinstance(details, Mapping):
+            raise CompilerError(
+                f"{route.compiler_id} must return a mapping of receipt details"
+            )
+        if not artifact_file.is_file():
+            raise CompilerError(
+                f"{route.compiler_id} returned without writing {request.artifact_path}"
+            )
+
+        return CompileResult(
+            godot_artifact=GodotArtifact(
+                type=request.artifact_type,
+                path=request.artifact_path,
+            ),
+            receipt=CompileReceipt(
+                compiler_id=route.compiler_id,
+                compiler_version=route.compiler_version,
+                production_family=request.production_family,
+                asset_id=request.asset_id,
+                source_layout_type=request.source_layout_type,
+                source_path=request.source_path,
+                artifact_type=request.artifact_type,
+                artifact_path=request.artifact_path,
+                details=dict(details),
+            ),
+        )

--- a/skills/assets/_shared/asset_compiler/registry.py
+++ b/skills/assets/_shared/asset_compiler/registry.py
@@ -8,13 +8,15 @@ layout-to-compiler map would reject those legal routes.
 Registration is checked against the frozen ``LAYOUT_ARTIFACT_TYPES`` relation,
 so a compiler cannot claim a pair the stable-entry schema would later refuse.
 Everything else fails closed: an unregistered pair, a mismatched type, a missing
-source, a compiler that raises, and a compiler that returns without writing its
-artifact are all a :class:`CompilerError`.
+source, a compiler that raises, a compiler that publishes its source image as
+the artifact, and a compiler that returns without rebuilding its artifact are
+all a :class:`CompilerError`.
 """
 from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Callable
 
 from ._stable_entry import LAYOUT_ARTIFACT_TYPES
@@ -32,16 +34,47 @@ from .contract import (
 # compiler can widen the worker snapshot.
 Compiler = Callable[[CompileRequest], Mapping[str, Any]]
 
+# The artifact types Godot's default import already produces from the source
+# file itself, and therefore the only ones a route may declare it writes no file
+# for. Every other type must produce a new file at a path distinct from its
+# source: a compiler that hands back its own source image is publishing a PNG as
+# the resource a worker was promised -- "Declaring the source image as the
+# artifact is the exact shortcut this mapping exists to reject"
+# (tools/asset_stable_entry.py). Existence alone cannot catch that, because the
+# source file satisfies it.
+SOURCE_IS_ARTIFACT_TYPES = ("Texture2D",)
+
+
+def _fingerprint(path: Path) -> tuple[int, int] | None:
+    """Return a change marker for ``path``, or ``None`` when it is absent.
+
+    Size alone misses a same-length rewrite and the modification time alone
+    misses a rewrite inside the clock's resolution, so both are compared.
+    Rewriting a file always advances ``st_mtime_ns``, so an unchanged marker
+    means the compiler did not touch the artifact this run.
+    """
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (stat.st_size, stat.st_mtime_ns)
+
 
 @dataclass(frozen=True)
 class CompilerRoute:
-    """One registered ``(layout, artifact type)`` to compiler binding."""
+    """One registered ``(layout, artifact type)`` to compiler binding.
+
+    ``writes_artifact`` is the opt-out for a route Godot's own import already
+    serves. A writing route must rebuild a file distinct from its source; a
+    non-writing route must name the source itself and change nothing.
+    """
 
     source_layout_type: str
     artifact_type: str
     compiler_id: str
     compiler_version: int
     compiler: Compiler
+    writes_artifact: bool = True
 
     @property
     def key(self) -> tuple[str, str]:
@@ -62,6 +95,7 @@ class CompilerRegistry:
         compiler_id: str,
         compiler_version: int,
         compiler: Compiler,
+        writes_artifact: bool = True,
     ) -> CompilerRoute:
         """Bind one compiler to one layout/artifact pair."""
         require_text(source_layout_type, "source_layout_type")
@@ -81,6 +115,14 @@ class CompilerRegistry:
             raise CompilerError("compiler_version must be a positive integer")
         if not callable(compiler):
             raise CompilerError("compiler must be callable")
+        if type(writes_artifact) is not bool:
+            raise CompilerError("writes_artifact must be a bool")
+        if not writes_artifact and artifact_type not in SOURCE_IS_ARTIFACT_TYPES:
+            raise CompilerError(
+                f"{artifact_type} must compile a new file; only "
+                f"{', '.join(SOURCE_IS_ARTIFACT_TYPES)} may be registered as a "
+                "non-writing route"
+            )
 
         key = (source_layout_type, artifact_type)
         existing = self._routes.get(key)
@@ -96,6 +138,7 @@ class CompilerRegistry:
             compiler_id=compiler_id,
             compiler_version=compiler_version,
             compiler=compiler,
+            writes_artifact=writes_artifact,
         )
         self._routes[key] = route
         return route
@@ -125,7 +168,20 @@ class CompilerRegistry:
         source_file = request.source_file()
         if not source_file.is_file():
             raise CompilerError(f"source_path not found: {request.source_path}")
-        artifact_file = request.artifact_file()
+
+        paths_match = request.artifact_path == request.source_path
+        if route.writes_artifact and paths_match:
+            raise CompilerError(
+                f"{route.compiler_id} must compile a new file; artifact_path may "
+                f"not be the source image itself ({request.artifact_path})"
+            )
+        if not route.writes_artifact and not paths_match:
+            raise CompilerError(
+                f"{route.compiler_id} writes no file, so artifact_path must equal "
+                f"source_path; got {request.artifact_path} instead of "
+                f"{request.source_path}"
+            )
+        before = _fingerprint(request.artifact_file())
 
         try:
             details = route.compiler(request)
@@ -138,9 +194,21 @@ class CompilerRegistry:
             raise CompilerError(
                 f"{route.compiler_id} must return a mapping of receipt details"
             )
-        if not artifact_file.is_file():
+
+        # Re-resolve rather than reuse: the first containment check ran against a
+        # path whose parent directories did not exist yet, so no symlink could be
+        # followed. Anything the compiler created in between is checked now.
+        artifact_file = request.artifact_file()
+        after = _fingerprint(artifact_file)
+        if after is None or not artifact_file.is_file():
             raise CompilerError(
                 f"{route.compiler_id} returned without writing {request.artifact_path}"
+            )
+        if route.writes_artifact and after == before:
+            raise CompilerError(
+                f"{route.compiler_id} returned without rebuilding "
+                f"{request.artifact_path}; the file on disk is unchanged from an "
+                "earlier run"
             )
 
         return CompileResult(

--- a/skills/assets/_shared/asset_compiler/registry.py
+++ b/skills/assets/_shared/asset_compiler/registry.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass
+from hashlib import sha256
 from pathlib import Path
 from typing import Any, Callable
 
@@ -45,19 +46,36 @@ Compiler = Callable[[CompileRequest], Mapping[str, Any]]
 SOURCE_IS_ARTIFACT_TYPES = ("Texture2D",)
 
 
-def _fingerprint(path: Path) -> tuple[int, int] | None:
-    """Return a change marker for ``path``, or ``None`` when it is absent.
+def _content_digest(path: Path) -> bytes | None:
+    """Return a content digest, or ``None`` when ``path`` cannot be read.
 
-    Size alone misses a same-length rewrite and the modification time alone
-    misses a rewrite inside the clock's resolution, so both are compared.
-    Rewriting a file always advances ``st_mtime_ns``, so an unchanged marker
-    means the compiler did not touch the artifact this run.
+    Only non-writing routes use this check. They are allowed to reuse their
+    source as the artifact, so existence cannot show whether their compiler
+    clobbered that source. Hashing gives this narrow route class a real
+    fail-closed guard without making writing compilers read large artifacts
+    twice merely to detect a no-op.
     """
+    digest = sha256()
     try:
-        stat = path.stat()
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
     except OSError:
         return None
-    return (stat.st_size, stat.st_mtime_ns)
+    return digest.digest()
+
+
+def _is_same_file(left: Path, right: Path) -> bool:
+    """True when two paths name one file: a hard link, or a case alias.
+
+    Distinct path strings are not distinct files. ``os.link`` gives a compiler a
+    second name for its source image, and on a case-insensitive filesystem
+    ``Hero.png`` and ``hero.png`` are already one file without any linking.
+    """
+    try:
+        return left.samefile(right)
+    except OSError:
+        return False
 
 
 @dataclass(frozen=True)
@@ -181,7 +199,25 @@ class CompilerRegistry:
                 f"source_path; got {request.artifact_path} instead of "
                 f"{request.source_path}"
             )
-        before = _fingerprint(request.artifact_file())
+        artifact_file = request.artifact_file()
+        if route.writes_artifact:
+            if _is_same_file(source_file, artifact_file):
+                raise CompilerError(
+                    f"{route.compiler_id} may not publish source_path as "
+                    f"artifact_path ({request.artifact_path})"
+                )
+            try:
+                artifact_file.unlink(missing_ok=True)
+            except OSError as exc:
+                raise CompilerError(
+                    f"{route.compiler_id} cannot clear prior artifact "
+                    f"{request.artifact_path}: {exc}"
+                ) from exc
+            source_digest = None
+        else:
+            source_digest = _content_digest(source_file)
+            if source_digest is None:
+                raise CompilerError(f"source_path cannot be read: {request.source_path}")
 
         try:
             details = route.compiler(request)
@@ -199,16 +235,22 @@ class CompilerRegistry:
         # path whose parent directories did not exist yet, so no symlink could be
         # followed. Anything the compiler created in between is checked now.
         artifact_file = request.artifact_file()
-        after = _fingerprint(artifact_file)
-        if after is None or not artifact_file.is_file():
+        if not artifact_file.is_file():
             raise CompilerError(
                 f"{route.compiler_id} returned without writing {request.artifact_path}"
             )
-        if route.writes_artifact and after == before:
+        source_file = request.source_file()
+        if not source_file.is_file():
+            raise CompilerError(f"source_path not found after compilation: {request.source_path}")
+        if route.writes_artifact and _is_same_file(source_file, artifact_file):
             raise CompilerError(
-                f"{route.compiler_id} returned without rebuilding "
-                f"{request.artifact_path}; the file on disk is unchanged from an "
-                "earlier run"
+                f"{route.compiler_id} may not publish source_path as "
+                f"artifact_path ({request.artifact_path})"
+            )
+        if not route.writes_artifact and _content_digest(source_file) != source_digest:
+            raise CompilerError(
+                f"{route.compiler_id} writes no artifact and must not modify "
+                f"source_path ({request.source_path})"
             )
 
         return CompileResult(

--- a/skills/assets/_shared/asset_compiler/texture2d.py
+++ b/skills/assets/_shared/asset_compiler/texture2d.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .contract import CompileRequest
+from .contract import CompileRequest, CompilerError
 from .registry import CompilerRegistry, CompilerRoute
 
 COMPILER_ID = "texture2d_default_import"
@@ -28,6 +28,11 @@ COMPILER_VERSION = 1
 
 def compile_texture2d(request: CompileRequest) -> dict[str, Any]:
     """Record that Godot's default import already produced the artifact."""
+    if request.artifact_path != request.source_path:
+        raise CompilerError(
+            "texture2d_default_import writes no file, so artifact_path must equal "
+            "source_path"
+        )
     return {"mode": "godot_default_import"}
 
 

--- a/skills/assets/_shared/asset_compiler/texture2d.py
+++ b/skills/assets/_shared/asset_compiler/texture2d.py
@@ -1,0 +1,43 @@
+"""The ``single`` to ``Texture2D`` route, served by Godot's default import.
+
+Godot already imports a plain image file as a ``Texture2D``, so this route
+writes nothing: the compiled artifact *is* the source image. It exists so the
+pair is a registered, receipted, validated outcome instead of an unregistered
+combination, and so the generic registry checks — stable-path containment and
+artifact existence — still run for it.
+
+v1 adds no texture-import profile system. Import settings stay Godot's defaults
+plus the project-wide pixel-art baseline; per-texture mipmap, repeat,
+compression, and filtering choices remain worker decisions.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import CompileRequest, CompilerError
+from .registry import CompilerRegistry, CompilerRoute
+
+COMPILER_ID = "texture2d_default_import"
+COMPILER_VERSION = 1
+
+
+def compile_texture2d(request: CompileRequest) -> dict[str, Any]:
+    """Confirm the artifact is the default-imported source image itself."""
+    if request.artifact_path != request.source_path:
+        raise CompilerError(
+            "a Texture2D artifact is the default-imported source image, so "
+            f"artifact_path must equal source_path; got {request.artifact_path} "
+            f"instead of {request.source_path}"
+        )
+    return {"mode": "godot_default_import"}
+
+
+def register_into(registry: CompilerRegistry) -> CompilerRoute:
+    """Register this route on ``registry``."""
+    return registry.register(
+        source_layout_type="single",
+        artifact_type="Texture2D",
+        compiler_id=COMPILER_ID,
+        compiler_version=COMPILER_VERSION,
+        compiler=compile_texture2d,
+    )

--- a/skills/assets/_shared/asset_compiler/texture2d.py
+++ b/skills/assets/_shared/asset_compiler/texture2d.py
@@ -6,6 +6,11 @@ pair is a registered, receipted, validated outcome instead of an unregistered
 combination, and so the generic registry checks — stable-path containment and
 artifact existence — still run for it.
 
+It registers with ``writes_artifact=False``, which is what makes
+``artifact_path == source_path`` legal here and rejected everywhere else. The
+registry enforces both halves of that rule; this module only has to declare
+which side it is on.
+
 v1 adds no texture-import profile system. Import settings stay Godot's defaults
 plus the project-wide pixel-art baseline; per-texture mipmap, repeat,
 compression, and filtering choices remain worker decisions.
@@ -14,7 +19,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .contract import CompileRequest, CompilerError
+from .contract import CompileRequest
 from .registry import CompilerRegistry, CompilerRoute
 
 COMPILER_ID = "texture2d_default_import"
@@ -22,13 +27,7 @@ COMPILER_VERSION = 1
 
 
 def compile_texture2d(request: CompileRequest) -> dict[str, Any]:
-    """Confirm the artifact is the default-imported source image itself."""
-    if request.artifact_path != request.source_path:
-        raise CompilerError(
-            "a Texture2D artifact is the default-imported source image, so "
-            f"artifact_path must equal source_path; got {request.artifact_path} "
-            f"instead of {request.source_path}"
-        )
+    """Record that Godot's default import already produced the artifact."""
     return {"mode": "godot_default_import"}
 
 
@@ -40,4 +39,5 @@ def register_into(registry: CompilerRegistry) -> CompilerRoute:
         compiler_id=COMPILER_ID,
         compiler_version=COMPILER_VERSION,
         compiler=compile_texture2d,
+        writes_artifact=False,
     )

--- a/skills/assets/_shared/godot-artifact-compiler-contract.md
+++ b/skills/assets/_shared/godot-artifact-compiler-contract.md
@@ -37,19 +37,21 @@ Two rules make "the compiler produced the artifact" mean something, because a
 generated asset overwrites a stable path in place and the artifact usually
 already exists from an earlier run:
 
-- **A writing route must rebuild.** The registry fingerprints the artifact's
-  size and modification time before and after the compiler runs, and rejects an
-  unchanged file. Otherwise a compiler that silently no-ops passes off the
-  previous run's bytes as this run's result.
+- **A writing route must replace the old artifact.** The registry removes an
+  existing artifact before the compiler runs and requires a new file after it
+  returns. Otherwise a compiler that silently no-ops passes off the previous
+  run's bytes as this run's result. This does not rely on filesystem timestamp
+  precision, so a same-byte deterministic rebuild remains valid.
 - **A writing route must not name its source.** `artifact_path` may not equal
-  `source_path`, so a compiler cannot publish its own source image as the
+  `source_path` or resolve to the same file, so a compiler cannot publish its
+  own source image (including through a hard link or case alias) as the
   resource a worker was promised. A file-existence check alone cannot catch
   this: the source file satisfies it.
 
 `writes_artifact=False` is the explicit opt-out, allowed only for the artifact
 types in `SOURCE_IS_ARTIFACT_TYPES` — the ones Godot's default import already
 produces from the source file itself. Such a route must name its source, and
-changes nothing.
+the registry rejects it if its compiler changes that source.
 
 ## Interface
 
@@ -69,10 +71,11 @@ family-specific `spec` mapping whose inner shape each concrete compiler owns.
 `CompileResult` is `godot_artifact` plus `receipt`.
 
 Both mapping fields — `CompileRequest.spec` and `CompileReceipt.details` — are
-deep-copied behind a read-only view at construction. They sit on frozen
-dataclasses that a caller, a compiler, and a stored receipt all hold at once, so
-a shared reference would make the freeze decorative and let a compiler edit what
-a finished receipt says it produced.
+deep-copied at construction. They sit on frozen dataclasses that a caller, a
+compiler, and a stored receipt all hold at once, so a shared reference would
+make the freeze decorative and let a compiler edit what a finished receipt says
+it produced. The copies deliberately remain ordinary mappings so standard
+dataclass, copy, and pickle operations stay usable.
 
 ## Fail-closed rules
 
@@ -87,13 +90,12 @@ layer surfaces — when:
   temporary `work/` workspace, or resolves out of the project through a symlink;
 - no compiler is registered for the pair;
 - the source file does not exist;
-- a writing route's `artifact_path` equals its `source_path`, or a non-writing
-  route's does not;
+- a writing route's `artifact_path` equals or resolves to its `source_path`, a
+  non-writing route's does not, or a non-writing compiler modifies its source;
 - the compiler raises — its own `CompilerError` propagates unchanged, any other
   exception is wrapped with the compiler id so nothing escapes as a traceback;
 - the compiler returns something other than a mapping;
-- the compiler returns without writing its artifact, or leaves it unchanged from
-  an earlier run.
+- the compiler returns without replacing its artifact for this run.
 
 Path containment is re-checked after the compiler returns, not reused from
 before it ran: the first check resolved a path whose parent directories did not

--- a/skills/assets/_shared/godot-artifact-compiler-contract.md
+++ b/skills/assets/_shared/godot-artifact-compiler-contract.md
@@ -22,13 +22,34 @@ relation is not one-to-one:
 | `theme_recipe` | `Theme` |
 | `tile_atlas` | `TileSet` |
 
-That table is not restated in code. `CompilerRegistry` imports the frozen
-`LAYOUT_ARTIFACT_TYPES` relation from `tools/asset_stable_entry.py`, so a route
-the stable-entry schema would reject cannot be registered in the first place and
-the two can never drift.
+`CompilerRegistry` does not restate that relation: it imports the frozen
+`LAYOUT_ARTIFACT_TYPES` from `tools/asset_stable_entry.py`, so a route the
+stable-entry schema would reject cannot be registered in the first place. The
+table above is the human-readable mirror, and `tests/assets/` asserts it row for
+row against the imported relation so it cannot go stale.
 
 A `reference` source layout, and any reference-only production family, compiles
 no Godot artifact at all.
+
+## The artifact must be produced by this run
+
+Two rules make "the compiler produced the artifact" mean something, because a
+generated asset overwrites a stable path in place and the artifact usually
+already exists from an earlier run:
+
+- **A writing route must rebuild.** The registry fingerprints the artifact's
+  size and modification time before and after the compiler runs, and rejects an
+  unchanged file. Otherwise a compiler that silently no-ops passes off the
+  previous run's bytes as this run's result.
+- **A writing route must not name its source.** `artifact_path` may not equal
+  `source_path`, so a compiler cannot publish its own source image as the
+  resource a worker was promised. A file-existence check alone cannot catch
+  this: the source file satisfies it.
+
+`writes_artifact=False` is the explicit opt-out, allowed only for the artifact
+types in `SOURCE_IS_ARTIFACT_TYPES` — the ones Godot's default import already
+produces from the source file itself. Such a route must name its source, and
+changes nothing.
 
 ## Interface
 
@@ -47,6 +68,12 @@ family-specific `spec` mapping whose inner shape each concrete compiler owns.
 
 `CompileResult` is `godot_artifact` plus `receipt`.
 
+Both mapping fields — `CompileRequest.spec` and `CompileReceipt.details` — are
+deep-copied behind a read-only view at construction. They sit on frozen
+dataclasses that a caller, a compiler, and a stored receipt all hold at once, so
+a shared reference would make the freeze decorative and let a compiler edit what
+a finished receipt says it produced.
+
 ## Fail-closed rules
 
 `CompilerRegistry.compile()` raises `CompilerError` — the only error type this
@@ -57,17 +84,25 @@ layer surfaces — when:
 - the source layout, or the family, is reference-only;
 - a source or artifact path is not a file under
   `res://assets/generated/<production_family>/<asset_id>/`, or depends on the
-  temporary `work/` workspace;
+  temporary `work/` workspace, or resolves out of the project through a symlink;
 - no compiler is registered for the pair;
 - the source file does not exist;
+- a writing route's `artifact_path` equals its `source_path`, or a non-writing
+  route's does not;
 - the compiler raises — its own `CompilerError` propagates unchanged, any other
   exception is wrapped with the compiler id so nothing escapes as a traceback;
 - the compiler returns something other than a mapping;
-- the compiler returns without writing its artifact.
+- the compiler returns without writing its artifact, or leaves it unchanged from
+  an earlier run.
+
+Path containment is re-checked after the compiler returns, not reused from
+before it ran: the first check resolved a path whose parent directories did not
+exist yet, so no symlink could be followed.
 
 Registration itself fails closed too: an incompatible pair, a non-callable
-compiler, a non-positive version, and a second compiler for an already
-registered pair are all rejected.
+compiler, a non-positive version, a `writes_artifact=False` claim on a type that
+must compile a new file, and a second compiler for an already registered pair
+are all rejected.
 
 ## Receipt boundary
 
@@ -81,11 +116,11 @@ storage location; nothing worker-facing may depend on one.
 
 ## Texture2D
 
-`single -> Texture2D` is served by `asset_compiler/texture2d.py` and writes
-nothing: Godot's default import already turns the image into a `Texture2D`, so
-the artifact path must equal the source path. The route exists so the pair is a
-registered, validated, receipted outcome rather than an unregistered
-combination.
+`single -> Texture2D` is served by `asset_compiler/texture2d.py`, registered
+with `writes_artifact=False`: Godot's default import already turns the image
+into a `Texture2D`, so the artifact path must equal the source path. The route
+exists so the pair is a registered, validated, receipted outcome rather than an
+unregistered combination.
 
 v1 introduces no general texture-import profile system. Import settings stay
 Godot's defaults plus the project-wide pixel-art baseline; per-texture mipmap,
@@ -98,3 +133,16 @@ independently triggerable. The registry holds no concrete `AtlasTexture`,
 `SpriteFrames`, `Theme`, `StyleBoxTexture`, or `TileSet` compiler; each lands
 with its own asset skill and registers itself through
 `CompilerRegistry.register()`.
+
+There is no module-level default registry instance. A caller builds one with
+`build_default_registry()` and every family compiler for that run registers into
+that instance. A process-global would let one caller's registrations be
+invisible to a second caller holding a freshly built registry, and — because
+`register()` rejects a duplicate pair outright — would turn a re-imported
+self-registering module into an import-time crash.
+
+`asset_compiler/` imports `tools/asset_stable_entry.py` through a path bridge
+resolved relative to the repository root, so it is importable from a source
+checkout only. `tools/publish.py` does not deploy `skills/assets/` yet; the
+bridge asserts the directory and names it in the error rather than failing as a
+bare `ModuleNotFoundError`.

--- a/skills/assets/_shared/godot-artifact-compiler-contract.md
+++ b/skills/assets/_shared/godot-artifact-compiler-contract.md
@@ -1,0 +1,100 @@
+# Godot Artifact Compiler Contract
+
+The single source of truth for how any deterministic Godot artifact compiler is
+invoked, what it returns, how it fails, and what it is allowed to hand a worker.
+Implemented by `asset_compiler/` next to this document.
+
+This is the L2 step of the readiness ladder: L1 produces source images, L2
+compiles the native Godot resource, L3-L4 verify it. A compiler never registers
+an asset, reads `ASSETS.md`, or touches manifests — that stays with `/gm-asset`.
+
+## Routing
+
+A compiler is registered for one `(source_layout.type, godot_artifact.type)`
+pair. The pair — not the layout alone — is the routing key, because the
+relation is not one-to-one:
+
+| Source layout | Compilable artifact types |
+|---|---|
+| `single` | `Texture2D`, `StyleBoxTexture` |
+| `grid_sheet` | `SpriteFrames` |
+| `region_atlas` | `AtlasTexture`, `StyleBoxTexture` |
+| `theme_recipe` | `Theme` |
+| `tile_atlas` | `TileSet` |
+
+That table is not restated in code. `CompilerRegistry` imports the frozen
+`LAYOUT_ARTIFACT_TYPES` relation from `tools/asset_stable_entry.py`, so a route
+the stable-entry schema would reject cannot be registered in the first place and
+the two can never drift.
+
+A `reference` source layout, and any reference-only production family, compiles
+no Godot artifact at all.
+
+## Interface
+
+```python
+Compiler = Callable[[CompileRequest], Mapping[str, Any]]
+```
+
+A compiler writes its artifact to `request.artifact_path` and returns its
+receipt details. It does not build the worker-facing artifact object; the
+registry does. That asymmetry is the mechanism behind the worker-snapshot
+boundary below.
+
+`CompileRequest` carries `production_family`, `asset_id`, `source_layout_type`,
+`source_path`, `artifact_type`, `artifact_path`, `project_root`, and a
+family-specific `spec` mapping whose inner shape each concrete compiler owns.
+
+`CompileResult` is `godot_artifact` plus `receipt`.
+
+## Fail-closed rules
+
+`CompilerRegistry.compile()` raises `CompilerError` — the only error type this
+layer surfaces — when:
+
+- the production family, source layout, or artifact type is unknown;
+- the artifact type is not compatible with the source layout;
+- the source layout, or the family, is reference-only;
+- a source or artifact path is not a file under
+  `res://assets/generated/<production_family>/<asset_id>/`, or depends on the
+  temporary `work/` workspace;
+- no compiler is registered for the pair;
+- the source file does not exist;
+- the compiler raises — its own `CompilerError` propagates unchanged, any other
+  exception is wrapped with the compiler id so nothing escapes as a traceback;
+- the compiler returns something other than a mapping;
+- the compiler returns without writing its artifact.
+
+Registration itself fails closed too: an incompatible pair, a non-callable
+compiler, a non-positive version, and a second compiler for an already
+registered pair are all rejected.
+
+## Receipt boundary
+
+`godot_artifact` is exactly `{type, path}`, built by the registry from the
+request. Compiler identity, version, and internal findings live in
+`CompileReceipt` and never widen the worker snapshot — a compiler cannot add a
+field to the artifact even by returning one, because it never constructs it.
+
+Receipts are returned to the caller. This layer does not define a receipt
+storage location; nothing worker-facing may depend on one.
+
+## Texture2D
+
+`single -> Texture2D` is served by `asset_compiler/texture2d.py` and writes
+nothing: Godot's default import already turns the image into a `Texture2D`, so
+the artifact path must equal the source path. The route exists so the pair is a
+registered, validated, receipted outcome rather than an unregistered
+combination.
+
+v1 introduces no general texture-import profile system. Import settings stay
+Godot's defaults plus the project-wide pixel-art baseline; per-texture mipmap,
+repeat, compression, and filtering choices remain worker decisions.
+
+## Boundary
+
+`_shared/` holds cross-skill material only. It has no `SKILL.md` and is not
+independently triggerable. The registry holds no concrete `AtlasTexture`,
+`SpriteFrames`, `Theme`, `StyleBoxTexture`, or `TileSet` compiler; each lands
+with its own asset skill and registers itself through
+`CompilerRegistry.register()`.

--- a/tests/assets/test_asset_compiler_contract_docs.py
+++ b/tests/assets/test_asset_compiler_contract_docs.py
@@ -1,0 +1,62 @@
+"""Bind the compiler contract doc to the code it describes.
+
+The routing table in `godot-artifact-compiler-contract.md` is a human-readable
+mirror of the frozen `LAYOUT_ARTIFACT_TYPES` relation. The registry tests walk
+that relation dynamically, so they stay green when it is extended — only these
+assertions catch the doc going stale.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
+CONTRACT_DOC = SHARED_DIR / "godot-artifact-compiler-contract.md"
+sys.path.insert(0, str(SHARED_DIR))
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from asset_compiler import SOURCE_IS_ARTIFACT_TYPES  # noqa: E402
+from asset_stable_entry import LAYOUT_ARTIFACT_TYPES  # noqa: E402
+
+_ROW = re.compile(r"^\|\s*`(?P<layout>[a-z_]+)`\s*\|(?P<types>[^|]+)\|\s*$")
+
+
+def _documented_relation() -> dict[str, tuple[str, ...]]:
+    relation: dict[str, tuple[str, ...]] = {}
+    for line in CONTRACT_DOC.read_text(encoding="utf-8").splitlines():
+        match = _ROW.match(line)
+        if match is None:
+            continue
+        relation[match.group("layout")] = tuple(
+            cell.strip().strip("`") for cell in match.group("types").split(",")
+        )
+    return relation
+
+
+def test_documented_routing_table_matches_the_frozen_relation():
+    assert _documented_relation() == LAYOUT_ARTIFACT_TYPES
+
+
+def test_doc_states_the_rules_the_registry_enforces():
+    doc = CONTRACT_DOC.read_text(encoding="utf-8")
+    for claim in (
+        "LAYOUT_ARTIFACT_TYPES",
+        "SOURCE_IS_ARTIFACT_TYPES",
+        "writes_artifact=False",
+        "build_default_registry()",
+        "CompilerError",
+    ):
+        assert claim in doc, f"the contract doc no longer mentions {claim}"
+    # The doc must not promise a module-level registry the package removed.
+    assert "DEFAULT_REGISTRY" not in doc
+
+
+def test_doc_names_every_type_allowed_to_skip_writing():
+    doc = CONTRACT_DOC.read_text(encoding="utf-8")
+    for artifact_type in SOURCE_IS_ARTIFACT_TYPES:
+        assert f"`{artifact_type}`" in doc
+
+
+def test_shared_has_no_skill_md():
+    # _shared holds cross-skill material and is not independently triggerable.
+    assert not (SHARED_DIR / "SKILL.md").exists()

--- a/tests/assets/test_asset_compiler_registry.py
+++ b/tests/assets/test_asset_compiler_registry.py
@@ -1,8 +1,10 @@
 """Routing, fail-closed, and boundary tests for the shared compiler registry."""
 import os
+import pickle
 import subprocess
 import sys
-from dataclasses import replace
+from copy import deepcopy
+from dataclasses import asdict, replace
 from pathlib import Path
 
 import pytest
@@ -21,6 +23,7 @@ from asset_compiler import (  # noqa: E402
     build_default_registry,
     texture2d,
 )
+from asset_compiler._stable_entry import StableEntryError, resolve_res_path  # noqa: E402
 from asset_stable_entry import (  # noqa: E402
     GODOT_ARTIFACT_KEYS,
     LAYOUT_ARTIFACT_TYPES,
@@ -333,11 +336,11 @@ def test_no_op_compiler_cannot_pass_off_a_previous_runs_artifact(project):
 
     registry = CompilerRegistry()
     _register(registry, "single", "StyleBoxTexture", compiler=lambda request: {})
-    with pytest.raises(CompilerError, match="unchanged from an earlier run"):
+    with pytest.raises(CompilerError, match="returned without writing"):
         registry.compile(
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )
-    assert stale.read_bytes() == b"STALE-FROM-RUN-1"
+    assert not stale.exists()
 
 
 def test_rebuilding_over_an_existing_artifact_is_accepted(project):
@@ -352,8 +355,8 @@ def test_rebuilding_over_an_existing_artifact_is_accepted(project):
 
 
 def test_same_size_rewrite_is_accepted(project):
-    # The guard compares size and st_mtime_ns, so a byte-count-preserving
-    # rebuild must not be mistaken for a no-op.
+    # Replacing the old path before compilation makes this independent of the
+    # filesystem timestamp resolution.
     (project / "assets/generated/ui-kit/panel/panel.tres").write_bytes(b"AAA")
 
     registry = CompilerRegistry()
@@ -386,7 +389,47 @@ def test_a_writing_route_may_not_hand_back_its_source_image(project):
         artifact_path="res://assets/generated/character-bundle/hero/hero.png",
         project_root=project,
     )
-    with pytest.raises(CompilerError, match="may not be the source image itself"):
+    with pytest.raises(CompilerError, match="must compile a new file"):
+        registry.compile(request)
+
+
+def test_a_writing_route_may_not_hard_link_its_source_as_the_artifact(project):
+    def links_the_source(request):
+        os.link(request.source_file(), request.artifact_file())
+        return {}
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=links_the_source)
+    with pytest.raises(CompilerError, match="may not publish source_path"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+
+def test_a_non_writing_route_may_not_modify_its_source(project):
+    def clobbers_the_source(request):
+        request.source_file().write_bytes(b"CLOBBERED")
+        return {}
+
+    registry = CompilerRegistry()
+    registry.register(
+        source_layout_type="single",
+        artifact_type="Texture2D",
+        compiler_id="unsafe_default_import",
+        compiler_version=1,
+        compiler=clobbers_the_source,
+        writes_artifact=False,
+    )
+    request = CompileRequest(
+        production_family="ui-kit",
+        asset_id="panel",
+        source_layout_type="single",
+        source_path="res://assets/generated/ui-kit/panel/panel.png",
+        artifact_type="Texture2D",
+        artifact_path="res://assets/generated/ui-kit/panel/panel.png",
+        project_root=project,
+    )
+    with pytest.raises(CompilerError, match="must not modify source_path"):
         registry.compile(request)
 
 
@@ -501,6 +544,13 @@ def test_texture2d_rejects_a_separate_artifact_path(project):
         )
 
 
+def test_texture2d_compiler_rejects_a_separate_artifact_path_directly(project):
+    with pytest.raises(CompilerError, match="must equal source_path"):
+        texture2d.compile_texture2d(
+            _make_request(project, layout="single", artifact_type="Texture2D")
+        )
+
+
 def test_default_registry_ships_only_the_texture2d_route():
     # No concrete AtlasTexture, SpriteFrames, Theme, StyleBoxTexture, or TileSet
     # compiler belongs to the shared layer; each lands with its asset skill.
@@ -516,6 +566,29 @@ def test_each_build_returns_an_independent_registry():
     _register(first, "grid_sheet", "SpriteFrames")
     assert len(first.routes()) == 2
     assert len(build_default_registry().routes()) == 1
+
+
+def test_relative_project_root_compiles_without_double_anchoring(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    project = Path("myproj")
+    source = project / "assets" / "generated" / "ui-kit" / "panel" / "panel.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"png")
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    result = registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+
+    assert result.godot_artifact.path.endswith("/panel.tres")
+    assert (project / "assets/generated/ui-kit/panel/panel.tres").is_file()
+
+
+@pytest.mark.parametrize("path", ["", "assets/generated/ui-kit/panel/panel.png", "/etc/passwd"])
+def test_exported_resolver_rejects_non_resource_paths(project, path):
+    with pytest.raises(StableEntryError, match="res:// path"):
+        resolve_res_path(project, path)
 
 
 # --- source_path validation ------------------------------------------------
@@ -628,7 +701,7 @@ def test_symlinked_stable_directory_is_rejected_on_disk(project, tmp_path):
 # --- immutability of the mapping fields ------------------------------------
 
 
-def test_request_spec_is_snapshotted_and_hashable(project):
+def test_request_spec_is_snapshotted_hashable_and_standard_library_safe(project):
     spec = {"frames": [1, 2]}
     request = _replace(
         _make_request(project, layout="single", artifact_type="StyleBoxTexture"),
@@ -638,12 +711,13 @@ def test_request_spec_is_snapshotted_and_hashable(project):
     spec["frames"].append(99)
 
     assert request.spec == {"frames": [1, 2]}
-    with pytest.raises(TypeError):
-        request.spec["frames"] = []
     assert isinstance(hash(request), int)
+    assert deepcopy(request).spec == {"frames": [1, 2]}
+    assert pickle.loads(pickle.dumps(request)).spec == {"frames": [1, 2]}
+    assert asdict(request)["spec"] == {"frames": [1, 2]}
 
 
-def test_receipt_details_are_snapshotted_and_hashable(project):
+def test_receipt_details_are_snapshotted_hashable_and_standard_library_safe(project):
     details = {"regions": ["a"]}
     receipt = CompileReceipt(
         compiler_id="boxes",
@@ -661,6 +735,9 @@ def test_receipt_details_are_snapshotted_and_hashable(project):
 
     assert receipt.details == {"regions": ["a"]}
     assert isinstance(hash(receipt), int)
+    assert deepcopy(receipt).details == {"regions": ["a"]}
+    assert pickle.loads(pickle.dumps(receipt)).details == {"regions": ["a"]}
+    assert asdict(receipt)["details"] == {"regions": ["a"]}
 
 
 def test_a_compiler_cannot_edit_its_receipt_after_the_fact(project):

--- a/tests/assets/test_asset_compiler_registry.py
+++ b/tests/assets/test_asset_compiler_registry.py
@@ -1,0 +1,402 @@
+"""Routing, fail-closed, and boundary tests for the shared compiler registry."""
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from asset_compiler import (  # noqa: E402
+    DEFAULT_REGISTRY,
+    CompileRequest,
+    CompilerError,
+    CompilerRegistry,
+    build_default_registry,
+    texture2d,
+)
+from asset_stable_entry import (  # noqa: E402
+    GODOT_ARTIFACT_KEYS,
+    LAYOUT_ARTIFACT_TYPES,
+    validate_entry,
+)
+
+
+def _writer(payload=b"artifact"):
+    """Return a compiler that writes its artifact and receipts what it wrote."""
+
+    def compiler(request):
+        target = request.artifact_file()
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(payload)
+        return {"bytes": len(payload)}
+
+    return compiler
+
+
+def _register(registry, layout, artifact_type, compiler=None, compiler_id=None):
+    return registry.register(
+        source_layout_type=layout,
+        artifact_type=artifact_type,
+        compiler_id=compiler_id or f"{layout}_{artifact_type}".lower(),
+        compiler_version=1,
+        compiler=compiler or _writer(),
+    )
+
+
+def _replace(request, field, value):
+    return replace(request, **{field: value})
+
+
+def _make_request(project_root, *, layout, artifact_type, family="ui-kit", asset_id="panel"):
+    stable = f"res://assets/generated/{family}/{asset_id}"
+    return CompileRequest(
+        production_family=family,
+        asset_id=asset_id,
+        source_layout_type=layout,
+        source_path=f"{stable}/{asset_id}.png",
+        artifact_type=artifact_type,
+        artifact_path=f"{stable}/{asset_id}.tres",
+        project_root=project_root,
+    )
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A project root with the ui-kit/panel source image already generated."""
+    source = tmp_path / "assets" / "generated" / "ui-kit" / "panel" / "panel.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"png")
+    return tmp_path
+
+
+# --- routing ---------------------------------------------------------------
+
+
+def test_routes_on_the_layout_and_artifact_pair(project):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler_id="single_box")
+    _register(registry, "region_atlas", "StyleBoxTexture", compiler_id="atlas_box")
+
+    # A one-to-one layout map would have refused the second registration; both
+    # legal StyleBoxTexture routes must coexist and resolve independently.
+    assert registry.resolve("single", "StyleBoxTexture").compiler_id == "single_box"
+    assert registry.resolve("region_atlas", "StyleBoxTexture").compiler_id == "atlas_box"
+    assert [route.key for route in registry.routes()] == [
+        ("region_atlas", "StyleBoxTexture"),
+        ("single", "StyleBoxTexture"),
+    ]
+
+
+def test_single_also_routes_to_texture2d_alongside_stylebox(project):
+    registry = CompilerRegistry()
+    _register(registry, "single", "Texture2D", compiler_id="tex")
+    _register(registry, "single", "StyleBoxTexture", compiler_id="box")
+
+    result = registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+    assert result.receipt.compiler_id == "box"
+
+
+def test_every_frozen_compatible_pair_is_registrable():
+    registry = CompilerRegistry()
+    for layout, artifact_types in LAYOUT_ARTIFACT_TYPES.items():
+        for artifact_type in artifact_types:
+            _register(registry, layout, artifact_type)
+    assert len(registry.routes()) == sum(
+        len(types) for types in LAYOUT_ARTIFACT_TYPES.values()
+    )
+
+
+def test_compile_returns_the_routed_compilers_receipt(project):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=_writer(b"12345"))
+
+    result = registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+    assert result.godot_artifact.type == "StyleBoxTexture"
+    assert result.godot_artifact.path.endswith("/panel.tres")
+    assert result.receipt.compiler_id == "single_styleboxtexture"
+    assert result.receipt.compiler_version == 1
+    assert result.receipt.details == {"bytes": 5}
+    assert (project / "assets/generated/ui-kit/panel/panel.tres").is_file()
+
+
+# --- registration failures -------------------------------------------------
+
+
+def test_duplicate_registration_is_rejected():
+    registry = CompilerRegistry()
+    _register(registry, "grid_sheet", "SpriteFrames", compiler_id="first")
+    with pytest.raises(CompilerError, match="already registered to first"):
+        _register(registry, "grid_sheet", "SpriteFrames", compiler_id="second")
+
+
+def test_registering_an_incompatible_pair_is_rejected():
+    registry = CompilerRegistry()
+    with pytest.raises(CompilerError, match="may not compile to"):
+        _register(registry, "grid_sheet", "Texture2D")
+
+
+def test_registering_an_unknown_layout_is_rejected():
+    registry = CompilerRegistry()
+    with pytest.raises(CompilerError, match="compiles no Godot artifact"):
+        _register(registry, "mosaic", "Texture2D")
+
+
+def test_registering_a_reference_layout_is_rejected():
+    registry = CompilerRegistry()
+    with pytest.raises(CompilerError, match="compiles no Godot artifact"):
+        _register(registry, "reference", "Texture2D")
+
+
+@pytest.mark.parametrize("version", [0, -1, True, 1.0, "1"])
+def test_registering_a_non_positive_integer_version_is_rejected(version):
+    registry = CompilerRegistry()
+    with pytest.raises(CompilerError, match="compiler_version"):
+        registry.register(
+            source_layout_type="tile_atlas",
+            artifact_type="TileSet",
+            compiler_id="tiles",
+            compiler_version=version,
+            compiler=_writer(),
+        )
+
+
+def test_registering_a_non_callable_is_rejected():
+    registry = CompilerRegistry()
+    with pytest.raises(CompilerError, match="callable"):
+        registry.register(
+            source_layout_type="theme_recipe",
+            artifact_type="Theme",
+            compiler_id="theme",
+            compiler_version=1,
+            compiler="not a compiler",
+        )
+
+
+# --- unknown / mismatched compile requests ---------------------------------
+
+
+def test_unregistered_pair_fails_closed(project):
+    registry = CompilerRegistry()
+    _register(registry, "single", "Texture2D")
+    with pytest.raises(CompilerError, match="no compiler is registered"):
+        registry.compile(
+            _make_request(project, layout="grid_sheet", artifact_type="SpriteFrames")
+        )
+
+
+def test_empty_registry_names_no_routes(project):
+    with pytest.raises(CompilerError, match="registered: none"):
+        CompilerRegistry().compile(
+            _make_request(project, layout="single", artifact_type="Texture2D")
+        )
+
+
+def test_type_mismatch_fails_before_routing(project):
+    registry = CompilerRegistry()
+    # Registered under its legal pair; the request still asks for the wrong type.
+    _register(registry, "grid_sheet", "SpriteFrames")
+    with pytest.raises(CompilerError, match="must be one of: SpriteFrames"):
+        registry.compile(
+            _make_request(project, layout="grid_sheet", artifact_type="Texture2D")
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value,message",
+    [
+        ("production_family", "sprites", "production_family is not allowed"),
+        ("production_family", "screen-reference", "reference-only"),
+        ("source_layout_type", "mosaic", "source_layout_type is not allowed"),
+        ("source_layout_type", "reference", "compiles no Godot artifact"),
+        ("artifact_type", "Resource", "must be one of"),
+        ("asset_id", "", "asset_id must be a non-empty string"),
+    ],
+)
+def test_unknown_or_reference_inputs_fail_closed(project, field, value, message):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    request = _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    with pytest.raises(CompilerError, match=message):
+        registry.compile(_replace(request, field, value))
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "res://assets/generated/ui-kit/other/panel.tres",
+        "res://.godotmaker/asset-generation/work/panel.tres",
+        "res://panel.tres",
+        "assets/generated/ui-kit/panel/panel.tres",
+    ],
+)
+def test_artifact_outside_the_stable_directory_is_rejected(project, path):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    request = _replace(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture"),
+        "artifact_path",
+        path,
+    )
+    with pytest.raises(CompilerError):
+        registry.compile(request)
+
+
+def test_missing_source_fails_before_the_compiler_runs(tmp_path):
+    registry = CompilerRegistry()
+    ran = []
+    _register(
+        registry,
+        "single",
+        "StyleBoxTexture",
+        compiler=lambda request: ran.append(request) or {},
+    )
+    with pytest.raises(CompilerError, match="source_path not found"):
+        registry.compile(
+            _make_request(tmp_path, layout="single", artifact_type="StyleBoxTexture")
+        )
+    assert ran == []
+
+
+# --- error propagation -----------------------------------------------------
+
+
+def test_compiler_error_propagates_unchanged(project):
+    registry = CompilerRegistry()
+
+    def failing(request):
+        raise CompilerError("nine-slice margins exceed the source rect")
+
+    _register(registry, "single", "StyleBoxTexture", compiler=failing)
+    with pytest.raises(CompilerError, match="nine-slice margins exceed"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+
+def test_unexpected_compiler_exception_is_wrapped_with_the_compiler_id(project):
+    registry = CompilerRegistry()
+
+    def exploding(request):
+        raise ValueError("bad frame index")
+
+    _register(
+        registry, "single", "StyleBoxTexture", compiler=exploding, compiler_id="boxes"
+    )
+    with pytest.raises(CompilerError, match="boxes failed: bad frame index"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+
+def test_compiler_returning_a_non_mapping_is_rejected(project):
+    def returns_a_string(request):
+        _writer()(request)
+        return "done"
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=returns_a_string)
+    with pytest.raises(CompilerError, match="must return a mapping"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+
+def test_compiler_that_writes_nothing_is_rejected(project):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=lambda request: {})
+    with pytest.raises(CompilerError, match="returned without writing"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+
+# --- worker snapshot boundary ----------------------------------------------
+
+
+def test_receipt_details_never_widen_the_worker_artifact(project):
+    def overreaching(request):
+        _writer()(request)
+        return {"type": "Resource", "path": "res://elsewhere.tres", "hash": "abc"}
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=overreaching)
+    result = registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+
+    # The compiler never builds the artifact, so the keys it returns land in the
+    # receipt and cannot overwrite or extend the worker-facing object.
+    assert set(result.godot_artifact.to_dict()) == GODOT_ARTIFACT_KEYS
+    assert result.godot_artifact.to_dict() == {
+        "type": "StyleBoxTexture",
+        "path": "res://assets/generated/ui-kit/panel/panel.tres",
+    }
+    assert result.receipt.details["hash"] == "abc"
+    assert "hash" not in result.to_dict()["godot_artifact"]
+
+
+def test_compiled_artifact_is_accepted_by_the_stable_entry_schema(project):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    result = registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+    entry = {
+        "version": 1,
+        "asset_id": "panel",
+        "tag": "v0.1.0",
+        "production_family": "ui-kit",
+        "source_layout": {
+            "type": "single",
+            "path": "res://assets/generated/ui-kit/panel/panel.png",
+        },
+        "godot_artifact": result.godot_artifact.to_dict(),
+        "processing_status": "compiled",
+    }
+    assert validate_entry(entry, project_root=project, check_files=True) == entry
+
+
+# --- Texture2D default import ----------------------------------------------
+
+
+def test_default_registry_serves_texture2d_through_godot_default_import(project):
+    request = CompileRequest(
+        production_family="ui-kit",
+        asset_id="panel",
+        source_layout_type="single",
+        source_path="res://assets/generated/ui-kit/panel/panel.png",
+        artifact_type="Texture2D",
+        artifact_path="res://assets/generated/ui-kit/panel/panel.png",
+        project_root=project,
+    )
+    result = DEFAULT_REGISTRY.compile(request)
+
+    assert result.receipt.compiler_id == texture2d.COMPILER_ID
+    assert result.receipt.details == {"mode": "godot_default_import"}
+    assert result.godot_artifact.to_dict() == {
+        "type": "Texture2D",
+        "path": "res://assets/generated/ui-kit/panel/panel.png",
+    }
+
+
+def test_texture2d_rejects_a_separate_artifact_path(project):
+    with pytest.raises(CompilerError, match="must equal source_path"):
+        DEFAULT_REGISTRY.compile(
+            _make_request(project, layout="single", artifact_type="Texture2D")
+        )
+
+
+def test_default_registry_ships_only_the_texture2d_route():
+    # No concrete AtlasTexture, SpriteFrames, Theme, StyleBoxTexture, or TileSet
+    # compiler belongs to the shared layer; each lands with its asset skill.
+    assert [route.key for route in build_default_registry().routes()] == [
+        ("single", "Texture2D")
+    ]

--- a/tests/assets/test_asset_compiler_registry.py
+++ b/tests/assets/test_asset_compiler_registry.py
@@ -1,4 +1,6 @@
 """Routing, fail-closed, and boundary tests for the shared compiler registry."""
+import os
+import subprocess
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -11,7 +13,8 @@ sys.path.insert(0, str(SHARED_DIR))
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
 from asset_compiler import (  # noqa: E402
-    DEFAULT_REGISTRY,
+    SOURCE_IS_ARTIFACT_TYPES,
+    CompileReceipt,
     CompileRequest,
     CompilerError,
     CompilerRegistry,
@@ -318,6 +321,110 @@ def test_compiler_that_writes_nothing_is_rejected(project):
         )
 
 
+# --- the artifact must actually be rebuilt this run ------------------------
+
+
+def test_no_op_compiler_cannot_pass_off_a_previous_runs_artifact(project):
+    # Regeneration overwrites a stable path in place, so the artifact usually
+    # already exists. Existence alone would let a silently no-op compiler hand
+    # back last run's bytes as this run's result.
+    stale = project / "assets/generated/ui-kit/panel/panel.tres"
+    stale.write_bytes(b"STALE-FROM-RUN-1")
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=lambda request: {})
+    with pytest.raises(CompilerError, match="unchanged from an earlier run"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+    assert stale.read_bytes() == b"STALE-FROM-RUN-1"
+
+
+def test_rebuilding_over_an_existing_artifact_is_accepted(project):
+    (project / "assets/generated/ui-kit/panel/panel.tres").write_bytes(b"OLD")
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=_writer(b"NEW-CONTENT"))
+    result = registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+    assert result.receipt.details == {"bytes": 11}
+
+
+def test_same_size_rewrite_is_accepted(project):
+    # The guard compares size and st_mtime_ns, so a byte-count-preserving
+    # rebuild must not be mistaken for a no-op.
+    (project / "assets/generated/ui-kit/panel/panel.tres").write_bytes(b"AAA")
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=_writer(b"BBB"))
+    registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+    assert (project / "assets/generated/ui-kit/panel/panel.tres").read_bytes() == b"BBB"
+
+
+# --- the source image may not be published as the artifact -----------------
+
+
+def test_a_writing_route_may_not_hand_back_its_source_image(project):
+    # tools/asset_stable_entry.py calls this out by name: declaring the source
+    # image as the artifact is the shortcut LAYOUT_ARTIFACT_TYPES exists to
+    # reject. A worker binding that PNG as SpriteFrames gets a frozen sprite.
+    source = project / "assets/generated/character-bundle/hero/hero.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"png")
+
+    registry = CompilerRegistry()
+    _register(registry, "grid_sheet", "SpriteFrames", compiler=lambda request: {})
+    request = CompileRequest(
+        production_family="character-bundle",
+        asset_id="hero",
+        source_layout_type="grid_sheet",
+        source_path="res://assets/generated/character-bundle/hero/hero.png",
+        artifact_type="SpriteFrames",
+        artifact_path="res://assets/generated/character-bundle/hero/hero.png",
+        project_root=project,
+    )
+    with pytest.raises(CompilerError, match="may not be the source image itself"):
+        registry.compile(request)
+
+
+@pytest.mark.parametrize(
+    "layout,artifact_type",
+    [
+        (layout, artifact_type)
+        for layout, artifact_types in sorted(LAYOUT_ARTIFACT_TYPES.items())
+        for artifact_type in artifact_types
+        if artifact_type not in SOURCE_IS_ARTIFACT_TYPES
+    ],
+)
+def test_only_texture2d_may_register_as_a_non_writing_route(layout, artifact_type):
+    registry = CompilerRegistry()
+    with pytest.raises(CompilerError, match="must compile a new file"):
+        registry.register(
+            source_layout_type=layout,
+            artifact_type=artifact_type,
+            compiler_id="shortcut",
+            compiler_version=1,
+            compiler=_writer(),
+            writes_artifact=False,
+        )
+
+
+def test_writes_artifact_must_be_a_bool():
+    registry = CompilerRegistry()
+    with pytest.raises(CompilerError, match="writes_artifact must be a bool"):
+        registry.register(
+            source_layout_type="single",
+            artifact_type="Texture2D",
+            compiler_id="tex",
+            compiler_version=1,
+            compiler=_writer(),
+            writes_artifact=0,
+        )
+
+
 # --- worker snapshot boundary ----------------------------------------------
 
 
@@ -367,7 +474,7 @@ def test_compiled_artifact_is_accepted_by_the_stable_entry_schema(project):
 # --- Texture2D default import ----------------------------------------------
 
 
-def test_default_registry_serves_texture2d_through_godot_default_import(project):
+def test_texture2d_is_served_through_godot_default_import(project):
     request = CompileRequest(
         production_family="ui-kit",
         asset_id="panel",
@@ -377,7 +484,7 @@ def test_default_registry_serves_texture2d_through_godot_default_import(project)
         artifact_path="res://assets/generated/ui-kit/panel/panel.png",
         project_root=project,
     )
-    result = DEFAULT_REGISTRY.compile(request)
+    result = build_default_registry().compile(request)
 
     assert result.receipt.compiler_id == texture2d.COMPILER_ID
     assert result.receipt.details == {"mode": "godot_default_import"}
@@ -389,7 +496,7 @@ def test_default_registry_serves_texture2d_through_godot_default_import(project)
 
 def test_texture2d_rejects_a_separate_artifact_path(project):
     with pytest.raises(CompilerError, match="must equal source_path"):
-        DEFAULT_REGISTRY.compile(
+        build_default_registry().compile(
             _make_request(project, layout="single", artifact_type="Texture2D")
         )
 
@@ -400,3 +507,229 @@ def test_default_registry_ships_only_the_texture2d_route():
     assert [route.key for route in build_default_registry().routes()] == [
         ("single", "Texture2D")
     ]
+
+
+def test_each_build_returns_an_independent_registry():
+    # There is no module-level singleton: registering a family compiler must not
+    # leak into a registry another caller builds.
+    first = build_default_registry()
+    _register(first, "grid_sheet", "SpriteFrames")
+    assert len(first.routes()) == 2
+    assert len(build_default_registry().routes()) == 1
+
+
+# --- source_path validation ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path,message",
+    [
+        ("", "source_path must be a non-empty string"),
+        ("   ", "source_path must be a non-empty string"),
+        ("assets/generated/ui-kit/panel/panel.png", "source_path must be a res:// path"),
+        (
+            "res://.godotmaker/asset-generation/work/panel.png",
+            "source_path must not depend on the generation work/ workspace",
+        ),
+        (
+            "res://assets/generated/ui-kit/other/panel.png",
+            "source_path must be a file under",
+        ),
+        ("res://assets/generated/ui-kit/panel/../x.png", "source_path"),
+    ],
+)
+def test_source_path_is_constrained_like_the_artifact_path(project, path, message):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    request = _replace(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture"),
+        "source_path",
+        path,
+    )
+    with pytest.raises(CompilerError, match=message):
+        registry.compile(request)
+
+
+@pytest.mark.parametrize("value", [None, 42, [], {}, b"res://x"])
+def test_require_text_rejects_non_strings(project, value):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    request = _replace(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture"),
+        "artifact_type",
+        value,
+    )
+    with pytest.raises(CompilerError, match="artifact_type must be a non-empty string"):
+        registry.compile(request)
+
+
+def test_project_root_must_be_a_path(project):
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    request = _replace(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture"),
+        "project_root",
+        str(project),
+    )
+    with pytest.raises(CompilerError, match="project_root must be a Path"):
+        registry.compile(request)
+
+
+@pytest.mark.parametrize("spec", [None, [], "frames", 3])
+def test_spec_must_be_a_mapping(project, spec):
+    with pytest.raises(CompilerError, match="spec must be a mapping"):
+        CompileRequest(
+            production_family="ui-kit",
+            asset_id="panel",
+            source_layout_type="single",
+            source_path="res://assets/generated/ui-kit/panel/panel.png",
+            artifact_type="StyleBoxTexture",
+            artifact_path="res://assets/generated/ui-kit/panel/panel.tres",
+            project_root=project,
+            spec=spec,
+        )
+
+
+@pytest.mark.parametrize("compiler_id", ["", "   ", None, 7])
+def test_registering_a_blank_compiler_id_is_rejected(compiler_id):
+    registry = CompilerRegistry()
+    with pytest.raises(CompilerError, match="compiler_id must be a non-empty string"):
+        registry.register(
+            source_layout_type="theme_recipe",
+            artifact_type="Theme",
+            compiler_id=compiler_id,
+            compiler_version=1,
+            compiler=_writer(),
+        )
+
+
+def test_symlinked_stable_directory_is_rejected_on_disk(project, tmp_path):
+    # The string-level checks all pass here; only the resolve-and-contain guard
+    # in assert_within_output_dir can catch a stable dir linked out of the tree.
+    outside = tmp_path.parent / "outside-the-project"
+    outside.mkdir(exist_ok=True)
+    stable = project / "assets" / "generated" / "ui-kit" / "linked"
+    try:
+        stable.symlink_to(outside, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlink creation unavailable: {exc}")
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    with pytest.raises(CompilerError, match="resolves outside the project root"):
+        registry.compile(
+            _make_request(
+                project, layout="single", artifact_type="StyleBoxTexture",
+                asset_id="linked",
+            )
+        )
+
+
+# --- immutability of the mapping fields ------------------------------------
+
+
+def test_request_spec_is_snapshotted_and_hashable(project):
+    spec = {"frames": [1, 2]}
+    request = _replace(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture"),
+        "spec",
+        spec,
+    )
+    spec["frames"].append(99)
+
+    assert request.spec == {"frames": [1, 2]}
+    with pytest.raises(TypeError):
+        request.spec["frames"] = []
+    assert isinstance(hash(request), int)
+
+
+def test_receipt_details_are_snapshotted_and_hashable(project):
+    details = {"regions": ["a"]}
+    receipt = CompileReceipt(
+        compiler_id="boxes",
+        compiler_version=1,
+        production_family="ui-kit",
+        asset_id="panel",
+        source_layout_type="single",
+        source_path="res://assets/generated/ui-kit/panel/panel.png",
+        artifact_type="StyleBoxTexture",
+        artifact_path="res://assets/generated/ui-kit/panel/panel.tres",
+        details=details,
+    )
+    details["regions"].append("b")
+    receipt.to_dict()["details"]["regions"].append("c")
+
+    assert receipt.details == {"regions": ["a"]}
+    assert isinstance(hash(receipt), int)
+
+
+def test_a_compiler_cannot_edit_its_receipt_after_the_fact(project):
+    escaped = {}
+
+    def leaky(request):
+        _writer()(request)
+        escaped["details"] = {"regions": ["a"]}
+        return escaped["details"]
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=leaky)
+    result = registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+    escaped["details"]["regions"].append("b")
+
+    assert result.receipt.details == {"regions": ["a"]}
+
+
+# --- the tools/ import bridge ----------------------------------------------
+
+
+def test_bridge_imports_the_package_without_tools_on_the_path(tmp_path):
+    # The suite puts tools/ on sys.path before importing asset_compiler, which
+    # hides the bridge entirely. Import it in a child process that has neither,
+    # so a wrong parents[] index is a failure instead of a silent no-op.
+    code = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(SHARED_DIR)!r})\n"
+        "assert 'asset_stable_entry' not in sys.modules\n"
+        "import asset_compiler\n"
+        "print(asset_compiler.build_default_registry().routes()[0].compiler_id)\n"
+    )
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout.strip() == texture2d.COMPILER_ID
+
+
+def test_bridge_reports_a_missing_tools_directory_diagnosably(tmp_path):
+    # A publish layout that moves the package away from tools/ must say so
+    # instead of raising a bare ModuleNotFoundError: asset_stable_entry.
+    package = tmp_path / "a" / "b" / "c" / "d" / "asset_compiler"
+    package.mkdir(parents=True)
+    source = SHARED_DIR / "asset_compiler"
+    for name in ("__init__.py", "_stable_entry.py", "contract.py", "registry.py",
+                 "texture2d.py"):
+        (package / name).write_bytes((source / name).read_bytes())
+
+    code = (
+        "import sys\n"
+        f"sys.path.insert(0, {str(package.parent)!r})\n"
+        "import asset_compiler\n"
+    )
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode != 0
+    assert "expects the repository tools/ directory" in completed.stderr
+    assert "ModuleNotFoundError" not in completed.stderr


### PR DESCRIPTION
## Summary

Adds the unified Godot artifact compiler interface and registry under `skills/assets/_shared/`, so each deterministic compiler that lands later has one stable input, output, error, and receipt boundary to implement against.

No concrete `AtlasTexture`, `SpriteFrames`, `Theme`, `StyleBoxTexture`, or `TileSet` compiler is included — each lands with its own asset skill and registers itself.

## Motivation

No public GitHub issue. This registry is required by the asset-generation pipeline design so that later family-compiler skills have a single fail-closed routing and validation boundary instead of each reimplementing it.

## Changes

- [x] `skills/assets/_shared/godot-artifact-compiler-contract.md` — contract doc (routing, fail-closed rules, receipt boundary, `Texture2D` route)
- [x] `skills/assets/_shared/asset_compiler/contract.py` — `CompileRequest` / `CompileResult` / `CompileReceipt` / `GodotArtifact` / `CompilerError`
- [x] `skills/assets/_shared/asset_compiler/registry.py` — `CompilerRegistry` routing, fail-closed compile, `build_default_registry()`
- [x] `skills/assets/_shared/asset_compiler/texture2d.py` — `single -> Texture2D` default-import route
- [x] `skills/assets/_shared/asset_compiler/_stable_entry.py` — import bridge to the frozen `tools/asset_stable_entry.py` contract
- [x] `tests/assets/test_asset_compiler_registry.py` and `tests/assets/test_asset_compiler_contract_docs.py` — unit tests (85 passed, 1 skipped)
- [x] `docs/update/next.md` — Added entry

### Design notes

- **Routing key is the `(source_layout.type, godot_artifact.type)` pair, not the layout alone** — `StyleBoxTexture` is reachable from both `single` and `region_atlas`, and `single` also compiles to `Texture2D`; a one-to-one layout map would reject those legal routes.
- **No restated compatibility table** — the registry imports the frozen `LAYOUT_ARTIFACT_TYPES` relation from `tools/asset_stable_entry.py`, so an incompatible pair cannot be registered and the two cannot drift.
- **The registry builds the worker-facing artifact, not the compiler** — a compiler writes its file and returns receipt details only; `GodotArtifact` is assembled by the registry from the request, so compiler output can never widen the worker snapshot beyond `{type, path}`.
- **`single -> Texture2D` is served by Godot's default import** and writes nothing; artifact path must equal source path. No general texture-import profile system is introduced.
- **Fail closed everywhere**, including regressions fixed during code review: stale/no-op compiler output, source-as-artifact shortcuts (hardlink/case-alias), non-writing routes mutating the source, relative `project_root` double-anchoring, and unvalidated `res://` path resolution.

## Testing

- [x] New or updated tests pass (`python -m pytest tests/assets tests/tools/test_asset_stable_entry.py tests/test_asset_skill_contract_docs.py` → 263 passed, 3 skipped; full `python -m pytest` → 1610 passed, 4 skipped)
- [x] Gitleaks passes or no secret-bearing files were touched (no credentials touched; verified by CI Secret Scan)
- [x] Manual testing completed, if applicable (fail-closed regressions were independently reproduced on a fresh checkout during code review)
- [ ] Godot editor import of the `Texture2D` default-import route was not exercised (no Godot editor available in this environment) — code/contract-level review only

## Benchmark Verification

- [x] Not performance-sensitive

## Version Compatibility

- [x] **No** - no migration needed (new module only; no existing file/config/behavior changed)

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — not applicable, no ECS systems touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated

---

This PR went through three rounds of code review; all blocking findings were resolved before merge readiness. Residual non-blocking risks: the registry does not yet write via temp-file + atomic rename before clearing a prior artifact, and two pre-compile guards (`_is_same_file`, post-compile source existence) are currently uncovered by tests — tracked for follow-up before the first concrete family compiler lands.
