### PR TITLE
Add shared L0-L4 asset readiness validation ladder

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -26,6 +26,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Added `tools/asset_curation_entry_draft.py`, which builds a v1 stable-entry draft from a selected curation candidate while enforcing candidate selection, unambiguous naming, coherent selection counts, and stable-path containment.
 - Added `tools/asset_finalize_entry_draft.py`, which builds a v1 stable-entry draft from an `asset_image_finalize.py` report for screen references, backgrounds, and single card or portrait frames while enforcing aspect validation, asset-label binding, and path containment.
 - Added a shared Godot artifact compiler interface and registry under `skills/assets/_shared/` that routes on the frozen source-layout to artifact-type compatibility set, keeps compiler receipts out of the worker-facing artifact, requires each compiler to actually rebuild an artifact distinct from its source image, serves `Texture2D` through Godot's default import, and fails closed on unregistered or mismatched combinations (#107).
+- Added the shared L0-L4 asset readiness ladder under `skills/assets/_shared/`, which reaches `ready` only after the stable entry contract, the processed source, the compiled artifact, a real headless Godot import and `ResourceLoader.load` type match, and a registered type-specific structure check all pass.
 
 ## Changed
 
@@ -33,7 +34,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Generated runtime handoff for gm-build, gm-fixgap, worker dispatch, and ASSETS.md rows now resolves the stable entry behind each root-index pointer.
 - An ASSETS.md runtime row reaches `generated` only from a `ready` non-reference stable entry, while a finalized registered screen reference completes its reference row at `source_ready` without becoming a worker runtime artifact.
 - `asset_generation_index.py --check-files` verifies that every registered source and artifact still exists, catching an asset deleted after registration.
-- Generated runtime assets now stop at `source_ready`: the native compilers and the L0-L4 runner are not implemented, so `/gm-asset` registers stable entries but produces no worker-consumable runtime asset and leaves generated runtime ASSETS.md rows `MISSING`.
+- Generated runtime assets now stop at `source_ready`: the native compilers are not implemented and `/gm-asset` does not yet run the L0-L4 ladder, so it registers stable entries but produces no worker-consumable runtime asset and leaves generated runtime ASSETS.md rows `MISSING`.
 - `godot_artifact` is written only by a native compiler, so a `grid_sheet` can no longer be published as a `Texture2D` standing in for its unbuilt `SpriteFrames`.
 - The stable-entry schema now validates each `source_layout.type` against its closed compatible Godot artifact-type set, including `StyleBoxTexture` for `single` and `region_atlas`, so mismatches are rejected before reaching a worker.
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -26,7 +26,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Added `tools/asset_curation_entry_draft.py`, which builds a v1 stable-entry draft from a selected curation candidate while enforcing candidate selection, unambiguous naming, coherent selection counts, and stable-path containment.
 - Added `tools/asset_finalize_entry_draft.py`, which builds a v1 stable-entry draft from an `asset_image_finalize.py` report for screen references, backgrounds, and single card or portrait frames while enforcing aspect validation, asset-label binding, and path containment.
 - Added a shared Godot artifact compiler interface and registry under `skills/assets/_shared/` that routes on the frozen source-layout to artifact-type compatibility set, keeps compiler receipts out of the worker-facing artifact, requires each compiler to actually rebuild an artifact distinct from its source image, serves `Texture2D` through Godot's default import, and fails closed on unregistered or mismatched combinations (#107).
-- Added the shared L0-L4 asset readiness ladder under `skills/assets/_shared/`, which reaches `ready` only after the stable entry contract, the processed source, the compiled artifact, a real headless Godot import and `ResourceLoader.load` type match, and a registered type-specific structure check all pass.
+- Added the shared L0-L4 asset readiness ladder under `skills/assets/_shared/`, which reaches `ready` only after the stable entry contract, the processed source, the compiled artifact, a real headless Godot import and `ResourceLoader.load` type match, and a registered type-specific structure check all pass (#108).
 
 ## Changed
 

--- a/skills/assets/_shared/asset-validation-ladder.md
+++ b/skills/assets/_shared/asset-validation-ladder.md
@@ -1,0 +1,178 @@
+# Asset Readiness Validation Ladder (L0-L4)
+
+The single source of truth for what `ready` means for a generated asset, which
+levels prove it, and how each one fails. Implemented by `asset_validation/` next
+to this document.
+
+`ready` is not a field an asset skill may assert. It is the conclusion of five
+ordered levels, and an asset that fails any of them is not worker-consumable.
+
+## The ladder
+
+| Level | Name | Consumes | Proves |
+|---|---|---|---|
+| `L0` | `contract` | the stable entry object and the project root | the entry satisfies the v1 stable-entry schema and path contract |
+| `L1` | `processed_source` | source_layout.path | deterministic source processing left a real file in the stable directory |
+| `L2` | `compiled_artifact` | godot_artifact and the compiler registry | a registered compiler route produced the artifact file |
+| `L3` | `godot_load` | the artifact path and a headless Godot binary | Godot imports the project, ResourceLoader.load succeeds, and the type matches |
+| `L4` | `structure` | the L3 probe result and the registered structure validator | the loaded resource satisfies its type-specific structural contract |
+
+`asset_validation/contract.py` holds this table as `LEVELS` and `tests/assets/`
+asserts the two agree row for row, so the document cannot go stale.
+
+L5 (a representative consumer can bind the artifact) and L6 (visual and semantic
+quality) are evaluation layers, not runtime readiness gates. They live privately
+in GodotMakerApp and are not implemented here.
+
+## Verify, do not produce
+
+The pipeline is generate, process, compile, *then* validate, then register. The
+ladder runs after production and proves each step's result is real and belongs to
+this entry. It never generates a source, calls a compiler, writes a file, or
+edits the entry.
+
+It also never decides what a caller records. `LadderResult.processing_status` is
+`ready` or `failed` and nothing else: the intermediate statuses (`pending`,
+`source_ready`, `compiled`) describe how far production got and are written by
+the step that got there.
+
+## Ordering and short-circuit
+
+Levels run in order and stop at the first failure. Every later level depends on
+the earlier one's output — there is no artifact to load when nothing compiled,
+and no structure to check when nothing loaded. Levels after the failure are
+reported as `not_run`, so a caller can distinguish "did not pass" from "was
+never asked".
+
+Each level reports one `LevelResult`: its identifier, `passed` / `failed` /
+`not_run`, an error string on failure only, and diagnostic details. The ladder
+does not raise for a bad asset; a failure is a result, because the caller has to
+record which level failed and why. `ValidationError` is the only error type the
+levels themselves surface, and construction is the only thing that raises.
+
+## Reference assets have no rung
+
+A reference asset — a `reference` source layout, or a reference-only production
+family — is never handed to a worker as a runtime game asset and compiles no
+Godot artifact. It completes at `source_ready`. Asking whether it is `ready` is a
+category error, so L0 rejects it rather than inventing a pass.
+
+## L3 runs real Godot
+
+Parsing a `.tres` in Python would prove the text is well formed and nothing else.
+L3 shells out to the engine instead, in two runs:
+
+1. `godot --headless --path <project> --import` builds `.godot/imported`. Without
+   it a fresh checkout cannot load a texture at all, and that absence is a real
+   readiness failure rather than a test-environment quirk.
+2. `godot --headless --path <project> --script probe.gd -- --request <path>
+   --report <path>` loads each resource through
+   `ResourceLoader.load(path, "", CACHE_MODE_IGNORE)` and writes a JSON report.
+
+The verdict comes from the report file, never from the exit code or the console.
+Godot 4.4 headless prints editor progress-dialog errors during `--import` and
+resource errors during a failed load, and exits `0` through both; the streams are
+captured for diagnostics only.
+
+Type matching uses `Object.is_class()`, so it covers the whole inheritance chain:
+an imported PNG that loads as `CompressedTexture2D` matches a declared
+`Texture2D`, while a `Theme` declared as `StyleBoxTexture` does not.
+
+`GodotProbe` takes `godot_path` from its caller rather than searching. A project
+already resolves it through `tools/agent_runtime.read_godot_path`, and a
+validator that silently searched `PATH` could verify an asset with a different
+engine build than the project uses. A missing or unusable binary is a
+`GodotProbeError`, which fails L3 — never a skipped level.
+
+## L4 is the extension point
+
+L3 proves Godot produced *a* resource of the declared type. It cannot prove the
+resource says anything useful: a `SpriteFrames` with no animations, a `Theme`
+with no type overrides, and a `TileSet` with no sources all load fine and are all
+unusable. What "useful" means is per type, so L4 is registered, not fixed.
+
+A family skill registers one validator per artifact type on a
+`StructureValidatorRegistry`:
+
+```python
+structures.register(
+    artifact_type="SpriteFrames",
+    validator_id="sprite_frames_structure",
+    validator=validate_sprite_frames,
+    checks=("sprite_frames",),
+)
+```
+
+`checks` names the structural facts `probe.gd` must collect during L3, so one
+Godot run serves both levels. The check names are a closed set in `probe.gd`
+(`KNOWN_CHECKS`); an unregistered check name is reported as an error, never
+silently skipped. A family adds its check branch there together with the
+validator that consumes it.
+
+A validator raises `ValidationError` when the structure is unusable and returns
+the facts it checked otherwise. Those facts are diagnostics and never widen the
+worker snapshot, which stays exactly `{type, path}`.
+
+The registry fails closed on an unregistered artifact type: an artifact nobody
+can check must not reach `ready` just because no one wrote the check yet. The
+shared layer ships exactly one validator — `Texture2D`, matching the one compiler
+it ships — which requires the loaded texture to report a positive width and
+height, because a zero-sized texture imports, loads, and gives a worker an
+invisible sprite with no error anywhere.
+
+## Fail-closed rules
+
+The ladder concludes `failed` when:
+
+- the entry is not a valid v1 stable entry, or its paths are not clean `res://`
+  files under `assets/generated/<production_family>/<asset_id>/`;
+- the entry is a reference asset;
+- `source_layout.path` resolves outside the stable directory, is missing, is not
+  a regular file, or is empty;
+- the entry declares no `godot_artifact`;
+- no compiler is registered for its `(source_layout.type, godot_artifact.type)`
+  pair;
+- `godot_artifact.path` resolves outside the stable directory, is missing, is not
+  a regular file, or is empty;
+- a writing route's `godot_artifact.path` equals or resolves to the same file as
+  `source_layout.path`, or a non-writing route's does not;
+- a supplied compile receipt describes a different asset, layout, or artifact;
+- Godot cannot be run, times out, or writes no report;
+- Godot has no importable resource at the artifact path, or
+  `ResourceLoader.load` returns null;
+- the loaded resource is not the declared type;
+- no structure validator is registered for the artifact type, or the registered
+  one rejects the structure.
+
+Path containment is re-resolved on disk at L1 and L2 rather than trusted from
+L0's string check, so a symlink inside the stable directory cannot aim the ladder
+at a file it was never allowed to accept.
+
+The compile receipt is optional because re-validating an already registered asset
+has none to offer. When one is supplied it must be this asset's, so a receipt
+from another compile cannot stand in as evidence.
+
+Registration fails closed too: an artifact type no source layout compiles to, a
+non-callable validator, malformed `checks`, and a second validator for an already
+registered type are all rejected.
+
+## Boundary
+
+`_shared/` holds cross-skill material only. It has no `SKILL.md` and is not
+independently triggerable.
+
+There is no module-level default ladder or structure registry. A caller builds
+them per run with `build_default_ladder()` or `build_default_structures()`, so
+one caller's family registrations can never be invisible to — or collide with —
+another's. This mirrors `build_default_registry()` in
+[`godot-artifact-compiler-contract.md`](godot-artifact-compiler-contract.md).
+
+The ladder does not register assets, read `ASSETS.md`, touch manifests, decide
+CI policy, or make reviewer judgments. Wiring it into `/gm-asset` is separate
+work.
+
+`asset_validation/` imports `tools/` and its sibling `asset_compiler` through a
+path bridge resolved relative to the repository root, so it is importable from a
+source checkout only. `tools/publish.py` does not deploy `skills/assets/` yet;
+the bridge asserts each directory and names it in the error rather than failing
+as a bare `ModuleNotFoundError`.

--- a/skills/assets/_shared/asset-validation-ladder.md
+++ b/skills/assets/_shared/asset-validation-ladder.md
@@ -104,14 +104,27 @@ structures.register(
 ```
 
 `checks` names the structural facts `probe.gd` must collect during L3, so one
-Godot run serves both levels. The check names are a closed set in `probe.gd`
-(`KNOWN_CHECKS`); an unregistered check name is reported as an error, never
-silently skipped. A family adds its check branch there together with the
-validator that consumes it.
+Godot run serves both levels. The check names are a closed set, declared twice on
+purpose: `KNOWN_CHECKS` in `probe.gd` is what the engine can answer, and
+`PROBE_CHECKS` in `godot_probe.py` is what a validator may ask for. A family adds
+its name to both together with the GDScript branch, and `tests/assets/` asserts
+the two agree.
 
-A validator raises `ValidationError` when the structure is unusable and returns
-the facts it checked otherwise. Those facts are diagnostics and never widen the
-worker snapshot, which stays exactly `{type, path}`.
+**Whether a declared check was answered is the registry's business, not the
+validator's.** A name `probe.gd` does not implement is rejected at registration,
+and a declared check the probe could not answer — a missing answer, or one
+carrying an `error` — fails L4 before the validator runs. Without that, a
+validator that simply never reads `request.probe.structure` would return
+normally and carry the whole ladder to `ready`, while the L3 details sitting
+right next to the verdict record that the check was impossible. Making every
+family validator repeat the guard would only give every family one chance to
+forget it.
+
+A validator therefore reads its facts through
+`StructureRequest.checked_structure(name)` and judges only what its type means.
+It raises `ValidationError` when the structure is unusable and returns the facts
+it checked otherwise. Those facts are diagnostics and never widen the worker
+snapshot, which stays exactly `{type, path}`.
 
 The registry fails closed on an unregistered artifact type: an artifact nobody
 can check must not reach `ready` just because no one wrote the check yet. The
@@ -141,8 +154,10 @@ The ladder concludes `failed` when:
 - Godot has no importable resource at the artifact path, or
   `ResourceLoader.load` returns null;
 - the loaded resource is not the declared type;
-- no structure validator is registered for the artifact type, or the registered
-  one rejects the structure.
+- no structure validator is registered for the artifact type;
+- a structural check the registered validator declared was not answered by the
+  probe, or was answered with an error;
+- the registered validator rejects the structure.
 
 Path containment is re-resolved on disk at L1 and L2 rather than trusted from
 L0's string check, so a symlink inside the stable directory cannot aim the ladder
@@ -153,8 +168,9 @@ has none to offer. When one is supplied it must be this asset's, so a receipt
 from another compile cannot stand in as evidence.
 
 Registration fails closed too: an artifact type no source layout compiles to, a
-non-callable validator, malformed `checks`, and a second validator for an already
-registered type are all rejected.
+non-callable validator, malformed `checks`, a check name `probe.gd` does not
+implement, and a second validator for an already registered type are all
+rejected.
 
 ## Boundary
 

--- a/skills/assets/_shared/asset_compiler/__init__.py
+++ b/skills/assets/_shared/asset_compiler/__init__.py
@@ -28,6 +28,7 @@ from .registry import (
     Compiler,
     CompilerRegistry,
     CompilerRoute,
+    is_same_file,
 )
 
 
@@ -49,6 +50,7 @@ __all__ = [
     "CompilerRoute",
     "GodotArtifact",
     "build_default_registry",
+    "is_same_file",
     "require_text",
     "texture2d",
 ]

--- a/skills/assets/_shared/asset_compiler/registry.py
+++ b/skills/assets/_shared/asset_compiler/registry.py
@@ -65,12 +65,15 @@ def _content_digest(path: Path) -> bytes | None:
     return digest.digest()
 
 
-def _is_same_file(left: Path, right: Path) -> bool:
+def is_same_file(left: Path, right: Path) -> bool:
     """True when two paths name one file: a hard link, or a case alias.
 
     Distinct path strings are not distinct files. ``os.link`` gives a compiler a
     second name for its source image, and on a case-insensitive filesystem
     ``Hero.png`` and ``hero.png`` are already one file without any linking.
+
+    Exported because the readiness ladder re-checks the same rule on an entry it
+    did not compile itself, and a second copy of it could drift.
     """
     try:
         return left.samefile(right)
@@ -201,7 +204,7 @@ class CompilerRegistry:
             )
         artifact_file = request.artifact_file()
         if route.writes_artifact:
-            if _is_same_file(source_file, artifact_file):
+            if is_same_file(source_file, artifact_file):
                 raise CompilerError(
                     f"{route.compiler_id} may not publish source_path as "
                     f"artifact_path ({request.artifact_path})"
@@ -242,7 +245,7 @@ class CompilerRegistry:
         source_file = request.source_file()
         if not source_file.is_file():
             raise CompilerError(f"source_path not found after compilation: {request.source_path}")
-        if route.writes_artifact and _is_same_file(source_file, artifact_file):
+        if route.writes_artifact and is_same_file(source_file, artifact_file):
             raise CompilerError(
                 f"{route.compiler_id} may not publish source_path as "
                 f"artifact_path ({request.artifact_path})"

--- a/skills/assets/_shared/asset_validation/__init__.py
+++ b/skills/assets/_shared/asset_validation/__init__.py
@@ -1,0 +1,81 @@
+"""Shared L0-L4 readiness ladder for asset skills.
+
+See ``asset-validation-ladder.md`` next to this package for the contract this
+code implements. ``ready`` is the conclusion of five ordered levels: the entry
+contract (L0), the processed source (L1), the compiled Godot artifact (L2), a
+real headless Godot import and load (L3), and the type-specific structural check
+(L4). A failure at any level means the asset is not ready.
+
+As with the compiler registry, there is deliberately no module-level default
+ladder or structure registry. A caller builds them per run with
+:func:`build_default_ladder` or :func:`build_default_structures`, so one caller's
+family registrations can never be invisible to -- or collide with -- another's.
+"""
+from __future__ import annotations
+
+from .contract import (
+    FAILED,
+    LEVEL_BY_ID,
+    LEVELS,
+    NOT_RUN,
+    PASSED,
+    STATUS_FAILED,
+    STATUS_READY,
+    LadderResult,
+    LevelResult,
+    LevelSpec,
+    ValidationError,
+)
+from .godot_probe import (
+    PROBE_SCRIPT,
+    GodotProbe,
+    GodotProbeError,
+    ProbeReport,
+    ProbeRequest,
+    ProbeResult,
+    find_godot,
+)
+from .ladder import ValidationLadder, build_default_ladder
+from .structure import (
+    KNOWN_ARTIFACT_TYPES,
+    TEXTURE2D_CHECKS,
+    TEXTURE2D_VALIDATOR_ID,
+    StructureRequest,
+    StructureRoute,
+    StructureValidator,
+    StructureValidatorRegistry,
+    build_default_structures,
+    validate_texture2d,
+)
+
+__all__ = [
+    "FAILED",
+    "KNOWN_ARTIFACT_TYPES",
+    "LEVELS",
+    "LEVEL_BY_ID",
+    "NOT_RUN",
+    "PASSED",
+    "PROBE_SCRIPT",
+    "STATUS_FAILED",
+    "STATUS_READY",
+    "TEXTURE2D_CHECKS",
+    "TEXTURE2D_VALIDATOR_ID",
+    "GodotProbe",
+    "GodotProbeError",
+    "LadderResult",
+    "LevelResult",
+    "LevelSpec",
+    "ProbeReport",
+    "ProbeRequest",
+    "ProbeResult",
+    "StructureRequest",
+    "StructureRoute",
+    "StructureValidator",
+    "StructureValidatorRegistry",
+    "ValidationError",
+    "ValidationLadder",
+    "build_default_ladder",
+    "build_default_structures",
+    "find_godot",
+    "validate_texture2d",
+]

--- a/skills/assets/_shared/asset_validation/__init__.py
+++ b/skills/assets/_shared/asset_validation/__init__.py
@@ -27,6 +27,7 @@ from .contract import (
     ValidationError,
 )
 from .godot_probe import (
+    PROBE_CHECKS,
     PROBE_SCRIPT,
     GodotProbe,
     GodotProbeError,
@@ -55,6 +56,7 @@ __all__ = [
     "LEVEL_BY_ID",
     "NOT_RUN",
     "PASSED",
+    "PROBE_CHECKS",
     "PROBE_SCRIPT",
     "STATUS_FAILED",
     "STATUS_READY",

--- a/skills/assets/_shared/asset_validation/_bridge.py
+++ b/skills/assets/_shared/asset_validation/_bridge.py
@@ -1,0 +1,75 @@
+"""Import bridge to the repository modules the readiness ladder validates against.
+
+The ladder must judge an asset against exactly the contracts the rest of the
+pipeline enforces, so it imports them instead of restating them:
+
+- ``tools/asset_stable_entry.py`` owns the entry schema (L0) and the stable
+  output-path relation the on-disk checks (L1, L2) resolve against;
+- ``asset_compiler`` next to this package owns the ``(source_layout, artifact
+  type)`` routing relation L2 requires a registered compiler for;
+- ``tools/agent_runtime.py`` owns the Windows console-binary preference the
+  Godot probe needs to capture output.
+
+Neither ``tools/`` nor ``_shared/`` is an installed package, so both are
+resolved relative to this file the same way the repository's tests do. That
+makes this package importable from a source checkout only: ``skills/assets/``
+is not part of the publish layout yet, so each location is asserted with a
+diagnosable message instead of failing as a bare ``ModuleNotFoundError``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SHARED_DIR = Path(__file__).resolve().parents[1]
+_TOOLS_DIR = _SHARED_DIR.parents[2] / "tools"
+
+for _label, _directory in (("tools/", _TOOLS_DIR), ("skills/assets/_shared/", _SHARED_DIR)):
+    if not _directory.is_dir():
+        raise ImportError(
+            f"the shared asset validation ladder expects the repository {_label} "
+            f"directory at {_directory}, resolved from {__file__}. It is "
+            "importable from a source checkout only; skills/assets/ is not "
+            "deployed by tools/publish.py yet."
+        )
+
+# Appended, never inserted: both are flat directories of scripts and packages,
+# and putting either ahead of the standard library would let a same-named module
+# shadow a real one for every later import in the process.
+for _directory in (_TOOLS_DIR, _SHARED_DIR):
+    if str(_directory) not in sys.path:
+        sys.path.append(str(_directory))
+
+from agent_runtime import prefer_console_godot_path  # noqa: E402
+from asset_compiler import (  # noqa: E402
+    CompileReceipt,
+    CompilerError,
+    CompilerRegistry,
+    build_default_registry,
+)
+from asset_compiler.registry import is_same_file  # noqa: E402
+from asset_stable_entry import (  # noqa: E402
+    LAYOUT_ARTIFACT_TYPES,
+    REFERENCE_FAMILIES,
+    REFERENCE_LAYOUTS,
+    StableEntryError,
+    assert_within_output_dir,
+    validate_entry,
+)
+from asset_compiler._stable_entry import resolve_res_path  # noqa: E402
+
+__all__ = [
+    "LAYOUT_ARTIFACT_TYPES",
+    "REFERENCE_FAMILIES",
+    "REFERENCE_LAYOUTS",
+    "CompileReceipt",
+    "CompilerError",
+    "CompilerRegistry",
+    "StableEntryError",
+    "assert_within_output_dir",
+    "build_default_registry",
+    "is_same_file",
+    "prefer_console_godot_path",
+    "resolve_res_path",
+    "validate_entry",
+]

--- a/skills/assets/_shared/asset_validation/contract.py
+++ b/skills/assets/_shared/asset_validation/contract.py
@@ -1,0 +1,154 @@
+"""The level, result, and error vocabulary of the L0-L4 readiness ladder.
+
+``ready`` is not a field an asset skill may assert; it is the conclusion of five
+ordered levels, each with one input, one outcome, and one error. This module
+holds that vocabulary so every level reports the same shape and no caller has to
+interpret a level-specific return value.
+
+The ladder never partially succeeds: :attr:`LadderResult.ready` is true only when
+all five levels passed, and :attr:`LadderResult.processing_status` collapses to
+``failed`` otherwise. Which level failed, and why, stays on the result.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+# The stable-entry processing statuses this layer may conclude. The intermediate
+# statuses (``pending``, ``source_ready``, ``compiled``) describe how far
+# production got and are written by the producing step; the ladder only decides
+# whether that production is worker-consumable.
+STATUS_READY = "ready"
+STATUS_FAILED = "failed"
+
+PASSED = "passed"
+FAILED = "failed"
+NOT_RUN = "not_run"
+
+
+class ValidationError(Exception):
+    """Raised when a level cannot conclude that its requirement is met."""
+
+
+@dataclass(frozen=True)
+class LevelSpec:
+    """One rung: its identifier, what it consumes, and what it proves."""
+
+    level: str
+    name: str
+    consumes: str
+    proves: str
+
+
+# The ladder in order. ``asset-validation-ladder.md`` mirrors this table and
+# tests/assets/ asserts the two agree, so the document cannot go stale.
+LEVELS: tuple[LevelSpec, ...] = (
+    LevelSpec(
+        level="L0",
+        name="contract",
+        consumes="the stable entry object and the project root",
+        proves="the entry satisfies the v1 stable-entry schema and path contract",
+    ),
+    LevelSpec(
+        level="L1",
+        name="processed_source",
+        consumes="source_layout.path",
+        proves="deterministic source processing left a real file in the stable directory",
+    ),
+    LevelSpec(
+        level="L2",
+        name="compiled_artifact",
+        consumes="godot_artifact and the compiler registry",
+        proves="a registered compiler route produced the artifact file",
+    ),
+    LevelSpec(
+        level="L3",
+        name="godot_load",
+        consumes="the artifact path and a headless Godot binary",
+        proves="Godot imports the project, ResourceLoader.load succeeds, and the type matches",
+    ),
+    LevelSpec(
+        level="L4",
+        name="structure",
+        consumes="the L3 probe result and the registered structure validator",
+        proves="the loaded resource satisfies its type-specific structural contract",
+    ),
+)
+
+LEVEL_BY_ID: dict[str, LevelSpec] = {spec.level: spec for spec in LEVELS}
+
+
+@dataclass(frozen=True)
+class LevelResult:
+    """The outcome of one level: passed, failed with a reason, or never run."""
+
+    level: str
+    name: str
+    status: str
+    error: str | None = None
+    details: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.status not in (PASSED, FAILED, NOT_RUN):
+            raise ValidationError(f"unknown level status: {self.status}")
+        if self.status == FAILED and not self.error:
+            raise ValidationError(f"{self.level} failed without an error message")
+        if self.status != FAILED and self.error:
+            raise ValidationError(f"{self.level} carries an error but did not fail")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "level": self.level,
+            "name": self.name,
+            "status": self.status,
+            "error": self.error,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class LadderResult:
+    """The verdict on one asset: every level's outcome, and whether it is ready."""
+
+    asset_id: str
+    production_family: str
+    levels: tuple[LevelResult, ...]
+
+    def __post_init__(self) -> None:
+        expected = tuple(spec.level for spec in LEVELS)
+        if tuple(result.level for result in self.levels) != expected:
+            raise ValidationError(
+                "a ladder result must report every level in order: "
+                f"{', '.join(expected)}"
+            )
+
+    @property
+    def failure(self) -> LevelResult | None:
+        """The first failed level, or ``None`` when every level passed."""
+        for result in self.levels:
+            if result.status == FAILED:
+                return result
+        return None
+
+    @property
+    def ready(self) -> bool:
+        """True only when all five levels passed."""
+        return all(result.status == PASSED for result in self.levels)
+
+    @property
+    def processing_status(self) -> str:
+        """The stable-entry status this verdict permits: ``ready`` or ``failed``."""
+        return STATUS_READY if self.ready else STATUS_FAILED
+
+    def to_dict(self) -> dict[str, Any]:
+        failure = self.failure
+        return {
+            "asset_id": self.asset_id,
+            "production_family": self.production_family,
+            "ready": self.ready,
+            "processing_status": self.processing_status,
+            "failed_level": None if failure is None else failure.level,
+            "error": None if failure is None else failure.error,
+            "levels": [result.to_dict() for result in self.levels],
+        }

--- a/skills/assets/_shared/asset_validation/godot_probe.py
+++ b/skills/assets/_shared/asset_validation/godot_probe.py
@@ -1,0 +1,282 @@
+"""Run L3 inside a real headless Godot: import the project, then load and type-check.
+
+Parsing a ``.tres`` in Python would only prove the text is well formed. It would
+not prove Godot can import the project, that ``ResourceLoader.load`` returns an
+object, or that the object is the declared ClassDB type -- and those are exactly
+the failures that reach a worker as an unusable resource. So this level shells
+out to Godot and asks it.
+
+Two runs, because they answer different questions:
+
+1. ``--import`` builds ``.godot/imported``. Without it a fresh checkout cannot
+   load a texture at all, and its absence is a real L3 failure rather than a
+   test-environment quirk.
+2. ``--script`` runs ``probe.gd``, which loads each resource and writes a JSON
+   report.
+
+The verdict comes from the report file, never from the exit code or the console.
+Godot 4.4 headless prints editor progress-dialog errors during ``--import`` and
+resource errors during a failed load, and it exits ``0`` through both, so the
+streams are captured for diagnostics only.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ._bridge import prefer_console_godot_path
+from .contract import ValidationError
+
+PROBE_SCRIPT = Path(__file__).resolve().parent / "probe.gd"
+
+# Godot's own import and script runs; generous because a first import of a
+# project with many textures is not fast, and a hang must still end as a
+# diagnosable failure rather than a stuck pipeline.
+IMPORT_TIMEOUT = 300
+SCRIPT_TIMEOUT = 300
+
+
+class GodotProbeError(ValidationError):
+    """Raised when Godot could not be asked, or did not answer."""
+
+
+@dataclass(frozen=True)
+class ProbeRequest:
+    """One resource to load, the type it must be, and the L4 facts to collect."""
+
+    res_path: str
+    expected_type: str
+    checks: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.res_path,
+            "expected_type": self.expected_type,
+            "checks": list(self.checks),
+        }
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """What Godot reported about one resource."""
+
+    res_path: str
+    expected_type: str
+    loaded: bool
+    godot_class: str
+    type_matches: bool
+    error: str | None = None
+    structure: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.res_path,
+            "expected_type": self.expected_type,
+            "loaded": self.loaded,
+            "class": self.godot_class,
+            "type_matches": self.type_matches,
+            "error": self.error,
+            "structure": dict(self.structure),
+        }
+
+
+@dataclass(frozen=True)
+class ProbeReport:
+    """One Godot run: which engine answered, and what it said about each resource.
+
+    The engine version travels with the answers because L3's verdict is only as
+    good as the build that produced it, and "ready here, broken there" is exactly
+    the report that needs it.
+    """
+
+    godot_version: str
+    resources: tuple[ProbeResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "godot_version": self.godot_version,
+            "resources": [result.to_dict() for result in self.resources],
+        }
+
+
+def _tail(text: str, limit: int = 2000) -> str:
+    """Return the end of a Godot stream, which is where its errors are."""
+    collapsed = (text or "").strip()
+    if len(collapsed) <= limit:
+        return collapsed
+    return "..." + collapsed[-limit:]
+
+
+class GodotProbe:
+    """Loads generated artifacts through a headless Godot binary.
+
+    ``godot_path`` is supplied by the caller rather than discovered here: a
+    project already resolves it through ``tools/agent_runtime.read_godot_path``,
+    and a validator that silently searched ``PATH`` could verify an asset with a
+    different engine build than the project uses.
+    """
+
+    def __init__(
+        self,
+        godot_path: str,
+        *,
+        import_timeout: int = IMPORT_TIMEOUT,
+        script_timeout: int = SCRIPT_TIMEOUT,
+    ) -> None:
+        if not isinstance(godot_path, str) or not godot_path.strip():
+            raise GodotProbeError("godot_path must be a non-empty string")
+        self._godot_path = prefer_console_godot_path(godot_path)
+        self._import_timeout = import_timeout
+        self._script_timeout = script_timeout
+
+    @property
+    def godot_path(self) -> str:
+        return self._godot_path
+
+    def _run(self, argv: list[str], *, timeout: int) -> subprocess.CompletedProcess:
+        try:
+            return subprocess.run(
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise GodotProbeError(
+                f"godot binary not found at {self._godot_path}: {exc}"
+            ) from exc
+        except OSError as exc:
+            raise GodotProbeError(
+                f"godot binary at {self._godot_path} could not be run: {exc}"
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise GodotProbeError(
+                f"godot did not finish within {timeout}s: {' '.join(argv[1:])}"
+            ) from exc
+
+    def probe(
+        self,
+        project_root: Path,
+        requests: Sequence[ProbeRequest],
+    ) -> ProbeReport:
+        """Import ``project_root`` and load every requested resource in one run."""
+        if not requests:
+            raise GodotProbeError("probe needs at least one resource request")
+        root = Path(project_root)
+        if not (root / "project.godot").is_file():
+            raise GodotProbeError(
+                f"{root} is not a Godot project: no project.godot"
+            )
+        if not PROBE_SCRIPT.is_file():
+            raise GodotProbeError(f"the probe script is missing: {PROBE_SCRIPT}")
+
+        with tempfile.TemporaryDirectory(prefix="godotmaker-l3-") as workspace:
+            work = Path(workspace)
+            request_file = work / "request.json"
+            report_file = work / "report.json"
+            request_file.write_text(
+                json.dumps({"resources": [item.to_dict() for item in requests]}),
+                encoding="utf-8",
+            )
+
+            imported = self._run(
+                [self._godot_path, "--headless", "--path", str(root), "--import"],
+                timeout=self._import_timeout,
+            )
+            if imported.returncode != 0:
+                raise GodotProbeError(
+                    f"godot --import failed with exit code {imported.returncode}: "
+                    f"{_tail(imported.stderr or imported.stdout)}"
+                )
+
+            ran = self._run(
+                [
+                    self._godot_path,
+                    "--headless",
+                    "--path",
+                    str(root),
+                    "--script",
+                    str(PROBE_SCRIPT),
+                    "--",
+                    "--request",
+                    str(request_file),
+                    "--report",
+                    str(report_file),
+                ],
+                timeout=self._script_timeout,
+            )
+            if not report_file.is_file():
+                raise GodotProbeError(
+                    f"the Godot probe wrote no report (exit code {ran.returncode}): "
+                    f"{_tail(ran.stderr or ran.stdout)}"
+                )
+            try:
+                report = json.loads(report_file.read_text(encoding="utf-8"))
+            except ValueError as exc:
+                raise GodotProbeError(f"the Godot probe report is not JSON: {exc}") from exc
+
+        return self._parse(report, requests)
+
+    @staticmethod
+    def _parse(report: Any, requests: Sequence[ProbeRequest]) -> ProbeReport:
+        if not isinstance(report, Mapping):
+            raise GodotProbeError("the Godot probe report is not a JSON object")
+        entries = report.get("resources")
+        if not isinstance(entries, list) or len(entries) != len(requests):
+            raise GodotProbeError(
+                f"the Godot probe reported {len(entries) if isinstance(entries, list) else 0} "
+                f"resources for {len(requests)} requests"
+            )
+        results: list[ProbeResult] = []
+        for request, entry in zip(requests, entries):
+            if not isinstance(entry, Mapping):
+                raise GodotProbeError("every Godot probe report entry must be an object")
+            # Pair by position and re-assert identity: a report whose rows do not
+            # line up with the requests would silently answer for another asset.
+            if entry.get("path") != request.res_path:
+                raise GodotProbeError(
+                    f"the Godot probe answered for {entry.get('path')!r} where "
+                    f"{request.res_path!r} was requested"
+                )
+            structure = entry.get("structure")
+            results.append(
+                ProbeResult(
+                    res_path=request.res_path,
+                    expected_type=request.expected_type,
+                    loaded=entry.get("loaded") is True,
+                    godot_class=str(entry.get("class") or ""),
+                    type_matches=entry.get("type_matches") is True,
+                    error=entry.get("error") or None,
+                    structure=dict(structure) if isinstance(structure, Mapping) else {},
+                )
+            )
+        return ProbeReport(
+            godot_version=str(report.get("godot_version") or ""),
+            resources=tuple(results),
+        )
+
+
+def find_godot(explicit: str | None = None) -> str | None:
+    """Return a usable godot command, or ``None``.
+
+    A convenience for callers that have no project configuration to read, such
+    as this repository's own integration tests. Production callers resolve
+    ``godot_path`` from the project instead.
+    """
+    if explicit and explicit.strip():
+        candidate = explicit.strip()
+        if Path(candidate).is_file():
+            return candidate
+        return shutil.which(candidate)
+    for name in ("godot", "godot4"):
+        found = shutil.which(name)
+        if found:
+            return found
+    return None

--- a/skills/assets/_shared/asset_validation/godot_probe.py
+++ b/skills/assets/_shared/asset_validation/godot_probe.py
@@ -35,6 +35,14 @@ from .contract import ValidationError
 
 PROBE_SCRIPT = Path(__file__).resolve().parent / "probe.gd"
 
+# The structural checks ``probe.gd`` implements, mirroring its ``KNOWN_CHECKS``;
+# tests/assets/ asserts the two agree so neither can drift. Declaring it here as
+# well is what lets a structure validator that asks for a check nobody wrote fail
+# at registration, instead of failing every asset of that type at L4 -- or, worse,
+# passing them, if the validator does not read the error the probe reported.
+# A family adds its name to both lists together with the GDScript branch.
+PROBE_CHECKS = ("texture2d",)
+
 # Godot's own import and script runs; generous because a first import of a
 # project with many textures is not fast, and a hang must still end as a
 # diagnosable failure rather than a stuck pipeline.

--- a/skills/assets/_shared/asset_validation/ladder.py
+++ b/skills/assets/_shared/asset_validation/ladder.py
@@ -1,0 +1,393 @@
+"""The L0-L4 readiness ladder: five ordered levels, one ``ready`` verdict.
+
+The ladder verifies; it does not produce. Source generation (L1) and Godot
+resource compilation (L2) have already run by the time it is called, and each
+level's job is to prove that step's result is real and belongs to this entry.
+That ordering comes straight from the pipeline the architecture defines:
+generate, process, compile, *then* validate, then register.
+
+Levels run in order and stop at the first failure, because every later level
+depends on the earlier one's output: there is no artifact to load when nothing
+compiled, and no structure to check when nothing loaded. Skipped levels are
+reported as ``not_run`` so a caller can tell "did not pass" from "was never
+asked".
+
+A reference asset has no rung on this ladder at all. It is never handed to a
+worker as a runtime game asset, compiles no Godot artifact, and completes at
+``source_ready``; asking whether it is ``ready`` is a category error, so L0
+rejects it rather than inventing a pass.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ._bridge import (
+    REFERENCE_FAMILIES,
+    REFERENCE_LAYOUTS,
+    CompileReceipt,
+    CompilerError,
+    CompilerRegistry,
+    StableEntryError,
+    assert_within_output_dir,
+    build_default_registry,
+    is_same_file,
+    resolve_res_path,
+    validate_entry,
+)
+from .contract import (
+    FAILED,
+    LEVELS,
+    NOT_RUN,
+    PASSED,
+    LadderResult,
+    LevelResult,
+    ValidationError,
+)
+from .godot_probe import GodotProbe, ProbeRequest, ProbeResult
+from .structure import (
+    StructureRequest,
+    StructureValidatorRegistry,
+    build_default_structures,
+)
+
+
+@dataclass
+class _Run:
+    """What each level hands to the next. Populated in order, never rewound."""
+
+    # Held exactly as the caller passed it: normalizing a malformed entry to an
+    # empty object here would replace L0's real complaint with a missing-field
+    # one, and the caller would go looking for the wrong problem.
+    entry: Any
+    project_root: Path
+    spec: Mapping[str, Any]
+    receipt: CompileReceipt | None = None
+    production_family: str = ""
+    asset_id: str = ""
+    source_layout_type: str = ""
+    source_path: str = ""
+    artifact_type: str = ""
+    artifact_path: str = ""
+    source_file: Path | None = None
+    artifact_file: Path | None = None
+    writes_artifact: bool = True
+    probe: ProbeResult | None = None
+
+
+class ValidationLadder:
+    """Runs L0-L4 over one stable entry and returns the readiness verdict.
+
+    The ladder never raises for a bad asset -- a failure is a result, because the
+    caller has to record which level failed and why. It raises only when it is
+    itself misconfigured, at construction.
+    """
+
+    def __init__(
+        self,
+        *,
+        registry: CompilerRegistry,
+        structures: StructureValidatorRegistry,
+        probe: GodotProbe,
+    ) -> None:
+        if not isinstance(registry, CompilerRegistry):
+            raise ValidationError("registry must be a CompilerRegistry")
+        if not isinstance(structures, StructureValidatorRegistry):
+            raise ValidationError("structures must be a StructureValidatorRegistry")
+        if not isinstance(probe, GodotProbe):
+            raise ValidationError("probe must be a GodotProbe")
+        self._registry = registry
+        self._structures = structures
+        self._probe = probe
+
+    def run(
+        self,
+        entry: Any,
+        *,
+        project_root: Path,
+        spec: Mapping[str, Any] | None = None,
+        receipt: CompileReceipt | None = None,
+    ) -> LadderResult:
+        """Validate one stable entry and return every level's outcome."""
+        if not isinstance(project_root, (str, Path)):
+            return self._verdict(
+                _Run(entry=entry, project_root=Path("."), spec={}),
+                [
+                    LevelResult(
+                        level=LEVELS[0].level,
+                        name=LEVELS[0].name,
+                        status=FAILED,
+                        error="project_root must be a path",
+                    )
+                ],
+            )
+        run = _Run(
+            entry=entry,
+            project_root=Path(project_root),
+            spec=dict(spec or {}),
+            receipt=receipt,
+        )
+
+        steps = (self._l0, self._l1, self._l2, self._l3, self._l4)
+        results: list[LevelResult] = []
+        for spec_row, step in zip(LEVELS, steps):
+            try:
+                details = step(run)
+            except (ValidationError, StableEntryError, CompilerError) as exc:
+                results.append(
+                    LevelResult(
+                        level=spec_row.level,
+                        name=spec_row.name,
+                        status=FAILED,
+                        error=str(exc),
+                    )
+                )
+                break
+            results.append(
+                LevelResult(
+                    level=spec_row.level,
+                    name=spec_row.name,
+                    status=PASSED,
+                    details=details,
+                )
+            )
+        return self._verdict(run, results)
+
+    @staticmethod
+    def _verdict(run: _Run, results: list[LevelResult]) -> LadderResult:
+        """Pad the levels that never ran and assemble the result."""
+        filled = list(results)
+        for spec_row in LEVELS[len(filled):]:
+            filled.append(
+                LevelResult(level=spec_row.level, name=spec_row.name, status=NOT_RUN)
+            )
+        declared = run.entry if isinstance(run.entry, Mapping) else {}
+        return LadderResult(
+            asset_id=run.asset_id or str(declared.get("asset_id") or ""),
+            production_family=run.production_family
+            or str(declared.get("production_family") or ""),
+            levels=tuple(filled),
+        )
+
+    # ------------------------------------------------------------------ L0
+    def _l0(self, run: _Run) -> dict[str, Any]:
+        """The entry itself must satisfy the v1 stable-entry contract."""
+        validated = validate_entry(run.entry, project_root=run.project_root)
+
+        family = validated["production_family"]
+        layout = validated["source_layout"]
+        layout_type = layout["type"]
+        if layout_type in REFERENCE_LAYOUTS or family in REFERENCE_FAMILIES:
+            raise ValidationError(
+                "a reference asset is never handed to a worker as a runtime game "
+                "asset and has no L0-L4 readiness ladder; it completes at "
+                "source_ready"
+            )
+
+        run.production_family = family
+        run.asset_id = validated["asset_id"]
+        run.source_layout_type = layout_type
+        run.source_path = layout["path"]
+        artifact = validated.get("godot_artifact")
+        if isinstance(artifact, Mapping):
+            run.artifact_type = artifact["type"]
+            run.artifact_path = artifact["path"]
+        return {
+            "production_family": family,
+            "asset_id": run.asset_id,
+            "source_layout_type": layout_type,
+            "processing_status": validated["processing_status"],
+        }
+
+    # ------------------------------------------------------------------ L1
+    def _l1(self, run: _Run) -> dict[str, Any]:
+        """Deterministic processing must have left a real file behind."""
+        run.source_file = self._resolve(run, run.source_path, "source_layout.path")
+        size = self._require_file(run.source_file, run.source_path, "source_layout.path")
+        return {"source_path": run.source_path, "bytes": size}
+
+    # ------------------------------------------------------------------ L2
+    def _l2(self, run: _Run) -> dict[str, Any]:
+        """A registered compiler route must have produced the artifact."""
+        if not run.artifact_path:
+            raise ValidationError(
+                "the entry declares no godot_artifact, so no native Godot resource "
+                "was compiled for it"
+            )
+        route = self._registry.resolve(run.source_layout_type, run.artifact_type)
+        run.writes_artifact = route.writes_artifact
+        run.artifact_file = self._resolve(run, run.artifact_path, "godot_artifact.path")
+        size = self._require_file(
+            run.artifact_file, run.artifact_path, "godot_artifact.path"
+        )
+
+        # The same rule the registry enforces at compile time, re-checked here
+        # because the ladder also runs on entries it did not compile: a writing
+        # route that names its source is publishing the source image as the
+        # resource a worker was promised.
+        if run.source_file is None:
+            raise ValidationError("L2 ran without a source file resolved by L1")
+        paths_match = run.artifact_path == run.source_path
+        if route.writes_artifact:
+            if paths_match or is_same_file(run.source_file, run.artifact_file):
+                raise ValidationError(
+                    f"{route.compiler_id} compiles a new file, so "
+                    f"godot_artifact.path may not be the source image itself "
+                    f"({run.artifact_path})"
+                )
+        elif not paths_match:
+            raise ValidationError(
+                f"{route.compiler_id} writes no file, so godot_artifact.path must "
+                f"equal source_layout.path; got {run.artifact_path} instead of "
+                f"{run.source_path}"
+            )
+
+        details: dict[str, Any] = {
+            "compiler_id": route.compiler_id,
+            "compiler_version": route.compiler_version,
+            "writes_artifact": route.writes_artifact,
+            "artifact_path": run.artifact_path,
+            "bytes": size,
+        }
+        if run.receipt is not None:
+            details["receipt"] = self._check_receipt(run, route)
+        return details
+
+    @staticmethod
+    def _check_receipt(run: _Run, route: Any) -> dict[str, Any]:
+        """Bind an optional compile receipt to the entry it claims to describe.
+
+        The receipt is optional because re-validating a registered asset has none
+        to offer. When one is supplied it must be this asset's: a receipt for a
+        different asset, layout, or artifact would otherwise be accepted as
+        evidence that this entry was compiled.
+        """
+        receipt = run.receipt
+        if not isinstance(receipt, CompileReceipt):
+            raise ValidationError(
+                "receipt must be a CompileReceipt returned by the compiler registry"
+            )
+        expected = {
+            "compiler_id": route.compiler_id,
+            "production_family": run.production_family,
+            "asset_id": run.asset_id,
+            "source_layout_type": run.source_layout_type,
+            "source_path": run.source_path,
+            "artifact_type": run.artifact_type,
+            "artifact_path": run.artifact_path,
+        }
+        for name, value in expected.items():
+            actual = getattr(receipt, name, None)
+            if actual != value:
+                raise ValidationError(
+                    f"the supplied compile receipt describes {name} {actual!r}, not "
+                    f"this entry's {value!r}"
+                )
+        return {
+            "compiler_id": receipt.compiler_id,
+            "compiler_version": receipt.compiler_version,
+        }
+
+    # ------------------------------------------------------------------ L3
+    def _l3(self, run: _Run) -> dict[str, Any]:
+        """Godot must import the project, load the artifact, and agree on its type."""
+        request = ProbeRequest(
+            res_path=run.artifact_path,
+            expected_type=run.artifact_type,
+            checks=self._structures.checks_for(run.artifact_type),
+        )
+        report = self._probe.probe(run.project_root, [request])
+        probe = report.resources[0]
+        run.probe = probe
+        if not probe.loaded:
+            raise ValidationError(
+                probe.error
+                or f"Godot could not load {run.artifact_path}"
+            )
+        if not probe.type_matches:
+            raise ValidationError(
+                f"Godot loaded {run.artifact_path} as {probe.godot_class}, which is "
+                f"not a {run.artifact_type}"
+            )
+        return {
+            "godot_version": report.godot_version,
+            "godot_class": probe.godot_class,
+            "expected_type": run.artifact_type,
+            "structure": dict(probe.structure),
+        }
+
+    # ------------------------------------------------------------------ L4
+    def _l4(self, run: _Run) -> dict[str, Any]:
+        """The loaded resource must satisfy its type-specific structural contract."""
+        if run.probe is None:
+            raise ValidationError("L4 ran without a Godot probe result from L3")
+        request = StructureRequest(
+            production_family=run.production_family,
+            asset_id=run.asset_id,
+            source_layout_type=run.source_layout_type,
+            source_path=run.source_path,
+            artifact_type=run.artifact_type,
+            artifact_path=run.artifact_path,
+            project_root=run.project_root,
+            probe=run.probe,
+            spec=run.spec,
+        )
+        details = dict(self._structures.validate(request))
+        details["validator_id"] = self._structures.resolve(run.artifact_type).validator_id
+        return details
+
+    # -------------------------------------------------------------- helpers
+    @staticmethod
+    def _resolve(run: _Run, res_path: str, label: str) -> Path:
+        """Resolve a ``res://`` path and re-assert it lands in the stable directory.
+
+        L0 checked the path string. This checks where it actually points, so a
+        symlink inside the stable directory cannot aim the ladder at a file it
+        was never allowed to accept.
+        """
+        try:
+            return assert_within_output_dir(
+                run.project_root,
+                resolve_res_path(run.project_root, res_path, label=label),
+                production_family=run.production_family,
+                asset_id=run.asset_id,
+                label=label,
+            )
+        except OSError as exc:
+            # Resolution itself can fail on a path the filesystem rejects; that
+            # is still an unusable asset, not a crash for the caller to handle.
+            raise ValidationError(f"{label} cannot be resolved: {res_path} ({exc})") from exc
+
+    @staticmethod
+    def _require_file(resolved: Path, res_path: str, label: str) -> int:
+        """Require a non-empty regular file and return its size."""
+        if not resolved.is_file():
+            raise ValidationError(f"{label} is not a file on disk: {res_path}")
+        try:
+            size = resolved.stat().st_size
+        except OSError as exc:
+            raise ValidationError(f"{label} cannot be read: {res_path} ({exc})") from exc
+        if size <= 0:
+            raise ValidationError(f"{label} is an empty file: {res_path}")
+        return size
+
+
+def build_default_ladder(
+    godot_path: str,
+    *,
+    registry: CompilerRegistry | None = None,
+    structures: StructureValidatorRegistry | None = None,
+) -> ValidationLadder:
+    """Return a ladder wired to the compilers and validators the shared layer ships.
+
+    A family skill that registers its own compiler and structure validator builds
+    both registries itself and constructs :class:`ValidationLadder` directly;
+    this is the shortest path for a caller that only needs the shared routes.
+    """
+    return ValidationLadder(
+        registry=registry if registry is not None else build_default_registry(),
+        structures=structures if structures is not None else build_default_structures(),
+        probe=GodotProbe(godot_path),
+    )

--- a/skills/assets/_shared/asset_validation/probe.gd
+++ b/skills/assets/_shared/asset_validation/probe.gd
@@ -1,0 +1,129 @@
+# L3 of the asset readiness ladder, running inside headless Godot.
+#
+# Reads a request JSON, loads each resource through ResourceLoader, and writes a
+# report JSON. It reports facts and never decides readiness: the Python side
+# owns the verdict, so a probe that cannot answer produces an error string
+# rather than an optimistic default.
+#
+# The report goes to a file rather than stdout because Godot writes engine
+# banners, import notices, and resource errors to the same streams, and a
+# resource that fails to load is exactly the case that floods them.
+#
+# Invoked as:
+#   godot --headless --path <project> --script <this file> --
+#         --request <abs path> --report <abs path>
+extends SceneTree
+
+# Structural facts a resource may be asked to report for L4. The set is closed:
+# an unknown check is an error, never a silent pass. A family skill adds its
+# check name here together with the Python structure validator that consumes it.
+const KNOWN_CHECKS := ["texture2d"]
+
+
+func _parse_user_args() -> Dictionary:
+	var options := {}
+	var args := OS.get_cmdline_user_args()
+	var index := 0
+	while index < args.size():
+		var argument: String = args[index]
+		if argument.begins_with("--") and index + 1 < args.size():
+			options[argument.substr(2)] = args[index + 1]
+			index += 2
+		else:
+			index += 1
+	return options
+
+
+func _structure(resource: Resource, checks: Array) -> Dictionary:
+	var structure := {}
+	for check in checks:
+		if not (check in KNOWN_CHECKS):
+			structure[check] = {"error": "unknown structural check: %s" % check}
+			continue
+		match check:
+			"texture2d":
+				if resource.is_class("Texture2D"):
+					structure[check] = {
+						"width": resource.get_width(),
+						"height": resource.get_height(),
+					}
+				else:
+					structure[check] = {
+						"error": "resource is a %s, not a Texture2D" % resource.get_class(),
+					}
+	return structure
+
+
+func _probe(item: Dictionary) -> Dictionary:
+	var path: String = item.get("path", "")
+	var expected_type: String = item.get("expected_type", "")
+	var report := {
+		"path": path,
+		"expected_type": expected_type,
+		"loaded": false,
+		"class": "",
+		"type_matches": false,
+		"structure": {},
+		"error": null,
+	}
+	if path == "" or expected_type == "":
+		report["error"] = "request item needs both a path and an expected_type"
+		return report
+	if not ResourceLoader.exists(path):
+		report["error"] = "Godot has no importable resource at %s" % path
+		return report
+	# CACHE_MODE_IGNORE forces a real load: a cached instance from an earlier
+	# probe in the same run would prove nothing about the file on disk.
+	var resource := ResourceLoader.load(path, "", ResourceLoader.CACHE_MODE_IGNORE)
+	if resource == null:
+		report["error"] = "ResourceLoader.load returned null for %s" % path
+		return report
+	report["loaded"] = true
+	report["class"] = resource.get_class()
+	# is_class covers the whole inheritance chain, so an imported PNG reporting
+	# CompressedTexture2D still matches a declared Texture2D.
+	report["type_matches"] = resource.is_class(expected_type)
+	report["structure"] = _structure(resource, item.get("checks", []))
+	return report
+
+
+func _fail(message: String, code: int) -> void:
+	printerr("asset validation probe: %s" % message)
+	quit(code)
+
+
+func _initialize() -> void:
+	var options := _parse_user_args()
+	var request_path: String = options.get("request", "")
+	var report_path: String = options.get("report", "")
+	if request_path == "" or report_path == "":
+		_fail("both --request and --report are required", 2)
+		return
+
+	var request_file := FileAccess.open(request_path, FileAccess.READ)
+	if request_file == null:
+		_fail("cannot read request file %s" % request_path, 2)
+		return
+	var request = JSON.parse_string(request_file.get_as_text())
+	request_file.close()
+	if typeof(request) != TYPE_DICTIONARY:
+		_fail("request file %s is not a JSON object" % request_path, 2)
+		return
+
+	var reports := []
+	for item in request.get("resources", []):
+		if typeof(item) != TYPE_DICTIONARY:
+			_fail("every request resource must be a JSON object", 2)
+			return
+		reports.append(_probe(item))
+
+	var report_file := FileAccess.open(report_path, FileAccess.WRITE)
+	if report_file == null:
+		_fail("cannot write report file %s" % report_path, 3)
+		return
+	report_file.store_string(JSON.stringify({
+		"godot_version": Engine.get_version_info().get("string", ""),
+		"resources": reports,
+	}))
+	report_file.close()
+	quit(0)

--- a/skills/assets/_shared/asset_validation/structure.py
+++ b/skills/assets/_shared/asset_validation/structure.py
@@ -1,0 +1,199 @@
+"""L4: the type-specific structural contract, and the registry families extend.
+
+L3 proves Godot produced *a* resource of the declared type. It cannot prove the
+resource says anything useful: a ``SpriteFrames`` with no animations, a ``Theme``
+with no type overrides, and a ``TileSet`` with no sources all load fine and are
+all unusable. What "useful" means is per type, so L4 is an extension point, not
+a fixed check.
+
+A family skill registers one validator for the artifact type it compiles,
+together with the structural facts its validator needs ``probe.gd`` to collect.
+The registry fails closed on an unregistered type: an artifact nobody can check
+must not reach ``ready`` just because no one wrote the check yet.
+
+The shared layer ships exactly one validator, for the one artifact type it
+compiles -- ``Texture2D``, through ``asset_compiler/texture2d.py``. Every other
+type lands with its family skill.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from ._bridge import LAYOUT_ARTIFACT_TYPES
+from .contract import ValidationError
+from .godot_probe import ProbeResult
+
+# Every artifact type the frozen stable-entry relation allows. A validator for a
+# type outside it could never run, so registering one is a mistake, not a
+# forward-compatible extension.
+KNOWN_ARTIFACT_TYPES = frozenset(
+    artifact_type
+    for artifact_types in LAYOUT_ARTIFACT_TYPES.values()
+    for artifact_type in artifact_types
+)
+
+
+@dataclass(frozen=True)
+class StructureRequest:
+    """Everything a structure validator is allowed to know about one artifact."""
+
+    production_family: str
+    asset_id: str
+    source_layout_type: str
+    source_path: str
+    artifact_type: str
+    artifact_path: str
+    project_root: Path
+    probe: ProbeResult
+    spec: Mapping[str, Any] = field(default_factory=dict)
+
+
+# A validator raises ``ValidationError`` when the structure is unusable and
+# returns the facts it checked otherwise. Those facts land in the L4 details of
+# the ladder result; they are diagnostics, never part of the worker snapshot.
+StructureValidator = Callable[[StructureRequest], Mapping[str, Any]]
+
+
+@dataclass(frozen=True)
+class StructureRoute:
+    """One artifact type bound to the validator that judges its structure."""
+
+    artifact_type: str
+    validator_id: str
+    validator: StructureValidator
+    checks: tuple[str, ...] = ()
+
+
+class StructureValidatorRegistry:
+    """Holds the L4 validator for each artifact type an asset skill may produce."""
+
+    def __init__(self) -> None:
+        self._routes: dict[str, StructureRoute] = {}
+
+    def register(
+        self,
+        *,
+        artifact_type: str,
+        validator_id: str,
+        validator: StructureValidator,
+        checks: tuple[str, ...] = (),
+    ) -> StructureRoute:
+        """Bind one validator to one artifact type."""
+        for label, value in (
+            ("artifact_type", artifact_type),
+            ("validator_id", validator_id),
+        ):
+            if not isinstance(value, str) or not value.strip():
+                raise ValidationError(f"{label} must be a non-empty string")
+        if artifact_type not in KNOWN_ARTIFACT_TYPES:
+            raise ValidationError(
+                f"no source layout compiles to {artifact_type}; allowed: "
+                f"{', '.join(sorted(KNOWN_ARTIFACT_TYPES))}"
+            )
+        if not callable(validator):
+            raise ValidationError("validator must be callable")
+        if not isinstance(checks, tuple) or not all(
+            isinstance(check, str) and check.strip() for check in checks
+        ):
+            raise ValidationError("checks must be a tuple of non-empty strings")
+        existing = self._routes.get(artifact_type)
+        if existing is not None:
+            raise ValidationError(
+                f"{artifact_type} is already validated by {existing.validator_id}"
+            )
+        route = StructureRoute(
+            artifact_type=artifact_type,
+            validator_id=validator_id,
+            validator=validator,
+            checks=checks,
+        )
+        self._routes[artifact_type] = route
+        return route
+
+    def routes(self) -> tuple[StructureRoute, ...]:
+        """Return every registered route, ordered by artifact type."""
+        return tuple(self._routes[key] for key in sorted(self._routes))
+
+    def resolve(self, artifact_type: str) -> StructureRoute:
+        """Return the route for one artifact type, or fail closed."""
+        route = self._routes.get(artifact_type)
+        if route is None:
+            registered = ", ".join(sorted(self._routes))
+            raise ValidationError(
+                f"no structure validator is registered for {artifact_type}, so its "
+                f"structure cannot be verified; registered: {registered or 'none'}"
+            )
+        return route
+
+    def checks_for(self, artifact_type: str) -> tuple[str, ...]:
+        """Return the probe checks L3 must collect for this type.
+
+        An unregistered type returns no checks rather than raising: L3 still runs
+        and reports its own verdict, and L4 is where the missing validator is
+        reported.
+        """
+        route = self._routes.get(artifact_type)
+        return () if route is None else route.checks
+
+    def validate(self, request: StructureRequest) -> Mapping[str, Any]:
+        """Run the registered validator and normalize how it may fail."""
+        route = self.resolve(request.artifact_type)
+        try:
+            details = route.validator(request)
+        except ValidationError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - surfaced as a validation error
+            raise ValidationError(f"{route.validator_id} failed: {exc}") from exc
+        if not isinstance(details, Mapping):
+            raise ValidationError(
+                f"{route.validator_id} must return a mapping of checked facts"
+            )
+        return dict(details)
+
+
+TEXTURE2D_VALIDATOR_ID = "texture2d_structure"
+TEXTURE2D_CHECKS = ("texture2d",)
+
+
+def validate_texture2d(request: StructureRequest) -> dict[str, Any]:
+    """Require the loaded texture to have real pixels.
+
+    A ``Texture2D`` that imported and loaded can still be a zero-sized image, and
+    binding one gives a worker an invisible sprite with no error anywhere. Godot
+    reports the dimensions of the loaded resource, not of the file on disk, so
+    this is the imported result being checked rather than the source PNG.
+    """
+    structure = request.probe.structure.get("texture2d")
+    if not isinstance(structure, Mapping):
+        raise ValidationError(
+            "the Godot probe collected no texture2d structure for "
+            f"{request.artifact_path}"
+        )
+    reported = structure.get("error")
+    if reported:
+        raise ValidationError(str(reported))
+    dimensions: dict[str, int] = {}
+    for axis in ("width", "height"):
+        value = structure.get(axis)
+        if type(value) is not int or value <= 0:
+            raise ValidationError(
+                f"the loaded Texture2D reports {axis} {value!r}; a usable texture "
+                "needs a positive width and height"
+            )
+        dimensions[axis] = value
+    return dimensions
+
+
+def build_default_structures() -> StructureValidatorRegistry:
+    """Return a new registry holding every validator the shared layer ships."""
+    registry = StructureValidatorRegistry()
+    registry.register(
+        artifact_type="Texture2D",
+        validator_id=TEXTURE2D_VALIDATOR_ID,
+        validator=validate_texture2d,
+        checks=TEXTURE2D_CHECKS,
+    )
+    return registry

--- a/skills/assets/_shared/asset_validation/structure.py
+++ b/skills/assets/_shared/asset_validation/structure.py
@@ -11,6 +11,13 @@ together with the structural facts its validator needs ``probe.gd`` to collect.
 The registry fails closed on an unregistered type: an artifact nobody can check
 must not reach ``ready`` just because no one wrote the check yet.
 
+The registry also owns whether those facts were actually collected. A check name
+``probe.gd`` does not implement is rejected at registration, and a declared check
+the probe could not answer fails the level before the validator runs -- otherwise
+a validator that simply ignores ``request.probe.structure`` would return normally
+and carry the ladder to ``ready`` while the L3 details record that the check was
+impossible.
+
 The shared layer ships exactly one validator, for the one artifact type it
 compiles -- ``Texture2D``, through ``asset_compiler/texture2d.py``. Every other
 type lands with its family skill.
@@ -24,7 +31,7 @@ from typing import Any, Callable
 
 from ._bridge import LAYOUT_ARTIFACT_TYPES
 from .contract import ValidationError
-from .godot_probe import ProbeResult
+from .godot_probe import PROBE_CHECKS, ProbeResult
 
 # Every artifact type the frozen stable-entry relation allows. A validator for a
 # type outside it could never run, so registering one is a mistake, not a
@@ -49,6 +56,29 @@ class StructureRequest:
     project_root: Path
     probe: ProbeResult
     spec: Mapping[str, Any] = field(default_factory=dict)
+
+    def checked_structure(self, check: str) -> Mapping[str, Any]:
+        """Return the facts Godot collected for one check, or fail closed.
+
+        The single place that decides whether a structural check was answered.
+        The registry calls it for every declared check before the validator runs,
+        and a validator reads its own facts through it, so a validator used
+        outside the registry gets the same guarantee rather than an attribute
+        error on a missing answer.
+        """
+        answered = self.probe.structure.get(check)
+        if not isinstance(answered, Mapping):
+            raise ValidationError(
+                f"the Godot probe reported no {check!r} structural check for "
+                f"{self.artifact_path}"
+            )
+        reported = answered.get("error")
+        if reported:
+            raise ValidationError(
+                f"the {check!r} structural check could not be performed on "
+                f"{self.artifact_path}: {reported}"
+            )
+        return answered
 
 
 # A validator raises ``ValidationError`` when the structure is unusable and
@@ -99,6 +129,12 @@ class StructureValidatorRegistry:
             isinstance(check, str) and check.strip() for check in checks
         ):
             raise ValidationError("checks must be a tuple of non-empty strings")
+        unknown = tuple(check for check in checks if check not in PROBE_CHECKS)
+        if unknown:
+            raise ValidationError(
+                f"probe.gd implements no structural check named "
+                f"{', '.join(unknown)}; implemented: {', '.join(PROBE_CHECKS)}"
+            )
         existing = self._routes.get(artifact_type)
         if existing is not None:
             raise ValidationError(
@@ -138,9 +174,27 @@ class StructureValidatorRegistry:
         route = self._routes.get(artifact_type)
         return () if route is None else route.checks
 
+    @staticmethod
+    def _require_answered_checks(route: StructureRoute, request: StructureRequest) -> None:
+        """Fail before the validator runs if Godot did not answer a declared check.
+
+        The registry, not the validator, owns this. A validator that never reads
+        ``request.probe.structure`` -- or reads only part of it -- would otherwise
+        return normally and carry the whole ladder to ``ready`` while the probe
+        result sitting in the L3 details says the check could not be performed.
+        Making every validator repeat the guard would only mean every family gets
+        one chance to forget it.
+
+        ``checks`` are what the validator declared it needs, so a missing or
+        errored one is a level that did not run, not an optional extra.
+        """
+        for check in route.checks:
+            request.checked_structure(check)
+
     def validate(self, request: StructureRequest) -> Mapping[str, Any]:
         """Run the registered validator and normalize how it may fail."""
         route = self.resolve(request.artifact_type)
+        self._require_answered_checks(route, request)
         try:
             details = route.validator(request)
         except ValidationError:
@@ -165,16 +219,13 @@ def validate_texture2d(request: StructureRequest) -> dict[str, Any]:
     binding one gives a worker an invisible sprite with no error anywhere. Godot
     reports the dimensions of the loaded resource, not of the file on disk, so
     this is the imported result being checked rather than the source PNG.
+
+    The template for a family validator: read the declared checks through
+    :meth:`StructureRequest.checked_structure` and judge only what this type
+    means. Whether the probe answered at all is the registry's guarantee, not
+    something each validator re-implements.
     """
-    structure = request.probe.structure.get("texture2d")
-    if not isinstance(structure, Mapping):
-        raise ValidationError(
-            "the Godot probe collected no texture2d structure for "
-            f"{request.artifact_path}"
-        )
-    reported = structure.get("error")
-    if reported:
-        raise ValidationError(str(reported))
+    structure = request.checked_structure("texture2d")
     dimensions: dict[str, int] = {}
     for axis in ("width", "height"):
         value = structure.get(axis)

--- a/tests/assets/conftest.py
+++ b/tests/assets/conftest.py
@@ -1,0 +1,54 @@
+"""Shared fixtures for the asset skill test suites.
+
+The Godot integration tests need a real engine binary. CI installs only pytest
+and pillow, so they skip there and run wherever a Godot 4.4+ build is reachable.
+``GODOT_PATH`` is the environment variable the rest of this ecosystem already
+uses (``tools/publish.py`` passes it to the Godot MCP server), so it is honoured
+here rather than inventing a second name.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
+for _directory in (SHARED_DIR, REPO_ROOT / "tools"):
+    if str(_directory) not in sys.path:
+        sys.path.insert(0, str(_directory))
+
+from asset_validation import find_godot  # noqa: E402
+
+PROJECT_GODOT = """config_version=5
+
+[application]
+
+config/name="validation-fixture"
+config/features=PackedStringArray("4.4")
+
+[debug]
+
+file_logging/enable_file_logging=false
+"""
+
+
+@pytest.fixture(scope="session")
+def godot_bin() -> str:
+    """An absolute path to a Godot binary, or skip the test."""
+    resolved = find_godot(os.environ.get("GODOT_PATH"))
+    if not resolved:
+        pytest.skip(
+            "no Godot binary found; set GODOT_PATH or put godot on PATH to run "
+            "the L3 integration tests"
+        )
+    return resolved
+
+
+@pytest.fixture
+def godot_project(tmp_path: Path) -> Path:
+    """A minimal, importable Godot project rooted in a temp directory."""
+    root = tmp_path / "game"
+    root.mkdir()
+    (root / "project.godot").write_text(PROJECT_GODOT, encoding="utf-8")
+    return root

--- a/tests/assets/test_asset_validation_contract_docs.py
+++ b/tests/assets/test_asset_validation_contract_docs.py
@@ -1,0 +1,106 @@
+"""Bind the readiness-ladder doc, the Python levels, and the GDScript probe.
+
+The doc's ladder table is a human-readable mirror of ``LEVELS``, and the probe's
+``KNOWN_CHECKS`` must cover every check a registered structure validator asks
+for. Nothing else notices when one of the three drifts.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
+CONTRACT_DOC = SHARED_DIR / "asset-validation-ladder.md"
+sys.path.insert(0, str(SHARED_DIR))
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from asset_validation import (  # noqa: E402
+    LEVELS,
+    PROBE_SCRIPT,
+    build_default_structures,
+)
+
+_ROW = re.compile(
+    r"^\|\s*`(?P<level>L\d)`\s*\|\s*`(?P<name>\w+)`\s*\|"
+    r"(?P<consumes>[^|]+)\|(?P<proves>[^|]+)\|\s*$"
+)
+_KNOWN_CHECKS = re.compile(r"^const KNOWN_CHECKS := \[(?P<items>[^\]]*)\]", re.MULTILINE)
+
+
+def _documented_levels():
+    rows = []
+    for line in CONTRACT_DOC.read_text(encoding="utf-8").splitlines():
+        match = _ROW.match(line)
+        if match is not None:
+            rows.append(
+                (
+                    match.group("level"),
+                    match.group("name"),
+                    match.group("consumes").strip(),
+                    match.group("proves").strip(),
+                )
+            )
+    return rows
+
+
+def _probe_known_checks() -> tuple[str, ...]:
+    text = PROBE_SCRIPT.read_text(encoding="utf-8")
+    match = _KNOWN_CHECKS.search(text)
+    assert match is not None, "probe.gd no longer declares KNOWN_CHECKS"
+    return tuple(
+        item.strip().strip('"') for item in match.group("items").split(",") if item.strip()
+    )
+
+
+def test_the_documented_ladder_matches_the_implemented_levels():
+    assert _documented_levels() == [
+        (spec.level, spec.name, spec.consumes, spec.proves) for spec in LEVELS
+    ]
+
+
+def test_the_doc_states_the_rules_the_ladder_enforces():
+    doc = CONTRACT_DOC.read_text(encoding="utf-8")
+    for claim in (
+        "ResourceLoader.load",
+        "--import",
+        "is_class",
+        "not_run",
+        "source_ready",
+        "ValidationError",
+        "GodotProbeError",
+        "StructureValidatorRegistry",
+        "build_default_structures()",
+        "build_default_ladder()",
+        "KNOWN_CHECKS",
+    ):
+        assert claim in doc, f"the contract doc no longer mentions {claim}"
+
+
+def test_the_doc_does_not_promise_the_private_evaluation_layers():
+    doc = CONTRACT_DOC.read_text(encoding="utf-8")
+    # L5 and L6 are named only to place them outside this layer.
+    assert "not runtime readiness gates" in doc
+    assert "GodotMakerApp" in doc
+
+
+def test_every_registered_structure_check_is_implemented_by_the_probe():
+    known = _probe_known_checks()
+    for route in build_default_structures().routes():
+        for check in route.checks:
+            assert check in known, (
+                f"{route.validator_id} asks for the {check!r} structural check, "
+                "which probe.gd does not implement"
+            )
+
+
+def test_the_probe_script_runs_as_a_headless_scene_tree():
+    text = PROBE_SCRIPT.read_text(encoding="utf-8")
+    assert "extends SceneTree" in text
+    assert "func _initialize()" in text
+    # The verdict travels through the report file, never the console.
+    assert "FileAccess.open(report_path, FileAccess.WRITE)" in text
+
+
+def test_shared_has_no_skill_md():
+    # _shared holds cross-skill material and is not independently triggerable.
+    assert not (SHARED_DIR / "SKILL.md").exists()

--- a/tests/assets/test_asset_validation_contract_docs.py
+++ b/tests/assets/test_asset_validation_contract_docs.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(REPO_ROOT / "tools"))
 
 from asset_validation import (  # noqa: E402
     LEVELS,
+    PROBE_CHECKS,
     PROBE_SCRIPT,
     build_default_structures,
 )
@@ -72,6 +73,8 @@ def test_the_doc_states_the_rules_the_ladder_enforces():
         "build_default_structures()",
         "build_default_ladder()",
         "KNOWN_CHECKS",
+        "PROBE_CHECKS",
+        "checked_structure",
     ):
         assert claim in doc, f"the contract doc no longer mentions {claim}"
 
@@ -81,6 +84,13 @@ def test_the_doc_does_not_promise_the_private_evaluation_layers():
     # L5 and L6 are named only to place them outside this layer.
     assert "not runtime readiness gates" in doc
     assert "GodotMakerApp" in doc
+
+
+def test_the_python_check_list_matches_the_probe_script():
+    # PROBE_CHECKS gates registration; KNOWN_CHECKS is what the engine can answer.
+    # If they drift, a validator can register a check Godot will only ever answer
+    # with an error.
+    assert _probe_known_checks() == tuple(PROBE_CHECKS)
 
 
 def test_every_registered_structure_check_is_implemented_by_the_probe():

--- a/tests/assets/test_asset_validation_godot.py
+++ b/tests/assets/test_asset_validation_godot.py
@@ -223,6 +223,55 @@ def test_the_probe_reports_a_path_godot_cannot_import(godot_bin, godot_project):
     assert "no importable resource" in absent.error
 
 
+def test_a_check_godot_cannot_answer_fails_l4_even_if_the_validator_ignores_it(
+    godot_bin, godot_project
+):
+    """Registration cannot catch this one: the check name is implemented.
+
+    ``texture2d`` is a legal check, but the artifact is a ``StyleBoxTexture``, so
+    the engine answers with an error instead of dimensions. The validator here
+    returns ``{}`` without reading the probe -- L4 must still fail, on Godot's
+    answer alone.
+    """
+    registry = build_default_registry()
+    registry.register(
+        source_layout_type="single",
+        artifact_type="StyleBoxTexture",
+        compiler_id="test_stylebox",
+        compiler_version=1,
+        compiler=lambda request: {},
+    )
+    structures = build_default_structures()
+    structures.register(
+        artifact_type="StyleBoxTexture",
+        validator_id="ignores_the_probe",
+        validator=lambda request: {},
+        checks=("texture2d",),
+    )
+    _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(8, 8))
+    _write(
+        godot_project,
+        "res://assets/generated/ui-kit/panel/panel.tres",
+        b'[gd_resource type="StyleBoxTexture" format=3]\n\n[resource]\n',
+    )
+    entry = _entry(
+        godot_artifact={
+            "type": "StyleBoxTexture",
+            "path": "res://assets/generated/ui-kit/panel/panel.tres",
+        }
+    )
+    ladder = ValidationLadder(
+        registry=registry, structures=structures, probe=GodotProbe(godot_bin)
+    )
+    result = ladder.run(entry, project_root=godot_project)
+
+    assert result.levels[3].status == PASSED
+    assert result.ready is False, result.to_dict()
+    assert result.failure.level == "L4"
+    assert "could not be performed" in result.failure.error
+    assert "not a Texture2D" in result.failure.error
+
+
 def test_the_probe_reports_an_unknown_structural_check(godot_bin, godot_project):
     """A check name probe.gd does not implement is an error, never a silent pass."""
     _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(4, 4))

--- a/tests/assets/test_asset_validation_godot.py
+++ b/tests/assets/test_asset_validation_godot.py
@@ -1,0 +1,284 @@
+"""L3 against a real engine: import the project, load the resource, match the type.
+
+These are the tests the unit suite cannot stand in for. A stubbed probe proves
+the ladder reacts correctly to an answer; only Godot proves the answer. They skip
+when no engine is reachable -- CI installs pytest and pillow only -- so a
+contributor with Godot 4.4+ installed runs them and CI does not.
+"""
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from asset_compiler import build_default_registry  # noqa: E402
+from asset_validation import (  # noqa: E402
+    NOT_RUN,
+    PASSED,
+    GodotProbe,
+    ProbeRequest,
+    ValidationLadder,
+    build_default_ladder,
+    build_default_structures,
+)
+
+# A Theme with no content: it loads cleanly, which is what makes it a useful
+# stand-in for a resource of the wrong type.
+THEME_TRES = '[gd_resource type="Theme" format=3]\n\n[resource]\n'
+
+
+def _png(width: int, height: int) -> bytes:
+    """Return a solid RGBA PNG of exactly this size, without a Pillow dependency."""
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        payload = tag + data
+        return (
+            struct.pack(">I", len(data))
+            + payload
+            + struct.pack(">I", zlib.crc32(payload) & 0xFFFFFFFF)
+        )
+
+    scanlines = b"".join(b"\x00" + b"\x40\x80\xc0\xff" * width for _ in range(height))
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(scanlines))
+        + chunk(b"IEND", b"")
+    )
+
+
+def _write(root: Path, res_path: str, payload: bytes) -> Path:
+    target = root / res_path[len("res://"):]
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(payload)
+    return target
+
+
+def _entry(**overrides):
+    entry = {
+        "version": 1,
+        "tag": "v0.1.0",
+        "asset_id": "panel",
+        "production_family": "ui-kit",
+        "source_layout": {
+            "type": "single",
+            "path": "res://assets/generated/ui-kit/panel/panel.png",
+        },
+        "godot_artifact": {
+            "type": "Texture2D",
+            "path": "res://assets/generated/ui-kit/panel/panel.png",
+        },
+        "processing_status": "compiled",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _stylebox_ladder(godot_bin: str) -> ValidationLadder:
+    """A ladder with one writing route, so a compiled ``.tres`` can reach L3."""
+    registry = build_default_registry()
+    registry.register(
+        source_layout_type="single",
+        artifact_type="StyleBoxTexture",
+        compiler_id="test_stylebox",
+        compiler_version=1,
+        compiler=lambda request: {},
+    )
+    return ValidationLadder(
+        registry=registry,
+        structures=build_default_structures(),
+        probe=GodotProbe(godot_bin),
+    )
+
+
+def test_a_generated_texture_reaches_ready_through_real_godot(godot_bin, godot_project):
+    _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(24, 16))
+    result = build_default_ladder(godot_bin).run(_entry(), project_root=godot_project)
+
+    assert result.ready is True, result.to_dict()
+    assert result.processing_status == "ready"
+    # Godot imports a PNG as a CompressedTexture2D; the declared Texture2D must
+    # still match, because is_class covers the whole inheritance chain.
+    assert result.levels[3].details["godot_class"] == "CompressedTexture2D"
+    assert result.levels[3].details["godot_version"].startswith("4.")
+    # L4 reads the dimensions of the resource Godot loaded, not of the file.
+    assert result.levels[4].details["width"] == 24
+    assert result.levels[4].details["height"] == 16
+
+
+def test_headless_godot_rejects_a_corrupt_resource(godot_bin, godot_project):
+    _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(8, 8))
+    _write(
+        godot_project,
+        "res://assets/generated/ui-kit/panel/panel.tres",
+        b"this is not a Godot resource\n",
+    )
+    entry = _entry(
+        godot_artifact={
+            "type": "StyleBoxTexture",
+            "path": "res://assets/generated/ui-kit/panel/panel.tres",
+        }
+    )
+    result = _stylebox_ladder(godot_bin).run(entry, project_root=godot_project)
+
+    assert result.ready is False
+    assert result.failure.level == "L3"
+    assert "ResourceLoader.load returned null" in result.failure.error
+    assert result.levels[4].status == NOT_RUN
+
+
+def test_headless_godot_rejects_a_resource_of_the_wrong_type(godot_bin, godot_project):
+    _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(8, 8))
+    _write(
+        godot_project,
+        "res://assets/generated/ui-kit/panel/panel.tres",
+        THEME_TRES.encode("utf-8"),
+    )
+    entry = _entry(
+        godot_artifact={
+            "type": "StyleBoxTexture",
+            "path": "res://assets/generated/ui-kit/panel/panel.tres",
+        }
+    )
+    result = _stylebox_ladder(godot_bin).run(entry, project_root=godot_project)
+
+    assert result.ready is False
+    assert result.failure.level == "L3"
+    assert "as Theme, which is not a StyleBoxTexture" in result.failure.error
+
+
+def test_a_loadable_type_without_a_structure_validator_stops_at_l4(godot_bin, godot_project):
+    """L3 passing is not readiness: an unchecked structure still fails closed."""
+    registry = build_default_registry()
+    registry.register(
+        source_layout_type="theme_recipe",
+        artifact_type="Theme",
+        compiler_id="test_theme",
+        compiler_version=1,
+        compiler=lambda request: {},
+    )
+    _write(
+        godot_project,
+        "res://assets/generated/ui-kit/skin/skin.json",
+        b'{"colors": {}}',
+    )
+    _write(
+        godot_project,
+        "res://assets/generated/ui-kit/skin/skin.tres",
+        THEME_TRES.encode("utf-8"),
+    )
+    entry = _entry(
+        asset_id="skin",
+        source_layout={
+            "type": "theme_recipe",
+            "path": "res://assets/generated/ui-kit/skin/skin.json",
+        },
+        godot_artifact={
+            "type": "Theme",
+            "path": "res://assets/generated/ui-kit/skin/skin.tres",
+        },
+    )
+    ladder = ValidationLadder(
+        registry=registry,
+        structures=build_default_structures(),
+        probe=GodotProbe(godot_bin),
+    )
+    result = ladder.run(entry, project_root=godot_project)
+
+    assert result.levels[3].status == PASSED
+    assert result.levels[3].details["godot_class"] == "Theme"
+    assert result.failure.level == "L4"
+    assert "no structure validator is registered for Theme" in result.failure.error
+
+
+def test_the_probe_reports_a_path_godot_cannot_import(godot_bin, godot_project):
+    _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(4, 4))
+    report = GodotProbe(godot_bin).probe(
+        godot_project,
+        [
+            ProbeRequest(
+                res_path="res://assets/generated/ui-kit/panel/panel.png",
+                expected_type="Texture2D",
+                checks=("texture2d",),
+            ),
+            ProbeRequest(
+                res_path="res://assets/generated/ui-kit/panel/absent.tres",
+                expected_type="Texture2D",
+            ),
+        ],
+    )
+
+    assert report.godot_version.startswith("4.")
+    present, absent = report.resources
+    assert present.loaded is True
+    assert present.type_matches is True
+    assert present.structure == {"texture2d": {"width": 4, "height": 4}}
+    assert absent.loaded is False
+    assert "no importable resource" in absent.error
+
+
+def test_the_probe_reports_an_unknown_structural_check(godot_bin, godot_project):
+    """A check name probe.gd does not implement is an error, never a silent pass."""
+    _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(4, 4))
+    report = GodotProbe(godot_bin).probe(
+        godot_project,
+        [
+            ProbeRequest(
+                res_path="res://assets/generated/ui-kit/panel/panel.png",
+                expected_type="Texture2D",
+                checks=("nine_slice_margins",),
+            )
+        ],
+    )
+
+    (result,) = report.resources
+    assert result.loaded is True
+    assert "unknown structural check" in result.structure["nine_slice_margins"]["error"]
+
+
+def test_the_ladder_leaves_the_project_sources_untouched(godot_bin, godot_project):
+    """Godot writes its import cache; the ladder itself writes nothing."""
+    source = _write(
+        godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(12, 12)
+    )
+    before = source.read_bytes()
+    result = build_default_ladder(godot_bin).run(_entry(), project_root=godot_project)
+
+    assert result.ready is True
+    assert source.read_bytes() == before
+    generated = sorted(
+        path.relative_to(godot_project).as_posix()
+        for path in (godot_project / "assets").rglob("*")
+        if path.is_file()
+    )
+    assert generated == [
+        "assets/generated/ui-kit/panel/panel.png",
+        "assets/generated/ui-kit/panel/panel.png.import",
+    ]
+
+
+@pytest.mark.parametrize("expected_type", ["SpriteFrames", "AtlasTexture"])
+def test_a_declared_type_the_resource_is_not_never_matches(
+    godot_bin, godot_project, expected_type
+):
+    _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(4, 4))
+    report = GodotProbe(godot_bin).probe(
+        godot_project,
+        [
+            ProbeRequest(
+                res_path="res://assets/generated/ui-kit/panel/panel.png",
+                expected_type=expected_type,
+            )
+        ],
+    )
+
+    (result,) = report.resources
+    assert result.loaded is True
+    assert result.godot_class == "CompressedTexture2D"
+    assert result.type_matches is False

--- a/tests/assets/test_asset_validation_ladder.py
+++ b/tests/assets/test_asset_validation_ladder.py
@@ -1,0 +1,942 @@
+"""Unit coverage for the shared L0-L4 readiness ladder.
+
+Godot is stubbed here so every level's own logic is exercised without an engine;
+``test_asset_validation_godot.py`` runs the same ladder against a real binary.
+The stub is a ``GodotProbe`` subclass rather than a mock so it cannot drift from
+the interface the ladder actually calls.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+
+from asset_compiler import CompileReceipt, CompilerRegistry, build_default_registry  # noqa: E402
+from asset_validation import (  # noqa: E402
+    FAILED,
+    LEVELS,
+    NOT_RUN,
+    PASSED,
+    STATUS_FAILED,
+    STATUS_READY,
+    GodotProbe,
+    GodotProbeError,
+    LadderResult,
+    LevelResult,
+    ProbeReport,
+    ProbeRequest,
+    ProbeResult,
+    StructureRequest,
+    StructureValidatorRegistry,
+    ValidationError,
+    ValidationLadder,
+    build_default_ladder,
+    build_default_structures,
+    find_godot,
+    validate_texture2d,
+)
+
+PNG = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x06"
+    b"\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01\x00\x00\x05"
+    b"\x00\x01\r\n-\xb4\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+
+SOURCE = "res://assets/generated/ui-kit/panel/panel.png"
+ARTIFACT = "res://assets/generated/ui-kit/panel/panel.tres"
+
+
+class StubProbe(GodotProbe):
+    """A ``GodotProbe`` that answers from a script instead of running Godot."""
+
+    def __init__(self, *, answers=None, raises=None, structure=None):
+        super().__init__("godot")
+        self.answers = answers
+        self.raises = raises
+        self.structure = structure if structure is not None else {"texture2d": {"width": 4, "height": 3}}
+        self.calls: list[tuple[Path, tuple[ProbeRequest, ...]]] = []
+
+    def probe(self, project_root, requests):
+        self.calls.append((Path(project_root), tuple(requests)))
+        if self.raises is not None:
+            raise self.raises
+        if self.answers is not None:
+            return ProbeReport(godot_version="4.4-stable (stub)", resources=tuple(self.answers))
+        return ProbeReport(
+            godot_version="4.4-stable (stub)",
+            resources=tuple(
+                ProbeResult(
+                    res_path=item.res_path,
+                    expected_type=item.expected_type,
+                    loaded=True,
+                    godot_class=item.expected_type,
+                    type_matches=True,
+                    structure={
+                        name: value
+                        for name, value in self.structure.items()
+                        if name in item.checks
+                    },
+                )
+                for item in requests
+            ),
+        )
+
+
+def _project(tmp_path: Path, *, family: str = "ui-kit", asset_id: str = "panel") -> Path:
+    root = tmp_path / "game"
+    (root / "assets" / "generated" / family / asset_id).mkdir(parents=True, exist_ok=True)
+    (root / "project.godot").write_text("config_version=5\n", encoding="utf-8")
+    return root
+
+
+def _write(root: Path, res_path: str, payload: bytes = PNG) -> Path:
+    target = root / res_path[len("res://"):]
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_bytes(payload)
+    return target
+
+
+def _entry(**overrides):
+    entry = {
+        "version": 1,
+        "tag": "v0.1.0",
+        "asset_id": "panel",
+        "production_family": "ui-kit",
+        "source_layout": {"type": "single", "path": SOURCE},
+        "godot_artifact": {"type": "Texture2D", "path": SOURCE},
+        "processing_status": "compiled",
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _stylebox_registry() -> CompilerRegistry:
+    """The shared registry plus one writing route, so L2's writing rules are reachable."""
+    registry = build_default_registry()
+    registry.register(
+        source_layout_type="single",
+        artifact_type="StyleBoxTexture",
+        compiler_id="test_stylebox",
+        compiler_version=2,
+        compiler=lambda request: {},
+    )
+    return registry
+
+
+def _ladder(*, registry=None, structures=None, probe=None) -> ValidationLadder:
+    return ValidationLadder(
+        registry=registry if registry is not None else build_default_registry(),
+        structures=structures if structures is not None else build_default_structures(),
+        probe=probe if probe is not None else StubProbe(),
+    )
+
+
+def _run(tmp_path, entry=None, **kwargs):
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    return _ladder(**kwargs).run(entry or _entry(), project_root=root), root
+
+
+def _failure(result):
+    assert result.failure is not None, result.to_dict()
+    return result.failure.level, result.failure.error
+
+
+# --------------------------------------------------------------------- happy
+
+
+def test_a_fully_valid_texture_entry_reaches_ready(tmp_path):
+    result, _ = _run(tmp_path)
+    assert result.ready is True
+    assert result.processing_status == STATUS_READY
+    assert result.failure is None
+    assert [level.status for level in result.levels] == [PASSED] * 5
+    assert result.asset_id == "panel"
+    assert result.production_family == "ui-kit"
+
+
+def test_every_level_is_reported_in_order_with_its_documented_name(tmp_path):
+    result, _ = _run(tmp_path)
+    assert [level.level for level in result.levels] == [spec.level for spec in LEVELS]
+    assert [level.name for level in result.levels] == [spec.name for spec in LEVELS]
+
+
+def test_the_verdict_serializes_every_level(tmp_path):
+    result, _ = _run(tmp_path)
+    payload = result.to_dict()
+    assert payload["ready"] is True
+    assert payload["processing_status"] == STATUS_READY
+    assert payload["failed_level"] is None
+    assert len(payload["levels"]) == 5
+    assert payload["levels"][3]["details"]["godot_class"] == "Texture2D"
+    assert payload["levels"][3]["details"]["godot_version"] == "4.4-stable (stub)"
+    assert payload["levels"][4]["details"]["validator_id"] == "texture2d_structure"
+
+
+def test_the_ladder_never_writes_to_the_project(tmp_path):
+    result, root = _run(tmp_path)
+    assert result.ready is True
+    produced = sorted(p.relative_to(root).as_posix() for p in root.rglob("*") if p.is_file())
+    assert produced == ["assets/generated/ui-kit/panel/panel.png", "project.godot"]
+
+
+# ------------------------------------------------------------------------ L0
+
+
+def test_a_non_object_entry_fails_l0(tmp_path):
+    root = _project(tmp_path)
+    result = _ladder().run(["not", "an", "entry"], project_root=root)
+    level, error = _failure(result)
+    assert level == "L0"
+    assert "JSON object" in error
+
+
+def test_a_legacy_runtime_artifact_entry_fails_l0(tmp_path):
+    result, _ = _run(tmp_path, _entry(runtime_artifact={"type": "grid_sheet"}))
+    level, error = _failure(result)
+    assert level == "L0"
+    assert "Legacy runtime_artifact schema" in error
+
+
+def test_a_wrong_schema_version_fails_l0(tmp_path):
+    result, _ = _run(tmp_path, _entry(version="1"))
+    assert _failure(result)[0] == "L0"
+
+
+def test_an_unknown_production_family_fails_l0(tmp_path):
+    result, _ = _run(tmp_path, _entry(production_family="mystery-family"))
+    level, error = _failure(result)
+    assert level == "L0"
+    assert "production_family is not allowed" in error
+
+
+def test_an_artifact_type_incompatible_with_its_layout_fails_l0(tmp_path):
+    result, _ = _run(
+        tmp_path,
+        _entry(
+            source_layout={"type": "grid_sheet", "path": SOURCE},
+            godot_artifact={"type": "Texture2D", "path": SOURCE},
+        ),
+    )
+    level, error = _failure(result)
+    assert level == "L0"
+    assert "must be one of: SpriteFrames" in error
+
+
+def test_a_source_outside_the_stable_directory_fails_l0(tmp_path):
+    result, _ = _run(
+        tmp_path,
+        _entry(source_layout={"type": "single", "path": "res://assets/generated/ui-kit/other/x.png"}),
+    )
+    level, error = _failure(result)
+    assert level == "L0"
+    assert "must be a file under res://assets/generated/ui-kit/panel/" in error
+
+
+def test_a_path_in_the_generation_workspace_fails_l0(tmp_path):
+    work = "res://.godotmaker/asset-generation/work/panel.png"
+    result, _ = _run(tmp_path, _entry(source_layout={"type": "single", "path": work}))
+    level, error = _failure(result)
+    assert level == "L0"
+    assert "work/ workspace" in error
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        _entry(
+            production_family="screen-reference",
+            asset_id="title",
+            source_layout={"type": "reference", "path": "res://assets/refs/title.png"},
+            godot_artifact=None,
+        ),
+    ],
+)
+def test_a_reference_asset_has_no_rung_on_the_ladder(tmp_path, entry):
+    root = _project(tmp_path, family="screen-reference", asset_id="title")
+    _write(root, "res://assets/refs/title.png")
+    result = _ladder().run(entry, project_root=root)
+    level, error = _failure(result)
+    assert level == "L0"
+    assert "no L0-L4 readiness ladder" in error
+    assert "source_ready" in error
+    assert result.processing_status == STATUS_FAILED
+
+
+def test_a_non_path_project_root_fails_l0(tmp_path):
+    result = _ladder().run(_entry(), project_root=object())
+    level, error = _failure(result)
+    assert level == "L0"
+    assert "project_root must be a path" in error
+
+
+def test_a_failure_leaves_every_later_level_not_run(tmp_path):
+    result, _ = _run(tmp_path, _entry(version=99))
+    assert [level.status for level in result.levels] == [FAILED, NOT_RUN, NOT_RUN, NOT_RUN, NOT_RUN]
+    assert result.ready is False
+    assert result.processing_status == STATUS_FAILED
+
+
+# ------------------------------------------------------------------------ L1
+
+
+def test_a_missing_processed_source_fails_l1(tmp_path):
+    root = _project(tmp_path)
+    result = _ladder().run(_entry(), project_root=root)
+    level, error = _failure(result)
+    assert level == "L1"
+    assert "is not a file on disk" in error
+
+
+def test_an_empty_processed_source_fails_l1(tmp_path):
+    root = _project(tmp_path)
+    _write(root, SOURCE, b"")
+    result = _ladder().run(_entry(), project_root=root)
+    level, error = _failure(result)
+    assert level == "L1"
+    assert "empty file" in error
+
+
+def test_a_directory_where_the_source_should_be_fails_l1(tmp_path):
+    root = _project(tmp_path)
+    (root / "assets/generated/ui-kit/panel/panel.png").mkdir(parents=True)
+    result = _ladder().run(_entry(), project_root=root)
+    assert _failure(result)[0] == "L1"
+
+
+# L0 already resolves both paths and requires them to stay inside the project
+# root, so a link aimed out of the project never reaches L1. The escape only L1
+# can catch is one that lands inside the project but outside the asset's own
+# stable directory -- another asset's files, or a shared directory -- which is
+# what both tests below build.
+def _elsewhere_in_project(root: Path) -> Path:
+    target = root / "assets" / "generated" / "ui-kit" / "borrowed"
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "panel.png").write_bytes(PNG)
+    return target
+
+
+def test_a_symlinked_source_leaving_the_stable_directory_fails_l1(tmp_path):
+    root = _project(tmp_path)
+    borrowed = _elsewhere_in_project(root)
+    link = root / "assets/generated/ui-kit/panel/panel.png"
+    try:
+        link.symlink_to(borrowed / "panel.png")
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not permitted on this platform")
+
+    result = _ladder().run(_entry(), project_root=root)
+    level, error = _failure(result)
+    assert level == "L1"
+    assert "must be written under assets/generated/ui-kit/panel/" in error
+
+
+def _link_directory(link: Path, target: Path) -> None:
+    """Link a directory, using a junction where symlinks need a privilege.
+
+    Windows reserves symlink creation for elevated or developer-mode sessions but
+    lets any user create a directory junction, and ``Path.resolve`` follows both.
+    Without this the on-disk containment guard would be exercised on no platform
+    a Windows contributor is likely to run tests on.
+    """
+    try:
+        link.symlink_to(target, target_is_directory=True)
+        return
+    except (OSError, NotImplementedError):
+        pass
+    if sys.platform != "win32":
+        pytest.skip("directory links not permitted on this platform")
+    completed = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        pytest.skip(f"directory junctions not permitted: {completed.stderr.strip()}")
+
+
+def test_a_linked_subdirectory_of_the_stable_directory_fails_l1(tmp_path):
+    root = _project(tmp_path)
+    borrowed = _elsewhere_in_project(root)
+    # A directory link *inside* the stable directory. The declared path is a
+    # clean res:// file under assets/generated/ui-kit/panel/, so L0 accepts it
+    # and it still resolves inside the project -- only the stable-directory
+    # containment can see that the bytes come from another asset.
+    _link_directory(root / "assets/generated/ui-kit/panel/nested", borrowed)
+    nested = "res://assets/generated/ui-kit/panel/nested/panel.png"
+
+    result = _ladder().run(
+        _entry(
+            source_layout={"type": "single", "path": nested},
+            godot_artifact={"type": "Texture2D", "path": nested},
+        ),
+        project_root=root,
+    )
+    level, error = _failure(result)
+    assert level == "L1"
+    assert "must be written under assets/generated/ui-kit/panel/" in error
+
+
+# ------------------------------------------------------------------------ L2
+
+
+def test_an_entry_without_a_godot_artifact_fails_l2(tmp_path):
+    result, _ = _run(tmp_path, _entry(godot_artifact=None, processing_status="source_ready"))
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "no native Godot resource was compiled" in error
+
+
+def test_an_artifact_type_with_no_registered_compiler_fails_l2(tmp_path):
+    root = _project(tmp_path, asset_id="hero")
+    entry = _entry(
+        asset_id="hero",
+        source_layout={"type": "grid_sheet", "path": "res://assets/generated/ui-kit/hero/hero.png"},
+        godot_artifact={"type": "SpriteFrames", "path": "res://assets/generated/ui-kit/hero/hero.tres"},
+    )
+    _write(root, "res://assets/generated/ui-kit/hero/hero.png")
+    _write(root, "res://assets/generated/ui-kit/hero/hero.tres", b"[gd_resource]\n")
+    result = _ladder().run(entry, project_root=root)
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "no compiler is registered for grid_sheet -> SpriteFrames" in error
+
+
+def test_a_missing_compiled_artifact_fails_l2(tmp_path):
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    entry = _entry(godot_artifact={"type": "StyleBoxTexture", "path": ARTIFACT})
+    result = _ladder(registry=_stylebox_registry()).run(entry, project_root=root)
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "godot_artifact.path is not a file on disk" in error
+
+
+def test_an_empty_compiled_artifact_fails_l2(tmp_path):
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    _write(root, ARTIFACT, b"")
+    entry = _entry(godot_artifact={"type": "StyleBoxTexture", "path": ARTIFACT})
+    result = _ladder(registry=_stylebox_registry()).run(entry, project_root=root)
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "empty file" in error
+
+
+def test_a_writing_route_may_not_publish_its_source_image_as_the_artifact(tmp_path):
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    entry = _entry(godot_artifact={"type": "StyleBoxTexture", "path": SOURCE})
+    result = _ladder(registry=_stylebox_registry()).run(entry, project_root=root)
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "may not be the source image itself" in error
+
+
+def test_a_writing_route_may_not_hard_link_its_source_as_the_artifact(tmp_path):
+    root = _project(tmp_path)
+    source = _write(root, SOURCE)
+    alias = root / ARTIFACT[len("res://"):]
+    try:
+        os.link(source, alias)
+    except (OSError, NotImplementedError, AttributeError):
+        pytest.skip("hard links not permitted on this platform")
+    entry = _entry(godot_artifact={"type": "StyleBoxTexture", "path": ARTIFACT})
+    result = _ladder(registry=_stylebox_registry()).run(entry, project_root=root)
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "may not be the source image itself" in error
+
+
+def test_a_non_writing_route_must_name_its_source_as_the_artifact(tmp_path):
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    _write(root, ARTIFACT, b"[gd_resource]\n")
+    entry = _entry(
+        source_layout={"type": "single", "path": SOURCE},
+        godot_artifact={"type": "Texture2D", "path": ARTIFACT},
+    )
+    result = _ladder().run(entry, project_root=root)
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "must equal source_layout.path" in error
+
+
+def test_l2_reports_the_route_that_compiled_the_artifact(tmp_path):
+    result, _ = _run(tmp_path)
+    details = result.levels[2].details
+    assert details["compiler_id"] == "texture2d_default_import"
+    assert details["compiler_version"] == 1
+    assert details["writes_artifact"] is False
+    assert details["bytes"] == len(PNG)
+
+
+def _receipt(**overrides):
+    fields = {
+        "compiler_id": "texture2d_default_import",
+        "compiler_version": 1,
+        "production_family": "ui-kit",
+        "asset_id": "panel",
+        "source_layout_type": "single",
+        "source_path": SOURCE,
+        "artifact_type": "Texture2D",
+        "artifact_path": SOURCE,
+        "details": {},
+    }
+    fields.update(overrides)
+    return CompileReceipt(**fields)
+
+
+def test_a_matching_compile_receipt_is_recorded_by_l2(tmp_path):
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    result = _ladder().run(_entry(), project_root=root, receipt=_receipt())
+    assert result.ready is True
+    assert result.levels[2].details["receipt"] == {
+        "compiler_id": "texture2d_default_import",
+        "compiler_version": 1,
+    }
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"asset_id": "someone-else"},
+        {"production_family": "card-kit"},
+        {"artifact_path": "res://assets/generated/ui-kit/panel/other.tres"},
+        {"compiler_id": "another_compiler"},
+    ],
+)
+def test_a_compile_receipt_for_another_asset_fails_l2(tmp_path, override):
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    result = _ladder().run(_entry(), project_root=root, receipt=_receipt(**override))
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "compile receipt describes" in error
+
+
+def test_an_object_that_is_not_a_compile_receipt_fails_l2(tmp_path):
+    class Lookalike:
+        compiler_id = "texture2d_default_import"
+        compiler_version = 1
+        production_family = "ui-kit"
+        asset_id = "panel"
+        source_layout_type = "single"
+        source_path = SOURCE
+        artifact_type = "Texture2D"
+        artifact_path = SOURCE
+
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    result = _ladder().run(_entry(), project_root=root, receipt=Lookalike())
+    level, error = _failure(result)
+    assert level == "L2"
+    assert "must be a CompileReceipt" in error
+
+
+# ------------------------------------------------------------------------ L3
+
+
+def test_l3_asks_godot_for_the_artifact_and_the_checks_l4_needs(tmp_path):
+    probe = StubProbe()
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    _ladder(probe=probe).run(_entry(), project_root=root)
+    (project_root, requests), = probe.calls
+    assert project_root == root
+    assert requests == (ProbeRequest(res_path=SOURCE, expected_type="Texture2D", checks=("texture2d",)),)
+
+
+def test_a_resource_godot_cannot_load_fails_l3(tmp_path):
+    probe = StubProbe(
+        answers=[
+            ProbeResult(
+                res_path=SOURCE,
+                expected_type="Texture2D",
+                loaded=False,
+                godot_class="",
+                type_matches=False,
+                error="ResourceLoader.load returned null for " + SOURCE,
+            )
+        ]
+    )
+    result, _ = _run(tmp_path, probe=probe)
+    level, error = _failure(result)
+    assert level == "L3"
+    assert "returned null" in error
+
+
+def test_a_resource_of_the_wrong_godot_type_fails_l3(tmp_path):
+    probe = StubProbe(
+        answers=[
+            ProbeResult(
+                res_path=SOURCE,
+                expected_type="Texture2D",
+                loaded=True,
+                godot_class="Theme",
+                type_matches=False,
+            )
+        ]
+    )
+    result, _ = _run(tmp_path, probe=probe)
+    level, error = _failure(result)
+    assert level == "L3"
+    assert "loaded" in error and "Theme" in error and "not a Texture2D" in error
+
+
+def test_an_unavailable_godot_binary_fails_l3_rather_than_skipping_it(tmp_path):
+    probe = StubProbe(raises=GodotProbeError("godot binary not found at godot"))
+    result, _ = _run(tmp_path, probe=probe)
+    level, error = _failure(result)
+    assert level == "L3"
+    assert "godot binary not found" in error
+    assert result.ready is False
+    assert result.levels[4].status == NOT_RUN
+
+
+# ------------------------------------------------------------------------ L4
+
+
+def test_an_artifact_type_with_no_structure_validator_fails_l4(tmp_path):
+    root = _project(tmp_path)
+    _write(root, SOURCE)
+    _write(root, ARTIFACT, b"[gd_resource]\n")
+    entry = _entry(godot_artifact={"type": "StyleBoxTexture", "path": ARTIFACT})
+    result = _ladder(registry=_stylebox_registry()).run(entry, project_root=root)
+    level, error = _failure(result)
+    assert level == "L4"
+    assert "no structure validator is registered for StyleBoxTexture" in error
+    assert result.levels[3].status == PASSED
+
+
+def test_a_zero_sized_texture_fails_l4(tmp_path):
+    probe = StubProbe(structure={"texture2d": {"width": 0, "height": 8}})
+    result, _ = _run(tmp_path, probe=probe)
+    level, error = _failure(result)
+    assert level == "L4"
+    assert "positive width and height" in error
+
+
+def test_a_texture_whose_dimensions_are_not_integers_fails_l4(tmp_path):
+    probe = StubProbe(structure={"texture2d": {"width": True, "height": 8}})
+    result, _ = _run(tmp_path, probe=probe)
+    assert _failure(result)[0] == "L4"
+
+
+def test_a_probe_that_collected_no_structure_fails_l4(tmp_path):
+    probe = StubProbe(structure={})
+    result, _ = _run(tmp_path, probe=probe)
+    level, error = _failure(result)
+    assert level == "L4"
+    assert "collected no texture2d structure" in error
+
+
+def test_a_structure_check_godot_could_not_answer_fails_l4(tmp_path):
+    probe = StubProbe(structure={"texture2d": {"error": "resource is a Theme, not a Texture2D"}})
+    result, _ = _run(tmp_path, probe=probe)
+    level, error = _failure(result)
+    assert level == "L4"
+    assert "resource is a Theme" in error
+
+
+def test_l4_reports_the_dimensions_it_checked(tmp_path):
+    result, _ = _run(tmp_path)
+    assert result.levels[4].details == {
+        "width": 4,
+        "height": 3,
+        "validator_id": "texture2d_structure",
+    }
+
+
+def test_a_validator_that_raises_an_unexpected_error_fails_l4(tmp_path):
+    structures = StructureValidatorRegistry()
+
+    def explode(request):
+        raise RuntimeError("boom")
+
+    structures.register(
+        artifact_type="Texture2D", validator_id="exploding", validator=explode
+    )
+    result, _ = _run(tmp_path, structures=structures)
+    level, error = _failure(result)
+    assert level == "L4"
+    assert "exploding failed: boom" in error
+
+
+def test_a_validator_that_returns_a_non_mapping_fails_l4(tmp_path):
+    structures = StructureValidatorRegistry()
+    structures.register(
+        artifact_type="Texture2D", validator_id="chatty", validator=lambda request: "fine"
+    )
+    result, _ = _run(tmp_path, structures=structures)
+    level, error = _failure(result)
+    assert level == "L4"
+    assert "must return a mapping" in error
+
+
+def test_the_validator_receives_the_entry_identity_and_the_probe_result(tmp_path):
+    seen = {}
+    structures = StructureValidatorRegistry()
+
+    def capture(request: StructureRequest):
+        seen["request"] = request
+        return {}
+
+    structures.register(
+        artifact_type="Texture2D", validator_id="capturing", validator=capture
+    )
+    result, root = _run(tmp_path, structures=structures)
+    assert result.ready is True
+    request = seen["request"]
+    assert request.production_family == "ui-kit"
+    assert request.asset_id == "panel"
+    assert request.source_layout_type == "single"
+    assert request.artifact_path == SOURCE
+    assert request.project_root == root
+    assert request.probe.godot_class == "Texture2D"
+
+
+# ------------------------------------------------- structure validator registry
+
+
+def test_a_validator_for_a_type_no_layout_compiles_to_is_rejected():
+    structures = StructureValidatorRegistry()
+    with pytest.raises(ValidationError, match="no source layout compiles to PackedScene"):
+        structures.register(
+            artifact_type="PackedScene", validator_id="scenes", validator=lambda r: {}
+        )
+
+
+def test_a_second_validator_for_one_type_is_rejected():
+    structures = build_default_structures()
+    with pytest.raises(ValidationError, match="already validated by texture2d_structure"):
+        structures.register(
+            artifact_type="Texture2D", validator_id="second", validator=lambda r: {}
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"artifact_type": "", "validator_id": "v"}, "artifact_type must be"),
+        ({"artifact_type": "Texture2D", "validator_id": "  "}, "validator_id must be"),
+    ],
+)
+def test_blank_registration_fields_are_rejected(kwargs, message):
+    structures = StructureValidatorRegistry()
+    with pytest.raises(ValidationError, match=message):
+        structures.register(validator=lambda r: {}, **kwargs)
+
+
+def test_a_non_callable_validator_is_rejected():
+    structures = StructureValidatorRegistry()
+    with pytest.raises(ValidationError, match="must be callable"):
+        structures.register(
+            artifact_type="Theme", validator_id="theme", validator="not callable"
+        )
+
+
+@pytest.mark.parametrize("checks", [["sprite_frames"], ("",), ("ok", 3)])
+def test_malformed_checks_are_rejected(checks):
+    structures = StructureValidatorRegistry()
+    with pytest.raises(ValidationError, match="checks must be a tuple"):
+        structures.register(
+            artifact_type="Theme",
+            validator_id="theme",
+            validator=lambda r: {},
+            checks=checks,
+        )
+
+
+def test_an_unregistered_type_asks_for_no_probe_checks():
+    assert build_default_structures().checks_for("TileSet") == ()
+    assert build_default_structures().checks_for("Texture2D") == ("texture2d",)
+
+
+def test_routes_are_ordered_by_artifact_type():
+    structures = build_default_structures()
+    structures.register(
+        artifact_type="AtlasTexture", validator_id="atlas", validator=lambda r: {}
+    )
+    assert [route.artifact_type for route in structures.routes()] == [
+        "AtlasTexture",
+        "Texture2D",
+    ]
+
+
+def test_each_build_returns_an_independent_structure_registry():
+    first = build_default_structures()
+    first.register(artifact_type="Theme", validator_id="theme", validator=lambda r: {})
+    assert [route.artifact_type for route in build_default_structures().routes()] == [
+        "Texture2D"
+    ]
+
+
+# ------------------------------------------------------------ result vocabulary
+
+
+def test_a_failed_level_must_carry_an_error():
+    with pytest.raises(ValidationError, match="failed without an error message"):
+        LevelResult(level="L1", name="processed_source", status=FAILED)
+
+
+def test_a_passing_level_may_not_carry_an_error():
+    with pytest.raises(ValidationError, match="did not fail"):
+        LevelResult(level="L1", name="processed_source", status=PASSED, error="hmm")
+
+
+def test_an_unknown_level_status_is_rejected():
+    with pytest.raises(ValidationError, match="unknown level status"):
+        LevelResult(level="L1", name="processed_source", status="maybe")
+
+
+def test_a_verdict_must_report_every_level_in_order():
+    with pytest.raises(ValidationError, match="every level in order"):
+        LadderResult(
+            asset_id="panel",
+            production_family="ui-kit",
+            levels=(LevelResult(level="L0", name="contract", status=PASSED),),
+        )
+
+
+def test_ready_requires_every_level_to_pass():
+    levels = tuple(
+        LevelResult(level=spec.level, name=spec.name, status=PASSED) for spec in LEVELS
+    )
+    assert LadderResult(asset_id="a", production_family="ui-kit", levels=levels).ready
+    degraded = levels[:4] + (
+        LevelResult(level="L4", name="structure", status=NOT_RUN),
+    )
+    verdict = LadderResult(asset_id="a", production_family="ui-kit", levels=degraded)
+    assert verdict.ready is False
+    assert verdict.processing_status == STATUS_FAILED
+    assert verdict.failure is None
+
+
+# ------------------------------------------------------------------ construction
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"registry": object()}, "registry must be a CompilerRegistry"),
+        ({"structures": object()}, "structures must be a StructureValidatorRegistry"),
+        ({"probe": object()}, "probe must be a GodotProbe"),
+    ],
+)
+def test_a_misconfigured_ladder_is_rejected_at_construction(kwargs, message):
+    arguments = {
+        "registry": build_default_registry(),
+        "structures": build_default_structures(),
+        "probe": StubProbe(),
+    }
+    arguments.update(kwargs)
+    with pytest.raises(ValidationError, match=message):
+        ValidationLadder(**arguments)
+
+
+def test_build_default_ladder_wires_the_shared_compiler_and_validator():
+    ladder = build_default_ladder("godot")
+    assert isinstance(ladder, ValidationLadder)
+    structures = build_default_structures()
+    assert [route.validator_id for route in structures.routes()] == ["texture2d_structure"]
+
+
+def test_build_default_ladder_accepts_family_registries():
+    registry = _stylebox_registry()
+    structures = build_default_structures()
+    ladder = build_default_ladder("godot", registry=registry, structures=structures)
+    assert isinstance(ladder, ValidationLadder)
+
+
+def test_the_texture_validator_is_usable_on_its_own():
+    request = StructureRequest(
+        production_family="ui-kit",
+        asset_id="panel",
+        source_layout_type="single",
+        source_path=SOURCE,
+        artifact_type="Texture2D",
+        artifact_path=SOURCE,
+        project_root=Path("."),
+        probe=ProbeResult(
+            res_path=SOURCE,
+            expected_type="Texture2D",
+            loaded=True,
+            godot_class="CompressedTexture2D",
+            type_matches=True,
+            structure={"texture2d": {"width": 32, "height": 16}},
+        ),
+    )
+    assert validate_texture2d(request) == {"width": 32, "height": 16}
+
+
+# ------------------------------------------------------------------ Godot probe
+
+
+def test_a_blank_godot_path_is_rejected():
+    with pytest.raises(GodotProbeError, match="non-empty string"):
+        GodotProbe("   ")
+
+
+def test_probing_nothing_is_rejected(tmp_path):
+    with pytest.raises(GodotProbeError, match="at least one resource request"):
+        GodotProbe("godot").probe(tmp_path, [])
+
+
+def test_probing_a_directory_that_is_not_a_godot_project_is_rejected(tmp_path):
+    with pytest.raises(GodotProbeError, match="no project.godot"):
+        GodotProbe("godot").probe(
+            tmp_path, [ProbeRequest(res_path=SOURCE, expected_type="Texture2D")]
+        )
+
+
+def test_a_missing_godot_binary_is_a_probe_error(tmp_path):
+    root = _project(tmp_path)
+    probe = GodotProbe(str(tmp_path / "definitely-not-godot"))
+    with pytest.raises(GodotProbeError, match="not found|could not be run"):
+        probe.probe(root, [ProbeRequest(res_path=SOURCE, expected_type="Texture2D")])
+
+
+@pytest.mark.parametrize(
+    "report, message",
+    [
+        (["not", "an", "object"], "not a JSON object"),
+        ({"resources": "nope"}, "reported 0 resources for 1 requests"),
+        ({"resources": []}, "reported 0 resources for 1 requests"),
+        ({"resources": ["nope"]}, "must be an object"),
+        ({"resources": [{"path": "res://other.tres"}]}, "answered for"),
+    ],
+)
+def test_a_malformed_probe_report_is_rejected(report, message):
+    with pytest.raises(GodotProbeError, match=message):
+        GodotProbe._parse(
+            report, [ProbeRequest(res_path=SOURCE, expected_type="Texture2D")]
+        )
+
+
+def test_a_probe_report_row_is_read_conservatively():
+    report = GodotProbe._parse(
+        {"resources": [{"path": SOURCE, "loaded": "yes", "type_matches": 1, "structure": []}]},
+        [ProbeRequest(res_path=SOURCE, expected_type="Texture2D")],
+    )
+    (result,) = report.resources
+    assert report.godot_version == ""
+    # Only a literal JSON ``true`` counts; a truthy string must not pass L3.
+    assert result.loaded is False
+    assert result.type_matches is False
+    assert result.structure == {}
+    assert result.godot_class == ""
+
+
+def test_find_godot_prefers_an_explicit_binary(tmp_path):
+    binary = tmp_path / "godot-here"
+    binary.write_text("", encoding="utf-8")
+    assert find_godot(str(binary)) == str(binary)
+    assert find_godot(str(tmp_path / "absent")) is None

--- a/tests/assets/test_asset_validation_ladder.py
+++ b/tests/assets/test_asset_validation_ladder.py
@@ -27,6 +27,7 @@ from asset_validation import (  # noqa: E402
     STATUS_READY,
     GodotProbe,
     GodotProbeError,
+    PROBE_CHECKS,
     LadderResult,
     LevelResult,
     ProbeReport,
@@ -635,7 +636,7 @@ def test_a_probe_that_collected_no_structure_fails_l4(tmp_path):
     result, _ = _run(tmp_path, probe=probe)
     level, error = _failure(result)
     assert level == "L4"
-    assert "collected no texture2d structure" in error
+    assert "reported no 'texture2d' structural check" in error
 
 
 def test_a_structure_check_godot_could_not_answer_fails_l4(tmp_path):
@@ -643,7 +644,56 @@ def test_a_structure_check_godot_could_not_answer_fails_l4(tmp_path):
     result, _ = _run(tmp_path, probe=probe)
     level, error = _failure(result)
     assert level == "L4"
+    assert "could not be performed" in error
     assert "resource is a Theme" in error
+
+
+@pytest.mark.parametrize(
+    "structure",
+    [
+        {},
+        {"texture2d": {"error": "unknown structural check: texture2d"}},
+        {"texture2d": "not even an object"},
+    ],
+)
+def test_a_validator_that_ignores_the_probe_cannot_pass_an_unanswered_check(
+    tmp_path, structure
+):
+    """The bypass this guard exists for: L4 must fail on the probe's answer alone.
+
+    A validator is free to return ``{}`` without reading anything. If the level
+    depended on it noticing, every family would get one chance to forget, and the
+    ladder would report ``ready`` beside an L3 detail saying the check was
+    impossible.
+    """
+    structures = StructureValidatorRegistry()
+    structures.register(
+        artifact_type="Texture2D",
+        validator_id="ignores_the_probe",
+        validator=lambda request: {},
+        checks=("texture2d",),
+    )
+    result, _ = _run(tmp_path, probe=StubProbe(structure=structure), structures=structures)
+
+    assert result.ready is False
+    assert result.processing_status == STATUS_FAILED
+    level, error = _failure(result)
+    assert level == "L4"
+    assert "texture2d" in error
+
+
+def test_a_validator_declaring_no_checks_still_runs(tmp_path):
+    """The guard covers declared checks only; a validator may need none."""
+    structures = StructureValidatorRegistry()
+    structures.register(
+        artifact_type="Texture2D",
+        validator_id="needs_nothing",
+        validator=lambda request: {"checked": "nothing"},
+    )
+    result, _ = _run(tmp_path, probe=StubProbe(structure={}), structures=structures)
+
+    assert result.ready is True
+    assert result.levels[4].details["checked"] == "nothing"
 
 
 def test_l4_reports_the_dimensions_it_checked(tmp_path):
@@ -743,7 +793,7 @@ def test_a_non_callable_validator_is_rejected():
         )
 
 
-@pytest.mark.parametrize("checks", [["sprite_frames"], ("",), ("ok", 3)])
+@pytest.mark.parametrize("checks", [["texture2d"], ("",), ("texture2d", 3)])
 def test_malformed_checks_are_rejected(checks):
     structures = StructureValidatorRegistry()
     with pytest.raises(ValidationError, match="checks must be a tuple"):
@@ -753,6 +803,29 @@ def test_malformed_checks_are_rejected(checks):
             validator=lambda r: {},
             checks=checks,
         )
+
+
+def test_a_check_the_probe_script_does_not_implement_is_rejected_at_registration():
+    structures = StructureValidatorRegistry()
+    with pytest.raises(ValidationError, match="probe.gd implements no structural check"):
+        structures.register(
+            artifact_type="StyleBoxTexture",
+            validator_id="nine_slice",
+            validator=lambda r: {},
+            checks=("unknown_structure",),
+        )
+
+
+def test_every_implemented_check_may_be_registered():
+    for check in PROBE_CHECKS:
+        structures = StructureValidatorRegistry()
+        route = structures.register(
+            artifact_type="Theme",
+            validator_id="theme",
+            validator=lambda r: {},
+            checks=(check,),
+        )
+        assert route.checks == (check,)
 
 
 def test_an_unregistered_type_asks_for_no_probe_checks():
@@ -854,6 +927,47 @@ def test_build_default_ladder_accepts_family_registries():
     structures = build_default_structures()
     ladder = build_default_ladder("godot", registry=registry, structures=structures)
     assert isinstance(ladder, ValidationLadder)
+
+
+def _structure_request(structure):
+    return StructureRequest(
+        production_family="ui-kit",
+        asset_id="panel",
+        source_layout_type="single",
+        source_path=SOURCE,
+        artifact_type="Texture2D",
+        artifact_path=SOURCE,
+        project_root=Path("."),
+        probe=ProbeResult(
+            res_path=SOURCE,
+            expected_type="Texture2D",
+            loaded=True,
+            godot_class="CompressedTexture2D",
+            type_matches=True,
+            structure=structure,
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "structure, message",
+    [
+        ({}, "reported no 'texture2d' structural check"),
+        ({"texture2d": None}, "reported no 'texture2d' structural check"),
+        ({"texture2d": "words"}, "reported no 'texture2d' structural check"),
+        ({"texture2d": {"error": "boom"}}, "could not be performed"),
+    ],
+)
+def test_reading_an_unanswered_check_fails_closed_outside_the_registry(structure, message):
+    # A validator used directly gets the same guarantee the registry enforces,
+    # rather than an attribute error on a missing answer.
+    with pytest.raises(ValidationError, match=message):
+        _structure_request(structure).checked_structure("texture2d")
+
+
+def test_reading_an_answered_check_returns_its_facts():
+    request = _structure_request({"texture2d": {"width": 2, "height": 2}})
+    assert request.checked_structure("texture2d") == {"width": 2, "height": 2}
 
 
 def test_the_texture_validator_is_usable_on_its_own():


### PR DESCRIPTION
## Summary

Adds a shared L0-L4 asset readiness validation ladder. `ready` is now derived from ordered contract, source, compiler-route, Godot-load/type, and type-specific structural validation rather than asserted by an asset skill.

## Motivation

Asset artifacts need a reusable, fail-closed validation path before they can be considered ready. This provides real headless-Godot loading checks and an extension point for family-specific structural validation.

## Changes

- [x] Add the shared `skills/assets/_shared/asset_validation/` contract, ladder, Godot probe, and structure-validator registry.
- [x] Add fail-closed validation for unregistered types and unavailable structural probe checks.
- [x] Add unit, integration, invalid-input, and contract-documentation coverage; update `docs/update/next.md`.

## Testing

- [x] New or updated tests pass (`python -m pytest`): 1714 passed, 15 skipped.
- [x] Gitleaks passes or no secret-bearing files were touched (Secret Scan CI passed).
- [x] Manual testing completed, if applicable: headless Godot 4.4 integration coverage passed where Godot is installed.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>` (not applicable; no migration).
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"` (not applicable; no migration).
- [ ] Post-upgrade on-disk state was inspected and matches expectations (not applicable; no migration).
- [ ] Re-running `tools/publish.py` produces no further migration changes (not applicable; no migration).
- [ ] Result attached or summarized below (not applicable; no migration).

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
