### PR TITLE
Preserve atlas backup after rollback failure

### DIFF
--- a/tests/tools/test_asset_atlas_assemble.py
+++ b/tests/tools/test_asset_atlas_assemble.py
@@ -266,6 +266,50 @@ def test_assemble_atlas_rolls_back_both_outputs_when_second_commit_fails(
     assert (tmp_path / METADATA_OUTPUT).read_bytes() == original_json
 
 
+def test_assemble_atlas_keeps_backup_when_commit_and_rollback_fail(
+    tmp_path, monkeypatch
+):
+    declaration = prepare_valid_declaration(tmp_path)
+    atlas_output = tmp_path / ATLAS_OUTPUT
+    metadata_output = tmp_path / METADATA_OUTPUT
+    write_png(atlas_output, (12, 8), (10, 20, 30, 255))
+    metadata_output.parent.mkdir(parents=True, exist_ok=True)
+    metadata_output.write_text('{"old": true}\n', encoding="utf-8")
+    original_png = atlas_output.read_bytes()
+    real_replace = atlas_assemble.os.replace
+    atlas_path = atlas_output.resolve()
+    metadata_path = metadata_output.resolve()
+    metadata_commit_failed = False
+    rollback_failed = False
+
+    def fail_commit_and_rollback(source, destination):
+        nonlocal metadata_commit_failed, rollback_failed
+        destination_path = Path(destination).resolve()
+        if destination_path == metadata_path and not metadata_commit_failed:
+            metadata_commit_failed = True
+            raise OSError("simulated metadata commit failure")
+        if (
+            destination_path == atlas_path
+            and metadata_commit_failed
+            and not rollback_failed
+        ):
+            rollback_failed = True
+            raise OSError("simulated atlas rollback failure")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr(atlas_assemble.os, "replace", fail_commit_and_rollback)
+
+    with pytest.raises(AtlasAssemblyError, match="rollback failed") as exc_info:
+        assemble(tmp_path, declaration)
+
+    backups = [path for path in atlas_output.parent.glob("*.png") if path != atlas_output]
+    assert len(backups) == 1
+    assert backups[0].read_bytes() == original_png
+    assert str(atlas_output) in str(exc_info.value)
+    assert str(backups[0]) in str(exc_info.value)
+    assert list(metadata_output.parent.glob("*.json")) == [metadata_output]
+
+
 def test_cli_reports_write_failures_as_json_and_leaves_no_orphan_atlas(tmp_path):
     declaration = prepare_valid_declaration(tmp_path)
     blocked_parent = tmp_path / OUTPUT_DIR / "blocked"

--- a/tools/asset_atlas_assemble.py
+++ b/tools/asset_atlas_assemble.py
@@ -181,6 +181,7 @@ def _commit_output_pair(
     metadata_backup: Path | None = None
     atlas_replaced = False
     metadata_replaced = False
+    commit_succeeded = False
     try:
         atlas_backup = _backup(atlas_output)
         metadata_backup = _backup(metadata_output)
@@ -188,25 +189,39 @@ def _commit_output_pair(
         atlas_replaced = True
         os.replace(metadata_temp, metadata_output)
         metadata_replaced = True
+        commit_succeeded = True
     except OSError as exc:
-        try:
-            if atlas_replaced:
+        rollback_failures: list[tuple[Path, Path | None, OSError]] = []
+        if atlas_replaced:
+            try:
                 _restore(atlas_output, atlas_backup)
                 atlas_backup = None
-            if metadata_replaced:
+            except OSError as rollback_exc:
+                rollback_failures.append((atlas_output, atlas_backup, rollback_exc))
+        if metadata_replaced:
+            try:
                 _restore(metadata_output, metadata_backup)
                 metadata_backup = None
-        except OSError as rollback_exc:
+            except OSError as rollback_exc:
+                rollback_failures.append(
+                    (metadata_output, metadata_backup, rollback_exc)
+                )
+        if rollback_failures:
+            recovery_locations = "; ".join(
+                f"{output} (backup: {backup})"
+                for output, backup, _ in rollback_failures
+            )
             raise AtlasAssemblyError(
-                "Unable to commit atlas outputs and rollback failed"
-            ) from rollback_exc
+                "Unable to commit atlas outputs and rollback failed; "
+                f"manual recovery required for: {recovery_locations}"
+            ) from rollback_failures[0][2]
         raise AtlasAssemblyError("Unable to commit atlas outputs; changes were rolled back") from exc
     finally:
         atlas_temp.unlink(missing_ok=True)
         metadata_temp.unlink(missing_ok=True)
-        if atlas_backup is not None:
+        if atlas_backup is not None and (commit_succeeded or not atlas_replaced):
             atlas_backup.unlink(missing_ok=True)
-        if metadata_backup is not None:
+        if metadata_backup is not None and (commit_succeeded or not metadata_replaced):
             metadata_backup.unlink(missing_ok=True)
 
 


### PR DESCRIPTION
## Summary

Preserve the original atlas backup and report its path when a commit failure is followed by a rollback failure.

## Motivation

The previous failure path could delete the only recoverable atlas backup when rollback itself failed. No public GitHub issue.

## Changes

- [x] Track commit and rollback state separately for each output.
- [x] Retain an unrecovered backup and include its recovery path in the error.
- [x] Add regression coverage for the compound commit-and-rollback failure path.

## Testing

- [x] New or updated tests pass (`python -m pytest tests/tools/test_asset_atlas_assemble.py`)
- [x] Gitleaks passes or no secret-bearing files were touched (CI Secret Scan passed)
- [x] Manual testing complete, if applicable (not applicable; automated failure-path coverage added)

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

N/A — this change only adjusts error-path backup retention.

</details>

## Version Compatibility

Does this PR change behaviors, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

N/A — no migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR (maintenance-only PR)
