### PR TITLE
Preserve artifacts when compilation fails

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -40,6 +40,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Failed native Godot artifact compilation now retains the previous stable artifact and atomically commits a validated replacement only after success.
 - Added the required `--grid` (and `--names`) argument to every production-unit `asset_sheet_process.py` example so the ui-kit, card-kit, compact-prop-pack, fx-bundle, scene-prop-set, and platform-strip commands run as written instead of failing on a missing required argument, and clarified that `--grid` is required in both autoslice and grid snap modes.
 - Point generated-asset runtime handoff (gm-build, gm-fixgap, worker dispatch, worker agent) at `.godotmaker/asset-generation/manifest.json` instead of the analyst's `assets/manifest.json` (#97)
 

--- a/skills/assets/_shared/asset_compiler/registry.py
+++ b/skills/assets/_shared/asset_compiler/registry.py
@@ -15,10 +15,11 @@ all a :class:`CompilerError`.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from hashlib import sha256
 from pathlib import Path
 from typing import Any, Callable
+from uuid import uuid4
 
 from ._stable_entry import LAYOUT_ARTIFACT_TYPES
 from .contract import (
@@ -44,6 +45,19 @@ Compiler = Callable[[CompileRequest], Mapping[str, Any]]
 # (tools/asset_stable_entry.py). Existence alone cannot catch that, because the
 # source file satisfies it.
 SOURCE_IS_ARTIFACT_TYPES = ("Texture2D",)
+
+
+def _staging_request(request: CompileRequest) -> CompileRequest:
+    """Return a request whose artifact target is a unique sibling staging file.
+
+    A compiler may overwrite the stable artifact on a successful regeneration,
+    but it must never expose a partial result at that path.  Keeping the staging
+    target in the same directory makes ``Path.replace`` an atomic commit on the
+    target filesystem, while the receipt still records the stable path.
+    """
+    parent, name = request.artifact_path.rsplit("/", 1)
+    staging_path = f"{parent}/{name}.staging-{uuid4().hex}"
+    return replace(request, artifact_path=staging_path)
 
 
 def _content_digest(path: Path) -> bytes | None:
@@ -202,59 +216,71 @@ class CompilerRegistry:
                 f"source_path; got {request.artifact_path} instead of "
                 f"{request.source_path}"
             )
-        artifact_file = request.artifact_file()
         if route.writes_artifact:
+            artifact_file = request.artifact_file()
             if is_same_file(source_file, artifact_file):
                 raise CompilerError(
                     f"{route.compiler_id} may not publish source_path as "
                     f"artifact_path ({request.artifact_path})"
                 )
-            try:
-                artifact_file.unlink(missing_ok=True)
-            except OSError as exc:
-                raise CompilerError(
-                    f"{route.compiler_id} cannot clear prior artifact "
-                    f"{request.artifact_path}: {exc}"
-                ) from exc
             source_digest = None
         else:
             source_digest = _content_digest(source_file)
             if source_digest is None:
                 raise CompilerError(f"source_path cannot be read: {request.source_path}")
 
+        staging_request = _staging_request(request) if route.writes_artifact else request
+        staging_file: Path | None = None
+        if route.writes_artifact:
+            staging_file = (
+                Path(staging_request.project_root)
+                / staging_request.artifact_path.removeprefix("res://")
+            )
         try:
-            details = route.compiler(request)
-        except CompilerError:
-            raise
-        except Exception as exc:  # noqa: BLE001 - surfaced as a compiler error
-            raise CompilerError(f"{route.compiler_id} failed: {exc}") from exc
+            try:
+                details = route.compiler(staging_request)
+            except CompilerError:
+                raise
+            except Exception as exc:  # noqa: BLE001 - surfaced as a compiler error
+                raise CompilerError(f"{route.compiler_id} failed: {exc}") from exc
 
-        if not isinstance(details, Mapping):
-            raise CompilerError(
-                f"{route.compiler_id} must return a mapping of receipt details"
-            )
+            if not isinstance(details, Mapping):
+                raise CompilerError(
+                    f"{route.compiler_id} must return a mapping of receipt details"
+                )
 
-        # Re-resolve rather than reuse: the first containment check ran against a
-        # path whose parent directories did not exist yet, so no symlink could be
-        # followed. Anything the compiler created in between is checked now.
-        artifact_file = request.artifact_file()
-        if not artifact_file.is_file():
-            raise CompilerError(
-                f"{route.compiler_id} returned without writing {request.artifact_path}"
-            )
-        source_file = request.source_file()
-        if not source_file.is_file():
-            raise CompilerError(f"source_path not found after compilation: {request.source_path}")
-        if route.writes_artifact and is_same_file(source_file, artifact_file):
-            raise CompilerError(
-                f"{route.compiler_id} may not publish source_path as "
-                f"artifact_path ({request.artifact_path})"
-            )
-        if not route.writes_artifact and _content_digest(source_file) != source_digest:
-            raise CompilerError(
-                f"{route.compiler_id} writes no artifact and must not modify "
-                f"source_path ({request.source_path})"
-            )
+            # Re-resolve rather than reuse: the first containment check ran against a
+            # path whose parent directories did not exist yet, so no symlink could be
+            # followed. Anything the compiler created in between is checked now.
+            artifact_file = staging_request.artifact_file()
+            if not artifact_file.is_file():
+                raise CompilerError(
+                    f"{route.compiler_id} returned without writing {request.artifact_path}"
+                )
+            source_file = request.source_file()
+            if not source_file.is_file():
+                raise CompilerError(f"source_path not found after compilation: {request.source_path}")
+            if route.writes_artifact and is_same_file(source_file, artifact_file):
+                raise CompilerError(
+                    f"{route.compiler_id} may not publish source_path as "
+                    f"artifact_path ({request.artifact_path})"
+                )
+            if not route.writes_artifact and _content_digest(source_file) != source_digest:
+                raise CompilerError(
+                    f"{route.compiler_id} writes no artifact and must not modify "
+                    f"source_path ({request.source_path})"
+                )
+            if route.writes_artifact:
+                try:
+                    artifact_file.replace(request.artifact_file())
+                except OSError as exc:
+                    raise CompilerError(
+                        f"{route.compiler_id} cannot commit artifact "
+                        f"{request.artifact_path}: {exc}"
+                    ) from exc
+        finally:
+            if staging_file is not None:
+                staging_file.unlink(missing_ok=True)
 
         return CompileResult(
             godot_artifact=GodotArtifact(

--- a/skills/assets/_shared/asset_compiler/registry.py
+++ b/skills/assets/_shared/asset_compiler/registry.py
@@ -270,6 +270,23 @@ class CompilerRegistry:
                     f"{route.compiler_id} writes no artifact and must not modify "
                     f"source_path ({request.source_path})"
                 )
+            result = CompileResult(
+                godot_artifact=GodotArtifact(
+                    type=request.artifact_type,
+                    path=request.artifact_path,
+                ),
+                receipt=CompileReceipt(
+                    compiler_id=route.compiler_id,
+                    compiler_version=route.compiler_version,
+                    production_family=request.production_family,
+                    asset_id=request.asset_id,
+                    source_layout_type=request.source_layout_type,
+                    source_path=request.source_path,
+                    artifact_type=request.artifact_type,
+                    artifact_path=request.artifact_path,
+                    details=details,
+                ),
+            )
             if route.writes_artifact:
                 try:
                     artifact_file.replace(request.artifact_file())
@@ -282,20 +299,4 @@ class CompilerRegistry:
             if staging_file is not None:
                 staging_file.unlink(missing_ok=True)
 
-        return CompileResult(
-            godot_artifact=GodotArtifact(
-                type=request.artifact_type,
-                path=request.artifact_path,
-            ),
-            receipt=CompileReceipt(
-                compiler_id=route.compiler_id,
-                compiler_version=route.compiler_version,
-                production_family=request.production_family,
-                asset_id=request.asset_id,
-                source_layout_type=request.source_layout_type,
-                source_path=request.source_path,
-                artifact_type=request.artifact_type,
-                artifact_path=request.artifact_path,
-                details=dict(details),
-            ),
-        )
+        return result

--- a/tests/assets/test_asset_compiler_registry.py
+++ b/tests/assets/test_asset_compiler_registry.py
@@ -328,9 +328,8 @@ def test_compiler_that_writes_nothing_is_rejected(project):
 
 
 def test_no_op_compiler_cannot_pass_off_a_previous_runs_artifact(project):
-    # Regeneration overwrites a stable path in place, so the artifact usually
-    # already exists. Existence alone would let a silently no-op compiler hand
-    # back last run's bytes as this run's result.
+    # A no-op compiler must not pass off last run's bytes as this run's result,
+    # nor may it remove the already-ready stable artifact.
     stale = project / "assets/generated/ui-kit/panel/panel.tres"
     stale.write_bytes(b"STALE-FROM-RUN-1")
 
@@ -340,11 +339,68 @@ def test_no_op_compiler_cannot_pass_off_a_previous_runs_artifact(project):
         registry.compile(
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )
-    assert not stale.exists()
+    assert stale.read_bytes() == b"STALE-FROM-RUN-1"
+
+
+@pytest.mark.parametrize(
+    "compiler",
+    [
+        pytest.param(lambda request: (_writer()(request), "not details")[1], id="bad-details"),
+        pytest.param(lambda request: {}, id="no-output"),
+    ],
+)
+def test_failed_compile_keeps_the_previous_artifact(project, compiler):
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stable.write_bytes(b"STABLE-OLD-CONTENT")
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=compiler)
+    with pytest.raises(CompilerError):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
+
+
+def test_raised_compiler_error_keeps_the_previous_artifact(project):
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stable.write_bytes(b"STABLE-OLD-CONTENT")
+
+    registry = CompilerRegistry()
+    _register(
+        registry,
+        "single",
+        "StyleBoxTexture",
+        compiler=lambda request: (_ for _ in ()).throw(CompilerError("failed")),
+    )
+    with pytest.raises(CompilerError, match="failed"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
+
+
+def test_first_failed_compile_leaves_no_stable_or_staging_artifact(project):
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=lambda request: {})
+
+    with pytest.raises(CompilerError, match="returned without writing"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert not stable.exists()
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
 
 
 def test_rebuilding_over_an_existing_artifact_is_accepted(project):
-    (project / "assets/generated/ui-kit/panel/panel.tres").write_bytes(b"OLD")
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stable.write_bytes(b"OLD")
 
     registry = CompilerRegistry()
     _register(registry, "single", "StyleBoxTexture", compiler=_writer(b"NEW-CONTENT"))
@@ -352,6 +408,8 @@ def test_rebuilding_over_an_existing_artifact_is_accepted(project):
         _make_request(project, layout="single", artifact_type="StyleBoxTexture")
     )
     assert result.receipt.details == {"bytes": 11}
+    assert stable.read_bytes() == b"NEW-CONTENT"
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
 
 
 def test_same_size_rewrite_is_accepted(project):
@@ -398,12 +456,59 @@ def test_a_writing_route_may_not_hard_link_its_source_as_the_artifact(project):
         os.link(request.source_file(), request.artifact_file())
         return {}
 
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stable.write_bytes(b"STABLE-OLD-CONTENT")
     registry = CompilerRegistry()
     _register(registry, "single", "StyleBoxTexture", compiler=links_the_source)
     with pytest.raises(CompilerError, match="may not publish source_path"):
         registry.compile(
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )
+    assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
+
+
+def test_a_writing_route_may_not_symlink_its_source_as_the_artifact(project):
+    def symlinks_the_source(request):
+        try:
+            request.artifact_file().symlink_to(request.source_file())
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlink creation unavailable: {exc}")
+        return {}
+
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stable.write_bytes(b"STABLE-OLD-CONTENT")
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=symlinks_the_source)
+    with pytest.raises(CompilerError, match="may not publish source_path"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+    assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
+
+
+def test_post_compile_source_validation_failure_keeps_previous_artifact(project):
+    def deletes_source_after_writing(request):
+        _writer()(request)
+        request.source_file().unlink()
+        return {}
+
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stable.write_bytes(b"STABLE-OLD-CONTENT")
+    registry = CompilerRegistry()
+    _register(
+        registry,
+        "single",
+        "StyleBoxTexture",
+        compiler=deletes_source_after_writing,
+    )
+    with pytest.raises(CompilerError, match="source_path not found after compilation"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+    assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
 
 
 def test_a_non_writing_route_may_not_modify_its_source(project):

--- a/tests/assets/test_asset_compiler_registry.py
+++ b/tests/assets/test_asset_compiler_registry.py
@@ -43,6 +43,15 @@ def _writer(payload=b"artifact"):
     return compiler
 
 
+def _writer_with_uncopyable_details(request):
+    class Uncopyable:
+        def __deepcopy__(self, memo):
+            raise TypeError("cannot snapshot")
+
+    _writer(b"NEW")(request)
+    return {"invalid": Uncopyable()}
+
+
 def _register(registry, layout, artifact_type, compiler=None, compiler_id=None):
     return registry.register(
         source_layout_type=layout,
@@ -390,6 +399,45 @@ def test_first_failed_compile_leaves_no_stable_or_staging_artifact(project):
     _register(registry, "single", "StyleBoxTexture", compiler=lambda request: {})
 
     with pytest.raises(CompilerError, match="returned without writing"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert not stable.exists()
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
+
+
+def test_uncopyable_receipt_details_keep_the_previous_artifact(project):
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stable.write_bytes(b"STABLE-OLD-CONTENT")
+    registry = CompilerRegistry()
+    _register(
+        registry,
+        "single",
+        "StyleBoxTexture",
+        compiler=_writer_with_uncopyable_details,
+    )
+
+    with pytest.raises(CompilerError, match="details must hold copyable plain data"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
+    assert not list(stable.parent.glob("panel.tres.staging-*"))
+
+
+def test_first_uncopyable_receipt_failure_leaves_no_artifact(project):
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    registry = CompilerRegistry()
+    _register(
+        registry,
+        "single",
+        "StyleBoxTexture",
+        compiler=_writer_with_uncopyable_details,
+    )
+
+    with pytest.raises(CompilerError, match="details must hold copyable plain data"):
         registry.compile(
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )


### PR DESCRIPTION
## Summary

Make compiler artifact replacement transactional so a failed compilation leaves the previous stable artifact intact.

## Motivation

Failed compiler output must not invalidate an artifact still referenced by ready entries or workers. No public GitHub issue is associated with this change.

## Changes

- [x] Stage writing-compiler output beside the stable artifact and atomically replace it only after validation.
- [x] Preserve the existing artifact across compiler, receipt, output, link, and post-validation failures.
- [x] Add regression coverage for existing-artifact and first-generation failure paths.

## Testing

- [x] New or updated tests pass (`pytest` where relevant): `python -m pytest tests/assets/test_asset_compiler_registry.py` and `python -m pytest`.
- [x] Gitleaks passes or no secret-bearing files were touched: CI Secret Scan passed.
- [x] Manual testing complete, if applicable: validated failure cleanup and replacement paths through regression tests.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable: this change is not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behaviors, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level
> does NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [x] Not applicable: no migration script was added or modified.
- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [x] Result attached or summarized below: not applicable; no migration changes.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable: no ECS systems changed)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR (maintenance-only bug fix; no release-note change required)
