### PR TITLE
Preserve Godot resource staging extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ node_modules/
 # Godot
 .godot/
 *.import
+*.staging-*
 
 # IDE / Editor
 .vscode/

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -41,7 +41,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
-- Preserved Godot resource extensions during compiler staging and issue compile receipts only after atomic artifact commits.
+- Compiler staging now preserves Godot resource extensions.
+- Compiler receipts are now issued only after atomic artifact commits.
 - Asset readiness promotion now requires a compiler receipt bound to the compiled entry, while already-ready assets can explicitly revalidate without retaining that receipt.
 - Failed native Godot artifact compilation now retains the previous stable artifact and atomically commits a validated replacement only after success.
 - Added the required `--grid` (and `--names`) argument to every production-unit `asset_sheet_process.py` example so the ui-kit, card-kit, compact-prop-pack, fx-bundle, scene-prop-set, and platform-strip commands run as written instead of failing on a missing required argument, and clarified that `--grid` is required in both autoslice and grid snap modes.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -41,6 +41,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Preserved Godot resource extensions during compiler staging and issue compile receipts only after atomic artifact commits.
 - Asset readiness promotion now requires a compiler receipt bound to the compiled entry, while already-ready assets can explicitly revalidate without retaining that receipt.
 - Failed native Godot artifact compilation now retains the previous stable artifact and atomically commits a validated replacement only after success.
 - Added the required `--grid` (and `--names`) argument to every production-unit `asset_sheet_process.py` example so the ui-kit, card-kit, compact-prop-pack, fx-bundle, scene-prop-set, and platform-strip commands run as written instead of failing on a missing required argument, and clarified that `--grid` is required in both autoslice and grid snap modes.

--- a/skills/assets/_shared/asset_compiler/registry.py
+++ b/skills/assets/_shared/asset_compiler/registry.py
@@ -53,10 +53,14 @@ def _staging_request(request: CompileRequest) -> CompileRequest:
     A compiler may overwrite the stable artifact on a successful regeneration,
     but it must never expose a partial result at that path.  Keeping the staging
     target in the same directory makes ``Path.replace`` an atomic commit on the
-    target filesystem, while the receipt still records the stable path.
+    target filesystem.  The final extension stays at the end of the staging
+    filename because Godot's ``ResourceSaver`` selects its format from that
+    extension.  The receipt still records the stable path.
     """
     parent, name = request.artifact_path.rsplit("/", 1)
-    staging_path = f"{parent}/{name}.staging-{uuid4().hex}"
+    extension = Path(name).suffix
+    stem = name.removesuffix(extension) if extension else name
+    staging_path = f"{parent}/{stem}.staging-{uuid4().hex}{extension}"
     return replace(request, artifact_path=staging_path)
 
 
@@ -297,14 +301,6 @@ class CompilerRegistry:
                 artifact_path=request.artifact_path,
                 details=details,
             )
-            self._issued_receipts[id(receipt)] = receipt
-            result = CompileResult(
-                godot_artifact=GodotArtifact(
-                    type=request.artifact_type,
-                    path=request.artifact_path,
-                ),
-                receipt=receipt,
-            )
             if route.writes_artifact:
                 try:
                     artifact_file.replace(request.artifact_file())
@@ -313,6 +309,17 @@ class CompilerRegistry:
                         f"{route.compiler_id} cannot commit artifact "
                         f"{request.artifact_path}: {exc}"
                     ) from exc
+            # A receipt is a capability used to promote an entry through L2.
+            # Issue it only once the stable artifact is in place, so a failed
+            # atomic commit cannot leave a receipt for bytes never published.
+            self._issued_receipts[id(receipt)] = receipt
+            result = CompileResult(
+                godot_artifact=GodotArtifact(
+                    type=request.artifact_type,
+                    path=request.artifact_path,
+                ),
+                receipt=receipt,
+            )
         finally:
             if staging_file is not None:
                 staging_file.unlink(missing_ok=True)

--- a/skills/assets/_shared/asset_compiler/registry.py
+++ b/skills/assets/_shared/asset_compiler/registry.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from hashlib import sha256
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 from uuid import uuid4
 
@@ -58,10 +58,42 @@ def _staging_request(request: CompileRequest) -> CompileRequest:
     extension.  The receipt still records the stable path.
     """
     parent, name = request.artifact_path.rsplit("/", 1)
-    extension = Path(name).suffix
-    stem = name.removesuffix(extension) if extension else name
-    staging_path = f"{parent}/{stem}.staging-{uuid4().hex}{extension}"
+    artifact_name = PurePosixPath(name)
+    staging_path = (
+        f"{parent}/{artifact_name.stem}.staging-{uuid4().hex}{artifact_name.suffix}"
+    )
     return replace(request, artifact_path=staging_path)
+
+
+def _staging_glob(request: CompileRequest) -> str:
+    """Return the exact sibling staging glob for one stable artifact."""
+    artifact_name = PurePosixPath(request.artifact_path)
+    return f"{artifact_name.stem}.staging-*{artifact_name.suffix}"
+
+
+def _remove_stale_staging(request: CompileRequest) -> None:
+    """Remove interrupted staging files for this one stable artifact.
+
+    This is deliberately narrower than a project-wide orphan scan: a new
+    compile only recovers siblings for its exact stable artifact name and final
+    extension. It prevents a prior interrupted Godot save from poisoning the
+    next project import while preserving the single-file commit boundary.
+    """
+    stable_file = request.artifact_file()
+    try:
+        stale_files = tuple(stable_file.parent.glob(_staging_glob(request)))
+    except OSError as exc:
+        raise CompilerError(
+            f"cannot inspect stale staging artifacts for {request.artifact_path}: {exc}"
+        ) from exc
+
+    for stale_file in stale_files:
+        try:
+            stale_file.unlink()
+        except OSError as exc:
+            raise CompilerError(
+                f"cannot remove stale staging artifact {stale_file.name}: {exc}"
+            ) from exc
 
 
 def _content_digest(path: Path) -> bytes | None:
@@ -243,6 +275,7 @@ class CompilerRegistry:
                     f"{route.compiler_id} may not publish source_path as "
                     f"artifact_path ({request.artifact_path})"
                 )
+            _remove_stale_staging(request)
             source_digest = None
         else:
             source_digest = _content_digest(source_file)
@@ -275,7 +308,8 @@ class CompilerRegistry:
             artifact_file = staging_request.artifact_file()
             if not artifact_file.is_file():
                 raise CompilerError(
-                    f"{route.compiler_id} returned without writing {request.artifact_path}"
+                    f"{route.compiler_id} returned without writing "
+                    f"{staging_request.artifact_path}"
                 )
             source_file = request.source_file()
             if not source_file.is_file():
@@ -283,7 +317,7 @@ class CompilerRegistry:
             if route.writes_artifact and is_same_file(source_file, artifact_file):
                 raise CompilerError(
                     f"{route.compiler_id} may not publish source_path as "
-                    f"artifact_path ({request.artifact_path})"
+                    f"staging artifact ({staging_request.artifact_path})"
                 )
             if not route.writes_artifact and _content_digest(source_file) != source_digest:
                 raise CompilerError(
@@ -322,6 +356,12 @@ class CompilerRegistry:
             )
         finally:
             if staging_file is not None:
-                staging_file.unlink(missing_ok=True)
+                try:
+                    staging_file.unlink(missing_ok=True)
+                except OSError:
+                    # Never replace the compile error being propagated. A later
+                    # compile for this exact artifact retries its narrow sibling
+                    # recovery before handing a fresh staging path to a compiler.
+                    pass
 
         return result

--- a/skills/assets/_shared/godot-artifact-compiler-contract.md
+++ b/skills/assets/_shared/godot-artifact-compiler-contract.md
@@ -37,11 +37,16 @@ Two rules make "the compiler produced the artifact" mean something, because a
 generated asset overwrites a stable path in place and the artifact usually
 already exists from an earlier run:
 
-- **A writing route must replace the old artifact.** The registry removes an
-  existing artifact before the compiler runs and requires a new file after it
-  returns. Otherwise a compiler that silently no-ops passes off the previous
-  run's bytes as this run's result. This does not rely on filesystem timestamp
-  precision, so a same-byte deterministic rebuild remains valid.
+- **A writing route must produce a sibling staging artifact.** The registry
+  passes the compiler a unique path beside the stable artifact, such as
+  `panel.staging-<uuid>.tres` for `panel.tres` or
+  `tileset.staging-<uuid>.res` for `tileset.res`. The final extension remains
+  intact so Godot's `ResourceSaver` recognizes the resource format. After the
+  compiler returns a valid file, the registry atomically commits that staging
+  artifact with `Path.replace()`. A no-op compiler therefore cannot pass off
+  the previous run's bytes, while compiler, validation, and commit failures
+  preserve the previous stable artifact. This does not rely on filesystem
+  timestamp precision, so a same-byte deterministic rebuild remains valid.
 - **A writing route must not name its source.** `artifact_path` may not equal
   `source_path` or resolve to the same file, so a compiler cannot publish its
   own source image (including through a hard link or case alias) as the
@@ -59,10 +64,11 @@ the registry rejects it if its compiler changes that source.
 Compiler = Callable[[CompileRequest], Mapping[str, Any]]
 ```
 
-A compiler writes its artifact to `request.artifact_path` and returns its
-receipt details. It does not build the worker-facing artifact object; the
-registry does. That asymmetry is the mechanism behind the worker-snapshot
-boundary below.
+A compiler writes its artifact to its staging `request.artifact_path` and
+returns its receipt details. The registry commits that artifact to the stable
+request path only after validation succeeds. It does not build the
+worker-facing artifact object; the registry does. That asymmetry is the
+mechanism behind the worker-snapshot boundary below.
 
 `CompileRequest` carries `production_family`, `asset_id`, `source_layout_type`,
 `source_path`, `artifact_type`, `artifact_path`, `project_root`, and a
@@ -95,7 +101,8 @@ layer surfaces — when:
 - the compiler raises — its own `CompilerError` propagates unchanged, any other
   exception is wrapped with the compiler id so nothing escapes as a traceback;
 - the compiler returns something other than a mapping;
-- the compiler returns without replacing its artifact for this run.
+- the compiler returns without writing its staging artifact for this run;
+- the staging artifact cannot be atomically committed to the stable path.
 
 Path containment is re-checked after the compiler returns, not reused from
 before it ran: the first check resolved a path whose parent directories did not
@@ -113,8 +120,10 @@ request. Compiler identity, version, and internal findings live in
 `CompileReceipt` and never widen the worker snapshot — a compiler cannot add a
 field to the artifact even by returning one, because it never constructs it.
 
-Receipts are returned to the caller. This layer does not define a receipt
-storage location; nothing worker-facing may depend on one.
+Receipts are returned to the caller only after the stable artifact commit
+succeeds (or, for a non-writing route, after its source-preservation checks
+succeed). This layer does not define a receipt storage location; nothing
+worker-facing may depend on one. A failed commit leaves no issued receipt.
 
 ## Texture2D
 

--- a/skills/assets/_shared/godot-artifact-compiler-contract.md
+++ b/skills/assets/_shared/godot-artifact-compiler-contract.md
@@ -47,6 +47,9 @@ already exists from an earlier run:
   the previous run's bytes, while compiler, validation, and commit failures
   preserve the previous stable artifact. This does not rely on filesystem
   timestamp precision, so a same-byte deterministic rebuild remains valid.
+  Before a new writing compile starts, the registry removes only interrupted
+  staging siblings for that exact stable filename and extension. This narrow
+  recovery is not a production-family orphan scan or a directory transaction.
 - **A writing route must not name its source.** `artifact_path` may not equal
   `source_path` or resolve to the same file, so a compiler cannot publish its
   own source image (including through a hard link or case alias) as the
@@ -64,11 +67,13 @@ the registry rejects it if its compiler changes that source.
 Compiler = Callable[[CompileRequest], Mapping[str, Any]]
 ```
 
-A compiler writes its artifact to its staging `request.artifact_path` and
-returns its receipt details. The registry commits that artifact to the stable
-request path only after validation succeeds. It does not build the
-worker-facing artifact object; the registry does. That asymmetry is the
-mechanism behind the worker-snapshot boundary below.
+A writing compiler receives a sibling staging `request.artifact_path`, writes
+its artifact there, and returns receipt details. The registry commits that
+artifact to the stable request path only after validation succeeds. A
+non-writing route receives the original request, writes no artifact, and has
+no staging or commit step. The compiler does not build the worker-facing
+artifact object; the registry does. That asymmetry is the mechanism behind the
+worker-snapshot boundary below.
 
 `CompileRequest` carries `production_family`, `asset_id`, `source_layout_type`,
 `source_path`, `artifact_type`, `artifact_path`, `project_root`, and a

--- a/skills/core/project-scaffold/templates/gitignore.tmpl
+++ b/skills/core/project-scaffold/templates/gitignore.tmpl
@@ -1,6 +1,7 @@
 # Godot
 .godot/
 *.import
+*.staging-*
 export_presets.cfg
 reports/
 

--- a/tests/assets/test_asset_compiler_contract_docs.py
+++ b/tests/assets/test_asset_compiler_contract_docs.py
@@ -45,8 +45,12 @@ def test_doc_states_the_rules_the_registry_enforces():
         "writes_artifact=False",
         "build_default_registry()",
         "CompilerError",
+        "sibling staging artifact",
+        "panel.staging-<uuid>.tres",
+        "after the stable artifact commit",
     ):
         assert claim in doc, f"the contract doc no longer mentions {claim}"
+    assert "removes an\n  existing artifact before the compiler runs" not in doc
     # The doc must not promise a module-level registry the package removed.
     assert "DEFAULT_REGISTRY" not in doc
 

--- a/tests/assets/test_asset_compiler_contract_docs.py
+++ b/tests/assets/test_asset_compiler_contract_docs.py
@@ -12,6 +12,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
 CONTRACT_DOC = SHARED_DIR / "godot-artifact-compiler-contract.md"
+SCAFFOLD_GITIGNORE = (
+    REPO_ROOT / "skills" / "core" / "project-scaffold" / "templates" / "gitignore.tmpl"
+)
 sys.path.insert(0, str(SHARED_DIR))
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
@@ -39,6 +42,7 @@ def test_documented_routing_table_matches_the_frozen_relation():
 
 def test_doc_states_the_rules_the_registry_enforces():
     doc = CONTRACT_DOC.read_text(encoding="utf-8")
+    normalized_doc = " ".join(doc.split())
     for claim in (
         "LAYOUT_ARTIFACT_TYPES",
         "SOURCE_IS_ARTIFACT_TYPES",
@@ -50,7 +54,16 @@ def test_doc_states_the_rules_the_registry_enforces():
         "after the stable artifact commit",
     ):
         assert claim in doc, f"the contract doc no longer mentions {claim}"
-    assert "removes an\n  existing artifact before the compiler runs" not in doc
+    for current_claim in (
+        "A writing compiler receives a sibling staging `request.artifact_path`",
+        "A non-writing route receives the original request, writes no artifact, and has no staging or commit step.",
+    ):
+        assert current_claim in normalized_doc
+    for retired_claim in (
+        "removes an existing artifact before the compiler runs",
+        "deletes the existing artifact before running the compiler",
+    ):
+        assert retired_claim not in normalized_doc
     # The doc must not promise a module-level registry the package removed.
     assert "DEFAULT_REGISTRY" not in doc
 
@@ -64,3 +77,8 @@ def test_doc_names_every_type_allowed_to_skip_writing():
 def test_shared_has_no_skill_md():
     # _shared holds cross-skill material and is not independently triggerable.
     assert not (SHARED_DIR / "SKILL.md").exists()
+
+
+def test_staging_artifacts_are_ignored_by_repo_and_scaffold_templates():
+    for gitignore in (REPO_ROOT / ".gitignore", SCAFFOLD_GITIGNORE):
+        assert "*.staging-*" in gitignore.read_text(encoding="utf-8")

--- a/tests/assets/test_asset_compiler_registry.py
+++ b/tests/assets/test_asset_compiler_registry.py
@@ -142,6 +142,31 @@ def test_compile_returns_the_routed_compilers_receipt(project):
     assert (project / "assets/generated/ui-kit/panel/panel.tres").is_file()
 
 
+@pytest.mark.parametrize("extension", [".tres", ".res"])
+def test_writing_compiler_gets_a_sibling_staging_path_with_final_extension(
+    project, extension
+):
+    observed_paths = []
+
+    def records_staging_path(request):
+        observed_paths.append(request.artifact_path)
+        return _writer()(request)
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=records_staging_path)
+    request = _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    request = _replace(request, "artifact_path", request.artifact_path.removesuffix(".tres") + extension)
+
+    registry.compile(request)
+
+    (staging_path,) = observed_paths
+    stable_parent, stable_name = request.artifact_path.rsplit("/", 1)
+    staging_parent, staging_name = staging_path.rsplit("/", 1)
+    assert staging_parent == stable_parent
+    assert staging_name.startswith(stable_name.removesuffix(extension) + ".staging-")
+    assert staging_name.endswith(extension)
+
+
 def test_only_the_exact_receipt_returned_by_this_registry_is_issued(project):
     registry = CompilerRegistry()
     _register(registry, "single", "StyleBoxTexture", compiler=_writer(b"12345"))
@@ -393,7 +418,7 @@ def test_failed_compile_keeps_the_previous_artifact(project, compiler):
         )
 
     assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_raised_compiler_error_keeps_the_previous_artifact(project):
@@ -413,7 +438,7 @@ def test_raised_compiler_error_keeps_the_previous_artifact(project):
         )
 
     assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_first_failed_compile_leaves_no_stable_or_staging_artifact(project):
@@ -427,7 +452,7 @@ def test_first_failed_compile_leaves_no_stable_or_staging_artifact(project):
         )
 
     assert not stable.exists()
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_uncopyable_receipt_details_keep_the_previous_artifact(project):
@@ -447,7 +472,7 @@ def test_uncopyable_receipt_details_keep_the_previous_artifact(project):
         )
 
     assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_first_uncopyable_receipt_failure_leaves_no_artifact(project):
@@ -466,7 +491,7 @@ def test_first_uncopyable_receipt_failure_leaves_no_artifact(project):
         )
 
     assert not stable.exists()
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_rebuilding_over_an_existing_artifact_is_accepted(project):
@@ -480,12 +505,12 @@ def test_rebuilding_over_an_existing_artifact_is_accepted(project):
     )
     assert result.receipt.details == {"bytes": 11}
     assert stable.read_bytes() == b"NEW-CONTENT"
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_same_size_rewrite_is_accepted(project):
-    # Replacing the old path before compilation makes this independent of the
-    # filesystem timestamp resolution.
+    # A distinct staging path makes this independent of filesystem timestamp
+    # resolution, including when the deterministic result has the same size.
     (project / "assets/generated/ui-kit/panel/panel.tres").write_bytes(b"AAA")
 
     registry = CompilerRegistry()
@@ -494,6 +519,55 @@ def test_same_size_rewrite_is_accepted(project):
         _make_request(project, layout="single", artifact_type="StyleBoxTexture")
     )
     assert (project / "assets/generated/ui-kit/panel/panel.tres").read_bytes() == b"BBB"
+
+
+def test_commit_failure_keeps_previous_artifact_and_does_not_issue_receipt(
+    project, monkeypatch
+):
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stable.write_bytes(b"STABLE-OLD-CONTENT")
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=_writer(b"NEW-CONTENT"))
+    original_replace = Path.replace
+
+    def reject_staging_commit(self, target):
+        if self.parent == stable.parent and self.name.startswith("panel.staging-"):
+            raise OSError("commit denied")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", reject_staging_commit)
+
+    with pytest.raises(CompilerError, match="cannot commit artifact"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
+    assert registry._issued_receipts == {}
+
+
+def test_first_commit_failure_leaves_no_artifact_or_receipt(project, monkeypatch):
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=_writer())
+    original_replace = Path.replace
+
+    def reject_staging_commit(self, target):
+        if self.parent == stable.parent and self.name.startswith("panel.staging-"):
+            raise OSError("commit denied")
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", reject_staging_commit)
+
+    with pytest.raises(CompilerError, match="cannot commit artifact"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert not stable.exists()
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
+    assert registry._issued_receipts == {}
 
 
 # --- the source image may not be published as the artifact -----------------
@@ -536,7 +610,7 @@ def test_a_writing_route_may_not_hard_link_its_source_as_the_artifact(project):
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )
     assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_a_writing_route_may_not_symlink_its_source_as_the_artifact(project):
@@ -556,7 +630,7 @@ def test_a_writing_route_may_not_symlink_its_source_as_the_artifact(project):
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )
     assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_post_compile_source_validation_failure_keeps_previous_artifact(project):
@@ -579,7 +653,7 @@ def test_post_compile_source_validation_failure_keeps_previous_artifact(project)
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )
     assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
-    assert not list(stable.parent.glob("panel.tres.staging-*"))
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
 
 
 def test_a_non_writing_route_may_not_modify_its_source(project):

--- a/tests/assets/test_asset_compiler_registry.py
+++ b/tests/assets/test_asset_compiler_registry.py
@@ -147,10 +147,11 @@ def test_writing_compiler_gets_a_sibling_staging_path_with_final_extension(
     project, extension
 ):
     observed_paths = []
+    payload = f"artifact{extension}".encode()
 
     def records_staging_path(request):
         observed_paths.append(request.artifact_path)
-        return _writer()(request)
+        return _writer(payload)(request)
 
     registry = CompilerRegistry()
     _register(registry, "single", "StyleBoxTexture", compiler=records_staging_path)
@@ -165,6 +166,8 @@ def test_writing_compiler_gets_a_sibling_staging_path_with_final_extension(
     assert staging_parent == stable_parent
     assert staging_name.startswith(stable_name.removesuffix(extension) + ".staging-")
     assert staging_name.endswith(extension)
+    stable_file = project / request.artifact_path.removeprefix("res://")
+    assert stable_file.read_bytes() == payload
 
 
 def test_only_the_exact_receipt_returned_by_this_registry_is_issued(project):
@@ -381,6 +384,23 @@ def test_compiler_that_writes_nothing_is_rejected(project):
         )
 
 
+def test_missing_artifact_diagnostic_names_the_staging_path(project):
+    observed_paths = []
+
+    def writes_nothing(request):
+        observed_paths.append(request.artifact_path)
+        return {}
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=writes_nothing)
+    with pytest.raises(CompilerError, match="returned without writing") as error:
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert observed_paths[0] in str(error.value)
+
+
 # --- the artifact must actually be rebuilt this run ------------------------
 
 
@@ -397,6 +417,91 @@ def test_no_op_compiler_cannot_pass_off_a_previous_runs_artifact(project):
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )
     assert stale.read_bytes() == b"STALE-FROM-RUN-1"
+
+
+def test_writing_compile_recovers_its_interrupted_staging_sibling(project):
+    stable = project / "assets/generated/ui-kit/panel/panel.tres"
+    stale = stable.with_name("panel.staging-interrupted.tres")
+    stale.write_bytes(b"PARTIAL")
+    saw_stale = []
+
+    def verifies_recovery(request):
+        saw_stale.append(stale.exists())
+        return _writer(b"FRESH")(request)
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=verifies_recovery)
+    registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+
+    assert saw_stale == [False]
+    assert stable.read_bytes() == b"FRESH"
+    assert not list(stable.parent.glob("panel.staging-*.tres"))
+
+
+def test_writing_compile_only_recovers_its_matching_staging_extension(project):
+    preserved = project / "assets/generated/ui-kit/panel/panel.staging-other.res"
+    preserved.write_bytes(b"OTHER-RESOURCE")
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture")
+    registry.compile(
+        _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+    )
+
+    assert preserved.read_bytes() == b"OTHER-RESOURCE"
+
+
+def test_unremovable_stale_staging_fails_before_the_compiler_runs(project, monkeypatch):
+    stale = project / "assets/generated/ui-kit/panel/panel.staging-locked.tres"
+    stale.write_bytes(b"LOCKED")
+    original_unlink = Path.unlink
+    ran = []
+
+    def locked_unlink(self, *args, **kwargs):
+        if self == stale:
+            raise PermissionError("locked")
+        return original_unlink(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", locked_unlink)
+    registry = CompilerRegistry()
+    _register(
+        registry,
+        "single",
+        "StyleBoxTexture",
+        compiler=lambda request: ran.append(request) or {},
+    )
+    with pytest.raises(CompilerError, match="cannot remove stale staging artifact"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
+
+    assert ran == []
+
+
+def test_staging_cleanup_error_does_not_mask_the_compiler_error(project, monkeypatch):
+    observed_paths = []
+    original_unlink = Path.unlink
+
+    def returns_bad_details(request):
+        observed_paths.append(request.artifact_file())
+        _writer()(request)
+        return []
+
+    def locked_unlink(self, *args, **kwargs):
+        if self in observed_paths:
+            raise PermissionError("locked")
+        return original_unlink(self, *args, **kwargs)
+
+    registry = CompilerRegistry()
+    _register(registry, "single", "StyleBoxTexture", compiler=returns_bad_details)
+    monkeypatch.setattr(Path, "unlink", locked_unlink)
+
+    with pytest.raises(CompilerError, match="must return a mapping of receipt details"):
+        registry.compile(
+            _make_request(project, layout="single", artifact_type="StyleBoxTexture")
+        )
 
 
 @pytest.mark.parametrize(
@@ -597,7 +702,10 @@ def test_a_writing_route_may_not_hand_back_its_source_image(project):
 
 
 def test_a_writing_route_may_not_hard_link_its_source_as_the_artifact(project):
+    observed_paths = []
+
     def links_the_source(request):
+        observed_paths.append(request.artifact_path)
         os.link(request.source_file(), request.artifact_file())
         return {}
 
@@ -605,10 +713,11 @@ def test_a_writing_route_may_not_hard_link_its_source_as_the_artifact(project):
     stable.write_bytes(b"STABLE-OLD-CONTENT")
     registry = CompilerRegistry()
     _register(registry, "single", "StyleBoxTexture", compiler=links_the_source)
-    with pytest.raises(CompilerError, match="may not publish source_path"):
+    with pytest.raises(CompilerError, match="may not publish source_path") as error:
         registry.compile(
             _make_request(project, layout="single", artifact_type="StyleBoxTexture")
         )
+    assert observed_paths[0] in str(error.value)
     assert stable.read_bytes() == b"STABLE-OLD-CONTENT"
     assert not list(stable.parent.glob("panel.staging-*.tres"))
 

--- a/tests/assets/test_asset_validation_godot.py
+++ b/tests/assets/test_asset_validation_godot.py
@@ -18,7 +18,7 @@ SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
 sys.path.insert(0, str(SHARED_DIR))
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
-from asset_compiler import CompileRequest, build_default_registry  # noqa: E402
+from asset_compiler import CompileRequest, CompilerError, build_default_registry  # noqa: E402
 from asset_validation import (  # noqa: E402
     NOT_RUN,
     PASSED,
@@ -28,6 +28,7 @@ from asset_validation import (  # noqa: E402
     ValidationLadder,
     build_default_structures,
 )
+from asset_validation.godot_probe import SCRIPT_TIMEOUT  # noqa: E402
 
 # A Theme with no content: it loads cleanly, which is what makes it a useful
 # stand-in for a resource of the wrong type.
@@ -60,6 +61,33 @@ func _init() -> void:
         return
     quit()
 """
+
+
+def _run_resource_saver(
+    probe: GodotProbe,
+    project_root: Path,
+    script: Path,
+    artifact_type: str,
+    artifact_path: str,
+) -> subprocess.CompletedProcess:
+    """Ask the same console Godot binary L3 uses to save one resource."""
+    return subprocess.run(
+        [
+            probe.godot_path,
+            "--headless",
+            "--path",
+            str(project_root),
+            "--script",
+            str(script),
+            "--",
+            artifact_type,
+            artifact_path,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=SCRIPT_TIMEOUT,
+    )
 
 
 def _png(width: int, height: int) -> bytes:
@@ -162,26 +190,27 @@ def test_resource_saver_accepts_extension_preserving_staging_artifacts(
     script = godot_project / "save_staging_resource.gd"
     script.write_text(RESOURCE_SAVER_SCRIPT, encoding="utf-8")
     staging_paths = []
+    probe = GodotProbe(godot_bin)
 
     def save_with_godot(request):
         staging_paths.append(request.artifact_path)
-        completed = subprocess.run(
-            [
-                godot_bin,
-                "--headless",
-                "--path",
-                str(godot_project),
-                "--script",
-                str(script),
-                "--",
+        try:
+            completed = _run_resource_saver(
+                probe,
+                godot_project,
+                script,
                 artifact_type,
                 request.artifact_path,
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        assert completed.returncode == 0, completed.stderr or completed.stdout
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise CompilerError(
+                f"ResourceSaver.save timed out after {SCRIPT_TIMEOUT}s"
+            ) from exc
+        if completed.returncode != 0:
+            raise CompilerError(
+                f"ResourceSaver.save failed for {request.artifact_path}: "
+                f"{completed.stderr.strip() or completed.stdout.strip()}"
+            )
         return {"writer": "ResourceSaver"}
 
     registry = build_default_registry()
@@ -207,13 +236,33 @@ def test_resource_saver_accepts_extension_preserving_staging_artifacts(
     (staging_path,) = staging_paths
     assert staging_path.endswith(Path(artifact_name).suffix)
     assert ".staging-" in staging_path
-    report = GodotProbe(godot_bin).probe(
+    report = probe.probe(
         godot_project,
         [ProbeRequest(result.godot_artifact.path, artifact_type)],
     )
     (loaded,) = report.resources
     assert loaded.loaded is True, loaded.to_dict()
     assert loaded.type_matches is True, loaded.to_dict()
+
+
+def test_resource_saver_rejects_a_staging_token_after_the_resource_extension(
+    godot_bin, godot_project
+):
+    """The legacy suffix order must remain a real engine failure."""
+    base = "res://assets/generated/ui-kit/panel"
+    _write(godot_project, f"{base}/panel.png", b"source")
+    script = godot_project / "save_legacy_staging_resource.gd"
+    script.write_text(RESOURCE_SAVER_SCRIPT, encoding="utf-8")
+
+    completed = _run_resource_saver(
+        GodotProbe(godot_bin),
+        godot_project,
+        script,
+        "StyleBoxTexture",
+        f"{base}/panel.tres.staging-legacy",
+    )
+
+    assert completed.returncode == 15, completed.stderr or completed.stdout
 
 
 def test_a_generated_texture_reaches_ready_through_real_godot(godot_bin, godot_project):

--- a/tests/assets/test_asset_validation_godot.py
+++ b/tests/assets/test_asset_validation_godot.py
@@ -6,6 +6,7 @@ when no engine is reachable -- CI installs pytest and pillow only -- so a
 contributor with Godot 4.4+ installed runs them and CI does not.
 """
 import struct
+import subprocess
 import sys
 import zlib
 from pathlib import Path
@@ -31,6 +32,34 @@ from asset_validation import (  # noqa: E402
 # A Theme with no content: it loads cleanly, which is what makes it a useful
 # stand-in for a resource of the wrong type.
 THEME_TRES = '[gd_resource type="Theme" format=3]\n\n[resource]\n'
+
+RESOURCE_SAVER_SCRIPT = """extends SceneTree
+
+func _init() -> void:
+    var arguments := OS.get_cmdline_user_args()
+    if arguments.size() != 2:
+        push_error("expected a resource type and target path")
+        quit(2)
+        return
+
+    var resource: Resource
+    match arguments[0]:
+        "StyleBoxTexture":
+            resource = StyleBoxTexture.new()
+        "Theme":
+            resource = Theme.new()
+        _:
+            push_error("unsupported resource type: " + arguments[0])
+            quit(2)
+            return
+
+    var error := ResourceSaver.save(resource, arguments[1])
+    if error != OK:
+        push_error("ResourceSaver.save failed: " + str(error))
+        quit(error)
+        return
+    quit()
+"""
 
 
 def _png(width: int, height: int) -> bytes:
@@ -109,6 +138,82 @@ def _default_compile_receipt(registry, root: Path):
             project_root=root,
         )
     ).receipt
+
+
+@pytest.mark.parametrize(
+    ("layout", "artifact_type", "asset_id", "source_name", "artifact_name"),
+    [
+        ("single", "StyleBoxTexture", "panel", "panel.png", "panel.tres"),
+        ("theme_recipe", "Theme", "skin", "skin.json", "skin.res"),
+    ],
+)
+def test_resource_saver_accepts_extension_preserving_staging_artifacts(
+    godot_bin,
+    godot_project,
+    layout,
+    artifact_type,
+    asset_id,
+    source_name,
+    artifact_name,
+):
+    """Exercise Godot's suffix-sensitive ResourceSaver through the registry."""
+    base = f"res://assets/generated/ui-kit/{asset_id}"
+    _write(godot_project, f"{base}/{source_name}", b"source")
+    script = godot_project / "save_staging_resource.gd"
+    script.write_text(RESOURCE_SAVER_SCRIPT, encoding="utf-8")
+    staging_paths = []
+
+    def save_with_godot(request):
+        staging_paths.append(request.artifact_path)
+        completed = subprocess.run(
+            [
+                godot_bin,
+                "--headless",
+                "--path",
+                str(godot_project),
+                "--script",
+                str(script),
+                "--",
+                artifact_type,
+                request.artifact_path,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stderr or completed.stdout
+        return {"writer": "ResourceSaver"}
+
+    registry = build_default_registry()
+    registry.register(
+        source_layout_type=layout,
+        artifact_type=artifact_type,
+        compiler_id=f"resource_saver_{artifact_type.lower()}",
+        compiler_version=1,
+        compiler=save_with_godot,
+    )
+    result = registry.compile(
+        CompileRequest(
+            production_family="ui-kit",
+            asset_id=asset_id,
+            source_layout_type=layout,
+            source_path=f"{base}/{source_name}",
+            artifact_type=artifact_type,
+            artifact_path=f"{base}/{artifact_name}",
+            project_root=godot_project,
+        )
+    )
+
+    (staging_path,) = staging_paths
+    assert staging_path.endswith(Path(artifact_name).suffix)
+    assert ".staging-" in staging_path
+    report = GodotProbe(godot_bin).probe(
+        godot_project,
+        [ProbeRequest(result.godot_artifact.path, artifact_type)],
+    )
+    (loaded,) = report.resources
+    assert loaded.loaded is True, loaded.to_dict()
+    assert loaded.type_matches is True, loaded.to_dict()
 
 
 def test_a_generated_texture_reaches_ready_through_real_godot(godot_bin, godot_project):


### PR DESCRIPTION
## Summary

Preserve native Godot resource extensions on sibling staging artifacts and register compiler receipts only after the stable artifact is atomically committed.

## Motivation

Godot selects `ResourceSaver` formats from the final filename extension. Staging names that placed a token after `.tres` or `.res` could therefore not be saved by native resource compilers. No public GitHub issue.

## Changes

- Keep `.tres` and `.res` as the final suffix of sibling staging artifacts.
- Recover only matching interrupted staging siblings before a writing compile starts.
- Register receipts only after the stable artifact commit succeeds.
- Update the compiler contract and add regression coverage for staging, cleanup, failed commits, and Godot resource saving/loading.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

Validated with Godot 4.4: `python -m pytest tests/assets -q` (216 passed, 3 skipped) and `python -m pytest -q` (1757 passed, 6 skipped). `python -m ruff check .` passed. CI checks for linting, secret scanning, documentation, and Python tests on Ubuntu, macOS, and Windows passed.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

Not applicable.

</details>

## Version Compatibility

Does this PR change behaviors, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

No migration scripts were added or modified; the Migration Upgrade Gate is not applicable.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

Not applicable: no migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
