### PR TITLE
Restrict reference entry completion status

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -42,6 +42,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Fixed
 
 - Reference-only stable entries now accept only `pending`, `source_ready`, or `failed`; only registered `source_ready` entries may promote ASSETS.md reference rows.
+- Existing reference entries persisted as `compiled` or `ready` must be manually corrected to `source_ready` before root-index validation; no migration or compatibility reader is provided.
 - Compiler staging now preserves Godot resource extensions.
 - Compiler receipts are now issued only after atomic artifact commits.
 - Asset readiness promotion now requires a compiler receipt bound to the compiled entry, while already-ready assets can explicitly revalidate without retaining that receipt.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -41,6 +41,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Reference-only stable entries now accept only `pending`, `source_ready`, or `failed`; only registered `source_ready` entries may promote ASSETS.md reference rows.
 - Compiler staging now preserves Godot resource extensions.
 - Compiler receipts are now issued only after atomic artifact commits.
 - Asset readiness promotion now requires a compiler receipt bound to the compiled entry, while already-ready assets can explicitly revalidate without retaining that receipt.

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -273,6 +273,9 @@ arbitrary ClassDB types:
 | `tile_atlas` | `TileSet` |
 | `reference` | no `godot_artifact` |
 
+Reference-only entries may use only `pending`, `source_ready`, or `failed`;
+`source_ready` is their sole completion state and is not runtime `ready`.
+
 Manual entry point:
 
 ```bash

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -307,7 +307,7 @@ read.
 entries. It revalidates every entry and referenced file first. Runtime rows
 require a `ready` non-reference entry, so they become `generated` only when the
 asset is worker-consumable. A `screen-reference` row may instead complete at
-`source_ready` and remain repeatable at `ready` when its finalized reference
+`source_ready` when its finalized reference
 file, canonical stable entry, and root-index pointer pass validation. The
 updater validates the reference file plus every root-index pointer without
 requiring unrelated pending entries to have files. This records the same entry

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -249,7 +249,7 @@ python tools/asset_generation_index.py --project-root . --check-entries --check-
 
 ## asset_assets_md_update.py
 
-`asset_assets_md_update.py` 会根据已注册的 stable entry 更新 ASSETS.md 行。它先重新校验每个 entry 和被引用的文件。运行时行必须使用 `ready` 的非 reference entry，因此只有素材确实可被 worker 消费时才会变成 `generated`。`screen-reference` 行是例外：当 finalize 后的参考图文件、canonical stable entry 和 root-index 指针通过适用校验时，可在 `source_ready`（或后续 `ready`）变为 `generated`。它记录同一个 entry 指针，但绝不会创建 `godot_artifact` 或交给 worker 作为运行时资产。
+`asset_assets_md_update.py` 会根据已注册的 stable entry 更新 ASSETS.md 行。它先重新校验每个 entry 和被引用的文件。运行时行必须使用 `ready` 的非 reference entry，因此只有素材确实可被 worker 消费时才会变成 `generated`。`screen-reference` 行是例外：当 finalize 后的参考图文件、canonical stable entry 和 root-index 指针通过适用校验时，只能在 `source_ready` 变为 `generated`。它记录同一个 entry 指针，但绝不会创建 `godot_artifact` 或交给 worker 作为运行时资产。
 
 手动入口：
 

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -225,6 +225,9 @@ ClassDB 类型：
 | `tile_atlas` | `TileSet` |
 | `reference` | 不带 `godot_artifact` |
 
+reference-only entry 只能使用 `pending`、`source_ready` 或 `failed`；其中只有
+`source_ready` 是完成态，且它不是运行时 `ready`。
+
 手动入口：
 
 ```bash

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -247,7 +247,7 @@ python tools/asset_generation_index.py --project-root . --check-entries --check-
 
    - Mark a `ready` non-reference entry `generated` after the full root-index
      gate passes.
-   - Mark a `screen-reference` entry `generated` at `source_ready` or `ready`
+   - Mark a `screen-reference` entry `generated` only at `source_ready`
      after its finalized file, canonical entry, and root-index pointer validate.
    - Do not create a `godot_artifact` or worker runtime handoff for a reference.
 
@@ -271,11 +271,11 @@ pass.
 For current-tag rows only:
 
 1. Confirm a `ready` non-reference entry is `generated`; confirm a validated
-   `source_ready` or `ready` reference-only entry is `generated`.
+   `source_ready` reference-only entry is `generated`.
 2. Mark provided files `provided`.
 3. Mark unprovided audio `deferred`.
 4. Keep runtime rows without a registered `ready` entry as `MISSING`. Mark a
-   registered, validated `screen-reference` at `source_ready` or `ready` as
+   registered, validated `screen-reference` at `source_ready` as
    `generated`.
 5. Confirm `Generation Params` include the stable entry pointer only.
 6. Update the Visual Asset Contract for gameplay-visible generated assets.
@@ -300,7 +300,7 @@ or leave a fix task for a later role.
 ## Completion
 
 Keep generated runtime rows below `ready` as `MISSING`. Registered, validated
-reference-only rows may complete at `source_ready` or `ready`. If runtime rows
+reference-only rows may complete only at `source_ready`. If runtime rows
 remain, report the asset stage blocked on compiler work.
 
 After ASSETS.md has no current-tag `MISSING` rows except deferred audio:

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -39,7 +39,7 @@ Current-tag visual anchors are:
 1. User-provided image assets accepted as `direct_runtime`.
 2. Current-tag `references/scene_*.png` files with matching reports.
 3. Current-tag generated `screen-reference` or `style_reference` stable
-   entries at `source_ready` or `ready` with existing files and canonical
+   entries at `source_ready` with existing files and canonical
    pointers that pass the root-index gate. Use them as visual anchors only.
 4. Current-tag canonical character or UI reference images whose stable entries
    are `ready`.
@@ -159,7 +159,7 @@ Use this order when units depend on each other:
 Update current-tag rows after producer reports:
 
 1. `generated`: a registered `ready` non-reference stable entry after the full
-   root-index gate, or a validated `source_ready` or `ready` reference-only
+   root-index gate, or a validated `source_ready` reference-only
    stable entry with its finalized file and canonical root-index pointer.
 2. `provided`: user-provided file matched the row.
 3. `deferred`: unprovided audio or intentionally skipped asset.

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -94,6 +94,8 @@ It is not a Godot artifact.
 5. `failed` — a stage failed.
 
 `compiled` and `ready` require a `godot_artifact` for every non-reference asset.
+Reference-only entries never enter this ladder: they may use only `pending`,
+`source_ready`, or `failed`, and only `source_ready` is their completion state.
 
 **Current pipeline state.** The native compilers and the L0-L4 runner are not
 implemented. `/gm-asset` therefore registers `source_ready` entries and nothing

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -290,7 +290,7 @@ python tools/asset_assets_md_update.py \
 
 The updater promotes a runtime row to `generated` only for a `ready`
 non-reference entry. A `screen-reference` row may become `generated` at
-`source_ready` or `ready` with a finalized reference file, canonical stable
+`source_ready` with a finalized reference file, canonical stable
 entry, and root-index pointer. It schema-validates index pointers and validates
 the selected reference file. Do not create a `godot_artifact`, worker handoff,
 or hand-edited ASSETS.md status for a reference. Keep all other `source_ready`

--- a/tests/assets/test_asset_validation_ladder.py
+++ b/tests/assets/test_asset_validation_ladder.py
@@ -277,6 +277,7 @@ def test_a_path_in_the_generation_workspace_fails_l0(tmp_path):
             asset_id="title",
             source_layout={"type": "reference", "path": "res://assets/refs/title.png"},
             godot_artifact=None,
+            processing_status="source_ready",
         ),
     ],
 )

--- a/tests/tools/test_asset_assets_md_update.py
+++ b/tests/tools/test_asset_assets_md_update.py
@@ -8,7 +8,11 @@ import pytest
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
 
-from asset_assets_md_update import AssetsMdUpdateError, update_assets_md  # noqa: E402
+from asset_assets_md_update import (  # noqa: E402
+    AssetsMdUpdateError,
+    _assert_promotable,
+    update_assets_md,
+)
 from asset_generation_index import update_index  # noqa: E402
 from asset_stable_entry import entry_relative_path, stable_output_dir  # noqa: E402
 
@@ -245,6 +249,17 @@ def test_update_assets_md_rejects_reference_runtime_ladder_status(tmp_path, stat
         update_assets_md(assets_md, [entry_file])
 
     assert "| generated |" not in assets_md.read_text(encoding="utf-8")
+
+
+def test_reference_promotability_requires_source_ready(tmp_path):
+    """Keep the updater's defense in depth independent of schema validation."""
+    with pytest.raises(
+        AssetsMdUpdateError, match="only a source_ready reference entry"
+    ):
+        _assert_promotable(
+            make_reference_entry(processing_status="ready"),
+            tmp_path / "reference.json",
+        )
 
 
 def test_reference_entry_must_be_registered_and_pass_the_root_index_gate(tmp_path):

--- a/tests/tools/test_asset_assets_md_update.py
+++ b/tests/tools/test_asset_assets_md_update.py
@@ -200,13 +200,12 @@ def write_reference_assets_md(path: Path):
     )
 
 
-@pytest.mark.parametrize("status", ["source_ready", "ready"])
-def test_update_assets_md_promotes_registered_reference(tmp_path, status):
+def test_update_assets_md_promotes_registered_source_ready_reference(tmp_path):
     """References complete after deterministic registration, not runtime readiness."""
     assets_md = tmp_path / "ASSETS.md"
     write_reference_assets_md(assets_md)
     touch(tmp_path, "references/scene_main.png")
-    entry_file = write_entry(tmp_path, make_reference_entry(processing_status=status))
+    entry_file = write_entry(tmp_path, make_reference_entry())
     update_index(
         tmp_path / ".godotmaker/asset-generation/manifest.json",
         [entry_file],
@@ -220,7 +219,7 @@ def test_update_assets_md_promotes_registered_reference(tmp_path, status):
     assert f"manifest_entry={entry_relative_path(TAG, 'scene_main')}" in text
 
 
-@pytest.mark.parametrize("status", ["pending", "compiled", "failed"])
+@pytest.mark.parametrize("status", ["pending", "failed"])
 def test_update_assets_md_rejects_incomplete_reference(tmp_path, status):
     assets_md = tmp_path / "ASSETS.md"
     write_reference_assets_md(assets_md)
@@ -228,6 +227,21 @@ def test_update_assets_md_rejects_incomplete_reference(tmp_path, status):
     entry_file = write_entry(tmp_path, make_reference_entry(processing_status=status))
 
     with pytest.raises(AssetsMdUpdateError, match=f"processing_status is {status}"):
+        update_assets_md(assets_md, [entry_file])
+
+    assert "| generated |" not in assets_md.read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("status", ["compiled", "ready"])
+def test_update_assets_md_rejects_reference_runtime_ladder_status(tmp_path, status):
+    assets_md = tmp_path / "ASSETS.md"
+    write_reference_assets_md(assets_md)
+    touch(tmp_path, "references/scene_main.png")
+    entry_file = write_entry(
+        tmp_path, make_reference_entry(processing_status=status)
+    )
+
+    with pytest.raises(AssetsMdUpdateError, match=rf"not {status}"):
         update_assets_md(assets_md, [entry_file])
 
     assert "| generated |" not in assets_md.read_text(encoding="utf-8")

--- a/tests/tools/test_asset_runtime_resolver.py
+++ b/tests/tools/test_asset_runtime_resolver.py
@@ -178,11 +178,13 @@ def test_reference_entry_cannot_appear_as_a_worker_runtime_asset(tmp_path):
         "tag": TAG,
         "production_family": "screen-reference",
         "source_layout": {"type": "reference", "path": "res://references/scene_main.png"},
-        "processing_status": "ready",
+        "processing_status": "source_ready",
     }
     _, pointer = register(tmp_path, entry, assets=True)
 
-    with pytest.raises(AssetRuntimeResolverError, match="reference-only"):
+    with pytest.raises(
+        AssetRuntimeResolverError, match="processing_status is source_ready"
+    ):
         resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
 
 

--- a/tests/tools/test_asset_runtime_resolver.py
+++ b/tests/tools/test_asset_runtime_resolver.py
@@ -8,6 +8,7 @@ import pytest
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
 
+import asset_runtime_resolver  # noqa: E402
 from asset_runtime_resolver import (  # noqa: E402
     AssetRuntimeResolverError,
     ROOT_INDEX_PATH,
@@ -171,7 +172,7 @@ def test_rejects_non_ready_entries_even_when_registered(tmp_path, status):
         resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
 
 
-def test_reference_entry_cannot_appear_as_a_worker_runtime_asset(tmp_path):
+def test_reference_entry_cannot_appear_as_a_worker_runtime_asset(tmp_path, monkeypatch):
     entry = {
         "version": 1,
         "asset_id": "scene_main",
@@ -182,9 +183,16 @@ def test_reference_entry_cannot_appear_as_a_worker_runtime_asset(tmp_path):
     }
     _, pointer = register(tmp_path, entry, assets=True)
 
-    with pytest.raises(
-        AssetRuntimeResolverError, match="processing_status is source_ready"
-    ):
+    # The schema rejects a ready reference first. Simulate a compromised
+    # validator result so this resolver's defense-in-depth branch remains
+    # directly covered.
+    monkeypatch.setattr(
+        asset_runtime_resolver,
+        "validate_entry",
+        lambda *args, **kwargs: {**entry, "processing_status": "ready"},
+    )
+
+    with pytest.raises(AssetRuntimeResolverError, match="reference-only"):
         resolve_manifest_entry(pointer, project_root=tmp_path, assets_md=tmp_path / "ASSETS.md")
 
 

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -54,7 +54,7 @@ def reference_entry(**overrides):
             "type": "reference",
             "path": "res://assets/references/title_screen.png",
         },
-        "processing_status": "ready",
+        "processing_status": "source_ready",
     }
     entry.update(overrides)
     return entry
@@ -146,6 +146,17 @@ def test_mismatched_artifact_type_is_rejected(layout, artifact_type):
 
 def test_reference_entry_needs_no_artifact():
     validate_entry(reference_entry())
+
+
+@pytest.mark.parametrize("status", ["pending", "source_ready", "failed"])
+def test_reference_entry_accepts_only_its_process_and_failure_statuses(status):
+    validate_entry(reference_entry(processing_status=status))
+
+
+@pytest.mark.parametrize("status", ["compiled", "ready"])
+def test_reference_entry_rejects_runtime_ladder_statuses(status):
+    with pytest.raises(StableEntryError, match=rf"not {status}"):
+        validate_entry(reference_entry(processing_status=status))
 
 
 def test_reference_entry_rejects_artifact():

--- a/tests/tools/test_asset_stable_entry.py
+++ b/tests/tools/test_asset_stable_entry.py
@@ -11,7 +11,10 @@ TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
 
 from asset_stable_entry import (  # noqa: E402
+    ARTIFACT_REQUIRED_STATUSES,
     LAYOUT_ARTIFACT_TYPES,
+    PROCESSING_STATUSES,
+    REFERENCE_PROCESSING_STATUSES,
     REFERENCE_LAYOUTS,
     SOURCE_LAYOUT_TYPES,
     StableEntryError,
@@ -83,6 +86,12 @@ def test_every_non_reference_layout_has_an_artifact_type():
         "theme_recipe": ("Theme",),
         "tile_atlas": ("TileSet",),
     }
+
+
+def test_reference_statuses_are_the_non_runtime_statuses():
+    assert REFERENCE_PROCESSING_STATUSES == (
+        PROCESSING_STATUSES - ARTIFACT_REQUIRED_STATUSES
+    )
 
 
 @pytest.mark.parametrize(

--- a/tools/asset_assets_md_update.py
+++ b/tools/asset_assets_md_update.py
@@ -32,7 +32,7 @@ from asset_generation_index import GenerationIndexError, check_index
 
 # The only readiness state that means "a worker can load this asset now".
 PROMOTABLE_STATUS = "ready"
-REFERENCE_PROMOTABLE_STATUSES = {"source_ready", "ready"}
+REFERENCE_PROMOTABLE_STATUSES = {"source_ready"}
 ROOT_INDEX_RELATIVE = ".godotmaker/asset-generation/manifest.json"
 GENERATED_ROW_STATUS = "generated"
 ASSETS_MD_MIN_CELLS = 8
@@ -59,15 +59,14 @@ def _assert_promotable(entry: dict[str, Any], entry_path: Path) -> bool:
     ``validate_entry`` proves the entry is well-formed and its files exist, but a
     well-formed runtime entry can still be mid-flight (``pending``,
     ``source_ready``, ``compiled``) or failed outright. A screen reference is
-    intentionally different: it completes at ``source_ready`` and remains
-    repeatable if a future process records it as ``ready``. Neither status makes
-    a reference worker-consumable.
+    intentionally different: it completes at ``source_ready``. That status does
+    not make a reference worker-consumable.
     """
     is_reference = entry["source_layout"]["type"] in REFERENCE_LAYOUTS
     status = entry["processing_status"]
     if is_reference and status in REFERENCE_PROMOTABLE_STATUSES:
         return True
-    expected_status = "source_ready or ready" if is_reference else PROMOTABLE_STATUS
+    expected_status = "source_ready" if is_reference else PROMOTABLE_STATUS
     if status != expected_status:
         raise AssetsMdUpdateError(
             f"{entry_path} processing_status is {status}; only a {expected_status} "

--- a/tools/asset_stable_entry.py
+++ b/tools/asset_stable_entry.py
@@ -72,6 +72,11 @@ PROCESSING_STATUSES = {
 # Statuses that require a compiled ``godot_artifact`` for non-reference assets.
 ARTIFACT_REQUIRED_STATUSES = {"compiled", "ready"}
 
+# Reference-only entries do not enter the L0-L4 runtime ladder. They may be
+# awaiting source generation, have a finalized source, or have failed; they can
+# never be compiled or runtime-ready.
+REFERENCE_PROCESSING_STATUSES = {"pending", "source_ready", "failed"}
+
 # ``godot_artifact.type`` has the shape of a Godot ClassDB identifier, while
 # the layout-to-type compatibility relation below is deliberately closed.
 GODOT_TYPE_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -469,6 +474,15 @@ def validate_entry(
     if family in REFERENCE_FAMILIES and layout_type not in REFERENCE_LAYOUTS:
         raise StableEntryError(
             f"production_family {family} must use a reference source_layout"
+        )
+    if (
+        layout_type in REFERENCE_LAYOUTS
+        and processing_status not in REFERENCE_PROCESSING_STATUSES
+    ):
+        allowed = ", ".join(sorted(REFERENCE_PROCESSING_STATUSES))
+        raise StableEntryError(
+            "processing_status for a reference source_layout must be one of: "
+            f"{allowed}; not {processing_status}"
         )
     artifact = _validate_godot_artifact(
         data,


### PR DESCRIPTION
## Summary

Restrict reference-only stable entries to `pending`, `source_ready`, or `failed`. Only registered `source_ready` entries can promote the corresponding ASSETS.md reference row.

## Motivation

Reference-only entries must not represent runtime completion or enter the runtime artifact ladder. No public GitHub issue.

## Changes

- [x] Reject `compiled` and `ready` for reference stable entries.
- [x] Restrict reference ASSETS.md promotion to `source_ready` and add regression coverage for the validator, updater, and runtime-resolver defenses.
- [x] Update the asset documentation and release notes with the permanent reference-state rule and upgrade guidance.

## Testing

- [x] New or updated tests pass (`python -m pytest`: 1751 passed, 19 skipped)
- [x] Gitleaks passes or no secret-bearing files were touched (CI Secret Scan passed)
- [x] Manual testing complete, if applicable (not applicable; schema, tool, and documentation change)

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

Not applicable.

</details>

## Version Compatibility

This PR intentionally changes validation behavior. No migration script is included: historical reference entries using `compiled` or `ready` must be manually changed to `source_ready` before future root-index validation.

- [x] **No** - no migration script required or included
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Not applicable: no migration script was added.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
