### PR TITLE
Add standalone TileSet Asset Skill

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,6 +17,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
+- Added a standalone TileSet Asset Skill with an explicit atlas and recipe contract, shared compiler and validation reuse, and an orthogonal-square fixture.
 - Added a recipe-only native TileSet atlas compiler with declared tile semantics and L4 source, tile, alternative, layer, and tile-size verification.
 - Added a deterministic SpriteFrames compiler that aggregates explicitly timed normalized action PNGs, rejects missing required actions, and serializes independent frame texture bindings for character bundles and animated FX.
 - Published first-class Asset Skills for Claude Code, Codex, and OpenCode together with their project-local shared compiler, validator, and schema runtime under `.godotmaker/asset-runtime/`.

--- a/skills/assets/tileset/SKILL.md
+++ b/skills/assets/tileset/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: tileset
+description: Generate a tile atlas and compile its explicit recipe into a native Godot TileSet resource. Use for reusable terrain, wall, floor, obstacle, and animated tile libraries; not for designing a TileMap layout.
+---
+
+# TileSet Asset Skill
+
+Produce one reusable TileSet from a processable atlas image and a fully declared
+TileSet recipe. This skill is standalone: a direct user request and any caller
+use the same request and result contract.
+
+## Contract
+
+Read and enforce the common request and result contract in
+`skills/assets/_shared/asset-skill-contract.md`. Accept only a request whose
+`asset_type` is `tileset`; require a stable `asset_id`, a concise `brief`, and
+an explicit `spec`. Return the common result object with:
+
+```json
+{
+  "asset_type": "tileset",
+  "outputs": [{
+    "role": "runtime",
+    "path": "res://assets/generated/tileset/<asset_id>/<asset_id>.tres",
+    "godot_type": "TileSet"
+  }],
+  "sources": [{
+    "path": "res://assets/generated/tileset/<asset_id>/<asset_id>_atlas.png",
+    "layout": "tile_atlas"
+  }],
+  "previews": [],
+  "validation": {"passed": true, "levels": {"L0": true, "L1": true, "L2": true, "L3": true, "L4": true}}
+}
+```
+
+One invocation may return further logical runtime outputs only when every one
+is declared in the request and independently satisfies the shared result
+contract. The primary output is always the `TileSet` above.
+
+Do not read or require tags, stage state, `ASSETS.md`, either generated
+manifest, or any `/gm-asset` mode. Do not register outputs or decide worker
+dispatch. Those are caller responsibilities outside this skill.
+
+## Tile Atlas Source Contract
+
+Generate or claim a single atlas PNG under
+`assets/generated/tileset/<asset_id>/`. The atlas must be deliberately laid out
+for the recipe, not merely visually tile-like:
+
+- Declare the atlas cell size, margins, separation, and every usable cell.
+- Use a square orthogonal atlas as the mature v1 path. Other Godot tile shapes
+  require an explicit supported recipe and are not inferred from pixels.
+- Keep tiles aligned to their declared grid. Leave unused grid cells absent from
+  `sources[].tiles`; never discover tiles by transparency, connected regions,
+  color, or filenames.
+- Include a fixed visual reference when style continuity matters. References
+  guide source generation but never replace the declared tile semantics.
+- Prompt for coherent edge treatment, readable walkable and blocking surfaces,
+  consistent lighting, and no labels or UI text. The prompt must name the tile
+  size, grid coverage, intended terrain variants, and any animated cells.
+
+The image does not declare collision, navigation, terrain connectivity, or map
+layout. It only provides pixels for the explicit recipe below.
+
+## Explicit Recipe
+
+Put all runtime semantics in `request.spec`, using the exact field shapes
+accepted by `skills/assets/_shared/asset_compiler/tileset.py`. The minimum
+recipe is:
+
+```json
+{
+  "godot_path": "/path/to/godot",
+  "tile_shape": "square",
+  "tile_size": [16, 16],
+  "sources": [{
+    "id": 0,
+    "texture": "res://assets/generated/tileset/grassland/grassland_atlas.png",
+    "region_size": [16, 16],
+    "margins": [0, 0],
+    "separation": [0, 0],
+    "tiles": [{"coords": [0, 0]}]
+  }]
+}
+```
+
+`tile_shape` is one of `square`, `isometric`, `half_offset_square`, or
+`hexagon`; v1 verification is deepest for `square`. Each source has a unique
+non-negative `id`, a `res://` texture path, and an explicit `tiles` list. Each
+tile supplies `coords` and may declare `texture_origin`, `z_index`,
+`y_sort_origin`, `probability`, `terrain_set`, `terrain`, `peering_bits`,
+`custom_data`, collision polygons, navigation polygons, occlusion polygons,
+alternatives, and animation.
+
+At TileSet scope, explicitly declare any `physics_layers`,
+`navigation_layers`, `occlusion_layers`, `custom_data_layers`, and
+`terrain_sets`. Terrain peering bits, polygons, custom data, alternatives, and
+animation timing are recipe data. Never infer them from the atlas image.
+
+An animation declares `mode` (`default`, `random_start_times`, or `max`),
+positive `frames_count`, positive `columns`, non-negative `separation`,
+positive `speed`, and optional continuous `frame_durations`. Each alternative
+has a positive integer `id`.
+
+See `fixtures/orthogonal-square-recipe.json` for the representative orthogonal
+square fixture, including one terrain tile, one collision polygon, and an
+explicit alternative.
+
+## Processing and Validation
+
+1. Validate the request with the shared contract checker and reject an
+   `asset_type` other than `tileset`.
+2. Produce or claim the atlas at its stable path and verify the file exists
+   (L1). Do not create versioned, timestamped, or work-directory outputs.
+3. Construct the recipe solely from supplied declarations. Reject incomplete,
+   ambiguous, out-of-contract, or implicit semantic input.
+4. Register `asset_compiler.tileset.register_into()` on a per-run
+   `CompilerRegistry`, then compile the `tile_atlas` to `TileSet` route. The
+   shared registry owns staging and atomic commit; this skill does not write a
+   hand-authored `.tres` (L2).
+5. Run the shared validation ladder with a headless Godot binary. It proves the
+   TileSet loads and matches `TileSet` (L3), then register
+   `asset_validation.tileset.register_into()` to compare the loaded source,
+   tile, alternative, animation, layer, terrain, polygon, and custom-data
+   structure against the declared recipe (L4).
+6. Return the common result only when L0-L4 pass. Report a failed validation
+   result otherwise; do not claim runtime readiness from source-image quality.
+
+## Delivery
+
+Report the stable atlas and `.tres` paths, the declared TileSet shape and tile
+size, the number of sources and tiles, and the L0-L4 validation outcome. State
+any intentionally omitted semantics (for example, no terrain set or navigation
+layer) rather than making assumptions. A TileSet is a reusable tile library;
+creating or painting a `TileMap` is outside this skill.

--- a/skills/assets/tileset/SKILL.md
+++ b/skills/assets/tileset/SKILL.md
@@ -118,13 +118,22 @@ explicit alternative.
    `CompilerRegistry`, then compile the `tile_atlas` to `TileSet` route. The
    shared registry owns staging and atomic commit; this skill does not write a
    hand-authored `.tres` (L2).
-5. Run the shared validation ladder with a headless Godot binary. It proves the
-   TileSet loads and matches `TileSet` (L3), then register
+5. Run `standalone_validation.compile_and_validate()` for the standalone path.
+   Its L0 runs the shared request/result checker only; it does not construct or
+   read a stable entry. Its L1 verifies every declared atlas source. For every
+   call it creates a fresh `CompilerRegistry`, registers
+   `asset_compiler.tileset.register_into()`, and compiles the declared
+   `tile_atlas` to `TileSet` route (L2). It then uses `GodotProbe` to load the
+   returned runtime path as `TileSet` (L3), creates a fresh
+   `StructureValidatorRegistry`, and registers
    `asset_validation.tileset.register_into()` to compare the loaded source,
    tile, alternative, animation, layer, terrain, polygon, and custom-data
    structure against the declared recipe (L4).
-6. Return the common result only when L0-L4 pass. Report a failed validation
-   result otherwise; do not claim runtime readiness from source-image quality.
+6. The standalone runner maps those five outcomes to
+   `result.validation.levels` and returns a shared-contract result. It reports
+   a failed validation result for L1-L4 failures; an invalid L0 request/result
+   pair is rejected before there is a valid result to return. Do not claim
+   runtime readiness from source-image quality.
 
 ## Delivery
 

--- a/skills/assets/tileset/SKILL.md
+++ b/skills/assets/tileset/SKILL.md
@@ -33,9 +33,11 @@ an explicit `spec`. Return the common result object with:
 }
 ```
 
-One invocation may return further logical runtime outputs only when every one
-is declared in the request and independently satisfies the shared result
-contract. The primary output is always the `TileSet` above.
+The shared contract permits multiple logical outputs, but this v1 TileSet skill
+supports exactly one runtime output: the `TileSet` above. It rejects any extra
+runtime output at L0 rather than marking an uncompiled or unvalidated resource
+as ready. Reference outputs remain allowed by the shared contract and do not
+enter runtime L2-L4 validation.
 
 Do not read or require tags, stage state, `ASSETS.md`, either generated
 manifest, or any `/gm-asset` mode. Do not register outputs or decide worker

--- a/skills/assets/tileset/fixtures/orthogonal-square-recipe.json
+++ b/skills/assets/tileset/fixtures/orthogonal-square-recipe.json
@@ -1,0 +1,25 @@
+{
+  "godot_path": "/path/to/godot",
+  "tile_shape": "square",
+  "tile_size": [16, 16],
+  "physics_layers": [{"collision_layer": 1, "collision_mask": 1}],
+  "terrain_sets": [{
+    "mode": 0,
+    "terrains": [{"name": "grass", "color": [0.2, 0.8, 0.3]}]
+  }],
+  "sources": [{
+    "id": 0,
+    "texture": "res://assets/generated/tileset/grassland/grassland_atlas.png",
+    "region_size": [16, 16],
+    "margins": [0, 0],
+    "separation": [0, 0],
+    "tiles": [{
+      "coords": [0, 0],
+      "terrain_set": 0,
+      "terrain": 0,
+      "peering_bits": [{"bit": 0, "terrain": 0}],
+      "collision_polygons": [{"layer": 0, "points": [[0, 0], [16, 0], [16, 16], [0, 16]]}],
+      "alternatives": [{"id": 1, "probability": 0.25}]
+    }]
+  }]
+}

--- a/skills/assets/tileset/standalone_validation.py
+++ b/skills/assets/tileset/standalone_validation.py
@@ -33,15 +33,11 @@ class TileSetSkillError(Exception):
 _LEVELS = ("L0", "L1", "L2", "L3", "L4")
 
 
-def _primary_output(result: Mapping[str, Any]) -> Mapping[str, Any]:
-    outputs = [
-        output
-        for output in result["outputs"]
-        if output["role"] == "runtime" and output.get("godot_type") == "TileSet"
-    ]
-    if len(outputs) != 1:
+def _runtime_output(result: Mapping[str, Any]) -> Mapping[str, Any]:
+    outputs = [output for output in result["outputs"] if output["role"] == "runtime"]
+    if len(outputs) != 1 or outputs[0].get("godot_type") != "TileSet":
         raise TileSetSkillError(
-            "a standalone tileset result must declare exactly one runtime TileSet output"
+            "v1 standalone tileset supports exactly one runtime output, and it must be TileSet"
         )
     return outputs[0]
 
@@ -115,7 +111,7 @@ def compile_and_validate(
         check_result(result)
         if request["asset_type"] != "tileset" or result["asset_type"] != "tileset":
             raise TileSetSkillError("standalone TileSet validation requires asset_type 'tileset'")
-        output = _primary_output(result)
+        output = _runtime_output(result)
         atlas_paths = _atlas_sources(request, result)
     except (AssetContractError, TileSetSkillError) as exc:
         raise TileSetSkillError(f"L0 standalone contract failed: {exc}") from exc

--- a/skills/assets/tileset/standalone_validation.py
+++ b/skills/assets/tileset/standalone_validation.py
@@ -1,0 +1,206 @@
+"""Standalone L0-L4 execution for the TileSet Asset Skill.
+
+This module deliberately does not use ``ValidationLadder``. That shared ladder
+validates a registered stable entry, whereas a first-class asset skill receives
+only the public request and result contract. The two boundaries must stay
+separate: this runner proves a standalone call without inventing tag, manifest,
+or processing-status state.
+"""
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+from asset_compiler import CompileRequest, CompilerError, CompilerRegistry
+from asset_compiler import tileset as tileset_compiler
+from asset_compiler._stable_entry import (
+    StableEntryError,
+    assert_within_output_dir,
+    resolve_res_path,
+)
+from asset_validation import GodotProbe, ProbeRequest, ValidationError
+from asset_validation import tileset as tileset_structures
+from asset_validation.structure import StructureRequest, StructureValidatorRegistry
+from asset_skill_contract_check import AssetContractError, check_request, check_result
+
+
+class TileSetSkillError(Exception):
+    """Raised when a standalone request/result pair cannot enter L0."""
+
+
+_LEVELS = ("L0", "L1", "L2", "L3", "L4")
+
+
+def _primary_output(result: Mapping[str, Any]) -> Mapping[str, Any]:
+    outputs = [
+        output
+        for output in result["outputs"]
+        if output["role"] == "runtime" and output.get("godot_type") == "TileSet"
+    ]
+    if len(outputs) != 1:
+        raise TileSetSkillError(
+            "a standalone tileset result must declare exactly one runtime TileSet output"
+        )
+    return outputs[0]
+
+
+def _atlas_sources(request: Mapping[str, Any], result: Mapping[str, Any]) -> list[str]:
+    recipe_sources = request.get("spec", {}).get("sources")
+    if not isinstance(recipe_sources, list) or not recipe_sources:
+        raise TileSetSkillError("tileset spec requires a non-empty sources list")
+    declared = {
+        source["path"]
+        for source in result["sources"]
+        if source.get("layout") == "tile_atlas"
+    }
+    paths: list[str] = []
+    for source in recipe_sources:
+        if not isinstance(source, Mapping) or not isinstance(source.get("texture"), str):
+            raise TileSetSkillError("every tileset recipe source requires a texture path")
+        texture = source["texture"]
+        if texture not in declared:
+            raise TileSetSkillError(
+                "every tileset recipe texture must be declared as a tile_atlas result source"
+            )
+        paths.append(texture)
+    return paths
+
+
+def _mapped_result(
+    result: Mapping[str, Any],
+    levels: Mapping[str, bool],
+    *,
+    error: str | None = None,
+) -> dict[str, Any]:
+    mapped = deepcopy(dict(result))
+    mapped["validation"] = {
+        "passed": all(levels.values()),
+        "levels": dict(levels),
+    }
+    if error:
+        mapped["validation"]["notes"] = error
+    try:
+        check_result(mapped)
+    except AssetContractError as exc:  # pragma: no cover - protected by L0 input check
+        raise TileSetSkillError(f"cannot map standalone validation result: {exc}") from exc
+    return mapped
+
+
+def _failure(result: Mapping[str, Any], passed: list[str], level: str, error: Exception) -> dict[str, Any]:
+    levels = {name: name in passed for name in _LEVELS}
+    levels[level] = False
+    return _mapped_result(result, levels, error=f"{level} failed: {error}")
+
+
+def compile_and_validate(
+    request: Mapping[str, Any],
+    result: Mapping[str, Any],
+    *,
+    project_root: Path,
+    godot_path: str,
+) -> dict[str, Any]:
+    """Compile one standalone TileSet request and map L0-L4 into its result.
+
+    L0 checks only the public request/result schemas and their TileSet-specific
+    links. L1 checks every declared atlas path. L2 compiles through a fresh
+    registry and keeps its receipt inside this invocation. L3 asks headless
+    Godot to load the returned runtime path, and L4 runs the registered TileSet
+    structure validator against the same explicit recipe. No stable entry is
+    constructed or read at any point.
+    """
+    try:
+        check_request(request)
+        check_result(result)
+        if request["asset_type"] != "tileset" or result["asset_type"] != "tileset":
+            raise TileSetSkillError("standalone TileSet validation requires asset_type 'tileset'")
+        output = _primary_output(result)
+        atlas_paths = _atlas_sources(request, result)
+    except (AssetContractError, TileSetSkillError) as exc:
+        raise TileSetSkillError(f"L0 standalone contract failed: {exc}") from exc
+
+    root = Path(project_root)
+    asset_id = request["asset_id"]
+    passed = ["L0"]
+    try:
+        for atlas_path in atlas_paths:
+            source_file = assert_within_output_dir(
+                root,
+                resolve_res_path(root, atlas_path, label="tileset atlas source"),
+                production_family="tileset",
+                asset_id=asset_id,
+                label="tileset atlas source",
+            )
+            if not source_file.is_file() or source_file.stat().st_size <= 0:
+                raise ValidationError(f"tileset atlas source is not a non-empty file: {atlas_path}")
+    except (OSError, StableEntryError, ValidationError) as exc:
+        return _failure(result, passed, "L1", exc)
+
+    primary_source = atlas_paths[0]
+    compile_request = CompileRequest(
+        production_family="tileset",
+        asset_id=asset_id,
+        source_layout_type="tile_atlas",
+        source_path=primary_source,
+        artifact_type="TileSet",
+        artifact_path=output["path"],
+        project_root=root,
+        spec=request["spec"],
+    )
+    registry = CompilerRegistry()
+    tileset_compiler.register_into(registry)
+    try:
+        compiled = registry.compile(compile_request)
+        if compiled.godot_artifact.to_dict() != {
+            "type": output["godot_type"],
+            "path": output["path"],
+        }:
+            raise ValidationError("TileSet compiler returned an artifact that does not match the result")
+    except CompilerError as exc:
+        return _failure(result, passed, "L2", exc)
+
+    passed.append("L1")
+    passed.append("L2")
+    structures = StructureValidatorRegistry()
+    tileset_structures.register_into(structures)
+    try:
+        probe = GodotProbe(godot_path)
+        report = probe.probe(
+            root,
+            [
+                ProbeRequest(
+                    res_path=output["path"],
+                    expected_type="TileSet",
+                    checks=structures.checks_for("TileSet"),
+                )
+            ],
+        )
+        loaded = report.resources[0]
+        if not loaded.loaded or not loaded.type_matches:
+            raise ValidationError(
+                loaded.error
+                or f"Godot did not load {output['path']} as TileSet"
+            )
+    except ValidationError as exc:
+        return _failure(result, passed, "L3", exc)
+
+    passed.append("L3")
+    try:
+        structures.validate(
+            StructureRequest(
+                production_family="tileset",
+                asset_id=asset_id,
+                source_layout_type="tile_atlas",
+                source_path=primary_source,
+                artifact_type="TileSet",
+                artifact_path=output["path"],
+                project_root=root,
+                probe=loaded,
+                spec=request["spec"],
+            )
+        )
+    except ValidationError as exc:
+        return _failure(result, passed, "L4", exc)
+
+    return _mapped_result(result, {level: True for level in _LEVELS})

--- a/tests/assets/test_tileset_skill_contract.py
+++ b/tests/assets/test_tileset_skill_contract.py
@@ -1,0 +1,75 @@
+"""Public contract checks for the standalone TileSet Asset Skill."""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "assets" / "tileset"
+FIXTURE = SKILL_DIR / "fixtures" / "orthogonal-square-recipe.json"
+sys.path.insert(0, str(REPO_ROOT / "skills" / "assets" / "_shared"))
+
+from asset_compiler import CompileRequest, CompilerError  # noqa: E402
+from asset_compiler import tileset as compiler  # noqa: E402
+
+
+def _fixture() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def test_tileset_skill_is_standalone_and_reuses_shared_contracts():
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    assert text.startswith("---\nname: tileset\n")
+    for shared_path in (
+        "skills/assets/_shared/asset-skill-contract.md",
+        "asset_compiler.tileset.register_into()",
+        "asset_validation.tileset.register_into()",
+    ):
+        assert shared_path in text
+    for forbidden_dependency in (
+        "Do not read or require tags",
+        "ASSETS.md",
+        "either generated\nmanifest",
+        "Do not register outputs",
+    ):
+        assert forbidden_dependency in text
+
+
+def test_tileset_skill_documents_recipe_only_semantics_and_l0_to_l4():
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    for field in (
+        "tile_size",
+        "margins",
+        "separation",
+        "terrain_sets",
+        "peering_bits",
+        "collision polygons",
+        "navigation polygons",
+        "occlusion polygons",
+        "alternatives",
+        "animation",
+    ):
+        assert field in text
+    assert "Never infer them from the atlas image." in text
+    for level in ("L0", "L1", "L2", "L3", "L4"):
+        assert level in text
+
+
+def test_orthogonal_square_fixture_is_compiler_acceptable_except_for_its_placeholder_binary(tmp_path):
+    recipe = _fixture()
+    assert recipe["tile_shape"] == "square"
+    assert recipe["tile_size"] == [16, 16]
+    assert recipe["sources"][0]["tiles"][0]["alternatives"] == [{"id": 1, "probability": 0.25}]
+    request = CompileRequest(
+        production_family="tileset",
+        asset_id="grassland",
+        source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grassland/grassland_atlas.png",
+        artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grassland/grassland.tres",
+        project_root=tmp_path,
+        spec=recipe,
+    )
+    with pytest.raises(CompilerError, match="Godot binary was not found"):
+        compiler.compile_tileset(request)

--- a/tests/assets/test_tileset_skill_contract.py
+++ b/tests/assets/test_tileset_skill_contract.py
@@ -9,9 +9,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SKILL_DIR = REPO_ROOT / "skills" / "assets" / "tileset"
 FIXTURE = SKILL_DIR / "fixtures" / "orthogonal-square-recipe.json"
 sys.path.insert(0, str(REPO_ROOT / "skills" / "assets" / "_shared"))
+sys.path.insert(0, str(REPO_ROOT / "tools"))
+sys.path.insert(0, str(SKILL_DIR))
 
 from asset_compiler import CompileRequest, CompilerError  # noqa: E402
 from asset_compiler import tileset as compiler  # noqa: E402
+from asset_validation import ProbeReport, ProbeResult  # noqa: E402
+from asset_validation.godot_probe import GodotProbe  # noqa: E402
+from standalone_validation import compile_and_validate  # noqa: E402
 
 
 def _fixture() -> dict:
@@ -25,6 +30,7 @@ def test_tileset_skill_is_standalone_and_reuses_shared_contracts():
         "skills/assets/_shared/asset-skill-contract.md",
         "asset_compiler.tileset.register_into()",
         "asset_validation.tileset.register_into()",
+        "standalone_validation.compile_and_validate()",
     ):
         assert shared_path in text
     for forbidden_dependency in (
@@ -73,3 +79,123 @@ def test_orthogonal_square_fixture_is_compiler_acceptable_except_for_its_placeho
     )
     with pytest.raises(CompilerError, match="Godot binary was not found"):
         compiler.compile_tileset(request)
+
+
+def test_standalone_runner_maps_request_result_l0_to_l4_without_a_stable_entry(
+    tmp_path, monkeypatch
+):
+    """Exercise the executable standalone flow without manifest-shaped state."""
+    root = tmp_path
+    (root / "project.godot").write_text("[application]\nconfig/name=\"test\"\n", encoding="utf-8")
+    request = {
+        "asset_type": "tileset",
+        "asset_id": "grassland",
+        "brief": "A grassland tile atlas.",
+        "spec": _fixture(),
+    }
+    source_path = "res://assets/generated/tileset/grassland/grassland_atlas.png"
+    source = root / source_path.removeprefix("res://")
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"png")
+    result = {
+        "asset_type": "tileset",
+        "outputs": [{"role": "runtime", "path": "res://assets/generated/tileset/grassland/grassland.tres", "godot_type": "TileSet"}],
+        "sources": [{"path": source_path, "layout": "tile_atlas"}],
+        "previews": [],
+        "validation": {"passed": False},
+    }
+
+    def fake_compile(compile_request):
+        artifact = root / compile_request.artifact_path.removeprefix("res://")
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("[gd_resource type=\"TileSet\"]\n", encoding="utf-8")
+        return {"sources": 1, "tile_size": [16, 16]}
+
+    facts = {
+        "tileset": {
+            "source_count": 1,
+            "tile_count": 1,
+            "alternative_count": 1,
+            "tile_shape": 0,
+            "tile_size": [16, 16],
+            "sources": [{
+                "id": 0,
+                "region_size": [16, 16],
+                "margins": [0, 0],
+                "separation": [0, 0],
+                "tiles": [{
+                    "coords": [0, 0], "texture_origin": [0, 0], "z_index": 0,
+                    "y_sort_origin": 0, "probability": 1.0, "terrain_set": 0,
+                    "terrain": 0, "peering_bits": [0] + [-1] * 15,
+                    "custom_data": [], "collision_polygons": [[[[0, 0], [16, 0], [16, 16], [0, 16]]]],
+                    "occlusion_polygons": [], "navigation_polygons": [], "alternatives": [{
+                        "id": 1, "texture_origin": [0, 0], "z_index": 0, "y_sort_origin": 0,
+                        "probability": 0.25, "terrain_set": -1, "terrain": -1,
+                        "peering_bits": [-1] * 16, "custom_data": [], "collision_polygons": [[]],
+                        "occlusion_polygons": [], "navigation_polygons": [],
+                    }],
+                }],
+            }],
+            "physics_layers_count": 1, "navigation_layers_count": 0,
+            "occlusion_layers_count": 0, "custom_data_layers_count": 0,
+            "terrain_sets_count": 1,
+            "physics_layers": [{"collision_layer": 1, "collision_mask": 1}],
+            "navigation_layers": [], "occlusion_layers": [], "custom_data_layers": [],
+            "terrain_sets": [{"mode": 0, "terrains": [{"name": "grass", "color": [0.2, 0.8, 0.3, 1.0]}]}],
+        }
+    }
+
+    def fake_probe(self, project_root, requests):
+        assert project_root == root
+        assert requests[0].checks == ("tileset",)
+        return ProbeReport(
+            godot_version="test",
+            resources=(ProbeResult(requests[0].res_path, "TileSet", True, "TileSet", True, structure=facts),),
+        )
+
+    monkeypatch.setattr(compiler, "compile_tileset", fake_compile)
+    monkeypatch.setattr(GodotProbe, "probe", fake_probe)
+    validated = compile_and_validate(request, result, project_root=root, godot_path="godot")
+
+    assert validated["validation"] == {
+        "passed": True,
+        "levels": {"L0": True, "L1": True, "L2": True, "L3": True, "L4": True},
+    }
+    assert "processing_status" not in validated
+    assert "godot_artifact" not in validated
+
+
+def test_standalone_runner_maps_a_godot_setup_failure_to_l3(tmp_path, monkeypatch):
+    root = tmp_path
+    request = {
+        "asset_type": "tileset",
+        "asset_id": "grassland",
+        "brief": "A grassland tile atlas.",
+        "spec": _fixture(),
+    }
+    source_path = "res://assets/generated/tileset/grassland/grassland_atlas.png"
+    source = root / source_path.removeprefix("res://")
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"png")
+    result = {
+        "asset_type": "tileset",
+        "outputs": [{"role": "runtime", "path": "res://assets/generated/tileset/grassland/grassland.tres", "godot_type": "TileSet"}],
+        "sources": [{"path": source_path, "layout": "tile_atlas"}],
+        "previews": [],
+        "validation": {"passed": False},
+    }
+
+    def fake_compile(compile_request):
+        artifact = root / compile_request.artifact_path.removeprefix("res://")
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("[gd_resource type=\"TileSet\"]\n", encoding="utf-8")
+        return {"sources": 1, "tile_size": [16, 16]}
+
+    monkeypatch.setattr(compiler, "compile_tileset", fake_compile)
+    validated = compile_and_validate(request, result, project_root=root, godot_path="")
+
+    assert validated["validation"]["passed"] is False
+    assert validated["validation"]["levels"] == {
+        "L0": True, "L1": True, "L2": True, "L3": False, "L4": False,
+    }
+    assert "godot_path must be a non-empty string" in validated["validation"]["notes"]

--- a/tests/assets/test_tileset_skill_contract.py
+++ b/tests/assets/test_tileset_skill_contract.py
@@ -16,7 +16,7 @@ from asset_compiler import CompileRequest, CompilerError  # noqa: E402
 from asset_compiler import tileset as compiler  # noqa: E402
 from asset_validation import ProbeReport, ProbeResult  # noqa: E402
 from asset_validation.godot_probe import GodotProbe  # noqa: E402
-from standalone_validation import compile_and_validate  # noqa: E402
+from standalone_validation import TileSetSkillError, compile_and_validate  # noqa: E402
 
 
 def _fixture() -> dict:
@@ -199,3 +199,25 @@ def test_standalone_runner_maps_a_godot_setup_failure_to_l3(tmp_path, monkeypatc
         "L0": True, "L1": True, "L2": True, "L3": False, "L4": False,
     }
     assert "godot_path must be a non-empty string" in validated["validation"]["notes"]
+
+
+def test_standalone_runner_rejects_an_unvalidated_extra_runtime_output(tmp_path):
+    request = {
+        "asset_type": "tileset",
+        "asset_id": "grassland",
+        "brief": "A grassland tile atlas.",
+        "spec": _fixture(),
+    }
+    result = {
+        "asset_type": "tileset",
+        "outputs": [
+            {"role": "runtime", "path": "res://assets/generated/tileset/grassland/grassland.tres", "godot_type": "TileSet"},
+            {"role": "runtime", "path": "res://assets/generated/tileset/grassland/unvalidated.tres", "godot_type": "Texture2D"},
+        ],
+        "sources": [{"path": "res://assets/generated/tileset/grassland/grassland_atlas.png", "layout": "tile_atlas"}],
+        "previews": [],
+        "validation": {"passed": False},
+    }
+
+    with pytest.raises(TileSetSkillError, match="exactly one runtime output"):
+        compile_and_validate(request, result, project_root=tmp_path, godot_path="godot")


### PR DESCRIPTION
## Summary

Adds a standalone TileSet Asset Skill, its validation runner, a representative orthogonal-square recipe fixture, public contract coverage, and a release-note entry.

## Motivation

Provides a self-contained contract for generating and validating TileSet atlas resources. No public GitHub issue.

## Changes

- [x] Add the standalone TileSet Asset Skill and explicit recipe semantics.
- [x] Add standalone L0-L4 validation with fail-closed runtime-output handling.
- [x] Add fixture and public contract tests.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — `python -m pytest` (1790 passed, 22 skipped).
- [x] Gitleaks passes or no secret-bearing files were touched — GitHub Secret Scan passed.
- [x] Manual testing completed, if applicable — not applicable; this is a skill contract and validation-runner change covered by automated tests.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>` — not applicable.
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"` — not applicable.
- [ ] Post-upgrade on-disk state was inspected and matches expectations — not applicable.
- [ ] Re-running `tools/publish.py` produces no further migration changes — not applicable.
- [ ] Result attached or summarized below — not applicable.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable — not applicable.
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
