### PR TITLE
Add deterministic StyleBoxTexture compiler

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -18,6 +18,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 ## Added
 
 - Added a deterministic SpriteFrames compiler that aggregates explicitly timed normalized action PNGs, rejects missing required actions, and serializes independent frame texture bindings for character bundles and animated FX.
+- Added a deterministic StyleBoxTexture compiler for reusable UI borders, with explicit texture regions, nine-slice borders, expand margins, and stretch axes verified through headless Godot.
 - Published first-class Asset Skills for Claude Code, Codex, and OpenCode together with their project-local shared compiler, validator, and schema runtime under `.godotmaker/asset-runtime/`.
 - Added a fail-closed `asset_runtime_resolver.py` that converts a registered ASSETS.md `manifest_entry` into the minimal ready worker runtime snapshot (#106).
 - Added `tools/asset_atlas_assemble.py` for reproducible fixed-slot physical PNG atlases and region metadata; it rejects implicit packing, trimming, heuristic discovery, invalid bounds, overlap, size mismatches, and missing source PNGs.

--- a/skills/assets/_shared/asset_compiler/__init__.py
+++ b/skills/assets/_shared/asset_compiler/__init__.py
@@ -14,7 +14,7 @@ re-imported self-registering module into an import-time crash.
 """
 from __future__ import annotations
 
-from . import atlas_texture, sprite_frames, texture2d
+from . import atlas_texture, sprite_frames, stylebox_texture, texture2d
 from .contract import (
     CompileReceipt,
     CompileRequest,
@@ -38,6 +38,7 @@ def build_default_registry() -> CompilerRegistry:
     texture2d.register_into(registry)
     atlas_texture.register_into(registry)
     sprite_frames.register_into(registry)
+    stylebox_texture.register_into(registry)
     return registry
 
 
@@ -56,5 +57,6 @@ __all__ = [
     "require_text",
     "atlas_texture",
     "sprite_frames",
+    "stylebox_texture",
     "texture2d",
 ]

--- a/skills/assets/_shared/asset_compiler/stylebox_texture.py
+++ b/skills/assets/_shared/asset_compiler/stylebox_texture.py
@@ -1,0 +1,214 @@
+"""Compile explicit nine-slice recipes into ``StyleBoxTexture`` resources."""
+from __future__ import annotations
+
+import math
+import struct
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ._stable_entry import resolve_res_path
+from .contract import CompileRequest, CompilerError
+from .registry import CompilerRegistry, CompilerRoute
+
+COMPILER_ID = "stylebox_texture_nine_slice"
+COMPILER_VERSION = 1
+
+_SPEC_KEYS = {"border", "expand_margin", "axis_stretch", "texture_region"}
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+_AXIS_STRETCH = {"stretch": 0, "tile": 1, "tile_fit": 2}
+
+
+@dataclass(frozen=True)
+class StyleBoxTextureInput:
+    """The normalized recipe facts represented by one StyleBoxTexture."""
+
+    texture_path: str
+    texture_region: tuple[int, int, int, int]
+    border: tuple[int, int, int, int]
+    expand_margin: tuple[float, float, float, float]
+    axis_stretch: tuple[str, str]
+
+
+def _object(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise CompilerError(f"{label} must be an object")
+    return value
+
+
+def _exact_keys(value: Mapping[str, Any], keys: set[str], label: str) -> None:
+    if set(value) != keys:
+        raise CompilerError(f"{label} must contain exactly {', '.join(sorted(keys))}")
+
+
+def _integer_rect(value: Any, label: str) -> tuple[int, int, int, int]:
+    if not isinstance(value, list) or len(value) != 4:
+        raise CompilerError(f"{label} must be [x, y, width, height]")
+    x, y, width, height = value
+    if any(type(component) is not int for component in value):
+        raise CompilerError(f"{label} values must be integers")
+    if x < 0 or y < 0 or width <= 0 or height <= 0:
+        raise CompilerError(f"{label} needs non-negative x/y and positive width/height")
+    return x, y, width, height
+
+
+def _border(value: Any) -> tuple[int, int, int, int]:
+    if not isinstance(value, list) or len(value) != 4:
+        raise CompilerError("StyleBoxTexture spec.border must be [left, top, right, bottom]")
+    if any(type(component) is not int or component < 0 for component in value):
+        raise CompilerError("StyleBoxTexture spec.border values must be non-negative integers")
+    return tuple(value)
+
+
+def _expand_margin(value: Any) -> tuple[float, float, float, float]:
+    if not isinstance(value, list) or len(value) != 4:
+        raise CompilerError(
+            "StyleBoxTexture spec.expand_margin must be [left, top, right, bottom]"
+        )
+    normalized: list[float] = []
+    for component in value:
+        if type(component) not in (int, float) or isinstance(component, bool):
+            raise CompilerError("StyleBoxTexture spec.expand_margin values must be finite non-negative numbers")
+        number = float(component)
+        if not math.isfinite(number) or number < 0:
+            raise CompilerError("StyleBoxTexture spec.expand_margin values must be finite non-negative numbers")
+        normalized.append(number)
+    return tuple(normalized)
+
+
+def _axis_stretch(value: Any) -> tuple[str, str]:
+    axis = _object(value, "StyleBoxTexture spec.axis_stretch")
+    _exact_keys(axis, {"horizontal", "vertical"}, "StyleBoxTexture spec.axis_stretch")
+    horizontal, vertical = axis.get("horizontal"), axis.get("vertical")
+    if horizontal not in _AXIS_STRETCH or vertical not in _AXIS_STRETCH:
+        allowed = ", ".join(_AXIS_STRETCH)
+        raise CompilerError(
+            "StyleBoxTexture spec.axis_stretch.horizontal and .vertical must be one of: "
+            + allowed
+        )
+    return horizontal, vertical
+
+
+def _png_size(path: Path) -> tuple[int, int]:
+    try:
+        header = path.read_bytes()[:24]
+    except OSError as exc:
+        raise CompilerError(f"cannot read StyleBoxTexture source PNG {path}: {exc}") from exc
+    if len(header) != 24 or header[:8] != _PNG_SIGNATURE or header[12:16] != b"IHDR":
+        raise CompilerError(f"StyleBoxTexture source_path is not a PNG with an IHDR header: {path}")
+    width, height = struct.unpack(">II", header[16:24])
+    if width <= 0 or height <= 0:
+        raise CompilerError(f"StyleBoxTexture source PNG has invalid dimensions: {path}")
+    return width, height
+
+
+def read_stylebox_texture_input(request: Any) -> StyleBoxTextureInput:
+    """Validate the explicit StyleBoxTexture recipe for compilation or L4."""
+    if request.source_layout_type not in ("single", "region_atlas"):
+        raise CompilerError(
+            "StyleBoxTexture compilation requires source_layout_type 'single' or 'region_atlas'"
+        )
+    if request.artifact_type != "StyleBoxTexture":
+        raise CompilerError("StyleBoxTexture compilation requires artifact_type 'StyleBoxTexture'")
+    if not isinstance(request.artifact_path, str) or not request.artifact_path.endswith(".tres"):
+        raise CompilerError("StyleBoxTexture artifact_path must end in .tres")
+
+    spec = _object(request.spec, "StyleBoxTexture spec")
+    _exact_keys(spec, _SPEC_KEYS, "StyleBoxTexture spec")
+    texture_region = _integer_rect(spec.get("texture_region"), "StyleBoxTexture spec.texture_region")
+    border = _border(spec.get("border"))
+    expand_margin = _expand_margin(spec.get("expand_margin"))
+    axis_stretch = _axis_stretch(spec.get("axis_stretch"))
+
+    try:
+        source_file = resolve_res_path(request.project_root, request.source_path, label="source_path")
+    except Exception as exc:
+        raise CompilerError(str(exc)) from exc
+    if source_file.suffix.lower() != ".png":
+        raise CompilerError("StyleBoxTexture source_path must end in .png")
+    image_width, image_height = _png_size(source_file)
+    x, y, width, height = texture_region
+    if x + width > image_width or y + height > image_height:
+        raise CompilerError(
+            "StyleBoxTexture spec.texture_region is outside source PNG bounds "
+            f"{image_width}x{image_height}"
+        )
+    left, top, right, bottom = border
+    if left + right > width or top + bottom > height:
+        raise CompilerError("StyleBoxTexture spec.border exceeds texture_region")
+    return StyleBoxTextureInput(
+        texture_path=request.source_path,
+        texture_region=texture_region,
+        border=border,
+        expand_margin=expand_margin,
+        axis_stretch=axis_stretch,
+    )
+
+
+def _escape(path: str) -> str:
+    return path.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _tres(recipe: StyleBoxTextureInput) -> str:
+    x, y, width, height = recipe.texture_region
+    left, top, right, bottom = recipe.border
+    expand_left, expand_top, expand_right, expand_bottom = recipe.expand_margin
+    horizontal, vertical = recipe.axis_stretch
+    return (
+        '[gd_resource type="StyleBoxTexture" load_steps=2 format=3]\n\n'
+        f'[ext_resource type="Texture2D" path="{_escape(recipe.texture_path)}" id="1_texture"]\n\n'
+        "[resource]\n"
+        'texture = ExtResource("1_texture")\n'
+        f"region_rect = Rect2({x}, {y}, {width}, {height})\n"
+        f"texture_margin_left = {left}\n"
+        f"texture_margin_top = {top}\n"
+        f"texture_margin_right = {right}\n"
+        f"texture_margin_bottom = {bottom}\n"
+        f"expand_margin_left = {expand_left!r}\n"
+        f"expand_margin_top = {expand_top!r}\n"
+        f"expand_margin_right = {expand_right!r}\n"
+        f"expand_margin_bottom = {expand_bottom!r}\n"
+        f"axis_stretch_horizontal = {_AXIS_STRETCH[horizontal]}\n"
+        f"axis_stretch_vertical = {_AXIS_STRETCH[vertical]}\n"
+    )
+
+
+def compile_stylebox_texture(request: CompileRequest) -> dict[str, Any]:
+    """Write one StyleBoxTexture with recipe-owned margins, stretch, and region."""
+    recipe = read_stylebox_texture_input(request)
+    target = request.artifact_file()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(_tres(recipe), encoding="utf-8", newline="\n")
+    except OSError as exc:
+        raise CompilerError(
+            f"cannot write StyleBoxTexture artifact {request.artifact_path}: {exc}"
+        ) from exc
+    return {
+        "texture_path": recipe.texture_path,
+        "texture_region": list(recipe.texture_region),
+        "border": list(recipe.border),
+        "expand_margin": list(recipe.expand_margin),
+        "axis_stretch": {"horizontal": recipe.axis_stretch[0], "vertical": recipe.axis_stretch[1]},
+    }
+
+
+def register_into(registry: CompilerRegistry) -> tuple[CompilerRoute, CompilerRoute]:
+    """Register both legal layout routes for the same explicit recipe compiler."""
+    return (
+        registry.register(
+            source_layout_type="single",
+            artifact_type="StyleBoxTexture",
+            compiler_id=COMPILER_ID,
+            compiler_version=COMPILER_VERSION,
+            compiler=compile_stylebox_texture,
+        ),
+        registry.register(
+            source_layout_type="region_atlas",
+            artifact_type="StyleBoxTexture",
+            compiler_id=COMPILER_ID,
+            compiler_version=COMPILER_VERSION,
+            compiler=compile_stylebox_texture,
+        ),
+    )

--- a/skills/assets/_shared/asset_validation/__init__.py
+++ b/skills/assets/_shared/asset_validation/__init__.py
@@ -41,6 +41,8 @@ from .structure import (
     KNOWN_ARTIFACT_TYPES,
     ATLAS_TEXTURE_CHECKS,
     ATLAS_TEXTURE_VALIDATOR_ID,
+    STYLEBOX_TEXTURE_CHECKS,
+    STYLEBOX_TEXTURE_VALIDATOR_ID,
     TEXTURE2D_CHECKS,
     TEXTURE2D_VALIDATOR_ID,
     StructureRequest,
@@ -50,6 +52,7 @@ from .structure import (
     build_default_structures,
     validate_texture2d,
     validate_atlas_texture,
+    validate_stylebox_texture,
 )
 
 __all__ = [
@@ -57,6 +60,8 @@ __all__ = [
     "KNOWN_ARTIFACT_TYPES",
     "ATLAS_TEXTURE_CHECKS",
     "ATLAS_TEXTURE_VALIDATOR_ID",
+    "STYLEBOX_TEXTURE_CHECKS",
+    "STYLEBOX_TEXTURE_VALIDATOR_ID",
     "LEVELS",
     "LEVEL_BY_ID",
     "NOT_RUN",
@@ -88,4 +93,5 @@ __all__ = [
     "find_godot",
     "validate_texture2d",
     "validate_atlas_texture",
+    "validate_stylebox_texture",
 ]

--- a/skills/assets/_shared/asset_validation/godot_probe.py
+++ b/skills/assets/_shared/asset_validation/godot_probe.py
@@ -41,7 +41,7 @@ PROBE_SCRIPT = Path(__file__).resolve().parent / "probe.gd"
 # at registration, instead of failing every asset of that type at L4 -- or, worse,
 # passing them, if the validator does not read the error the probe reported.
 # A family adds its name to both lists together with the GDScript branch.
-PROBE_CHECKS = ("texture2d", "atlas_texture", "spriteframes")
+PROBE_CHECKS = ("texture2d", "atlas_texture", "spriteframes", "stylebox_texture")
 
 # Godot's own import and script runs; generous because a first import of a
 # project with many textures is not fast, and a hang must still end as a

--- a/skills/assets/_shared/asset_validation/probe.gd
+++ b/skills/assets/_shared/asset_validation/probe.gd
@@ -17,7 +17,7 @@ extends SceneTree
 # Structural facts a resource may be asked to report for L4. The set is closed:
 # an unknown check is an error, never a silent pass. A family skill adds its
 # check name here together with the Python structure validator that consumes it.
-const KNOWN_CHECKS := ["texture2d", "atlas_texture", "spriteframes"]
+const KNOWN_CHECKS := ["texture2d", "atlas_texture", "spriteframes", "stylebox_texture"]
 
 
 func _parse_user_args() -> Dictionary:
@@ -91,6 +91,23 @@ func _structure(resource: Resource, checks: Array) -> Dictionary:
 					structure[check] = {"animations": animations}
 				else:
 					structure[check] = {"error": "resource is a %s, not SpriteFrames" % resource.get_class()}
+			"stylebox_texture":
+				if resource.is_class("StyleBoxTexture"):
+					var style_box: StyleBoxTexture = resource
+					var texture_path := ""
+					if style_box.texture != null:
+						texture_path = style_box.texture.resource_path
+					var region := style_box.region_rect
+					structure[check] = {
+						"has_texture": style_box.texture != null,
+						"texture_path": texture_path,
+						"texture_region": [region.position.x, region.position.y, region.size.x, region.size.y],
+						"border": [style_box.texture_margin_left, style_box.texture_margin_top, style_box.texture_margin_right, style_box.texture_margin_bottom],
+						"expand_margin": [style_box.expand_margin_left, style_box.expand_margin_top, style_box.expand_margin_right, style_box.expand_margin_bottom],
+						"axis_stretch": [style_box.axis_stretch_horizontal, style_box.axis_stretch_vertical],
+					}
+				else:
+					structure[check] = {"error": "resource is a %s, not StyleBoxTexture" % resource.get_class()}
 	return structure
 
 

--- a/skills/assets/_shared/asset_validation/structure.py
+++ b/skills/assets/_shared/asset_validation/structure.py
@@ -33,6 +33,7 @@ from ._bridge import LAYOUT_ARTIFACT_TYPES
 from .contract import ValidationError
 from .godot_probe import PROBE_CHECKS, ProbeResult
 from asset_compiler.atlas_texture import read_atlas_texture_input
+from asset_compiler.stylebox_texture import read_stylebox_texture_input
 
 # Every artifact type the frozen stable-entry relation allows. A validator for a
 # type outside it could never run, so registering one is a mistake, not a
@@ -213,6 +214,8 @@ TEXTURE2D_VALIDATOR_ID = "texture2d_structure"
 TEXTURE2D_CHECKS = ("texture2d",)
 ATLAS_TEXTURE_VALIDATOR_ID = "atlas_texture_fixed_slot_structure"
 ATLAS_TEXTURE_CHECKS = ("atlas_texture",)
+STYLEBOX_TEXTURE_VALIDATOR_ID = "stylebox_texture_nine_slice_structure"
+STYLEBOX_TEXTURE_CHECKS = ("stylebox_texture",)
 
 
 def validate_texture2d(request: StructureRequest) -> dict[str, Any]:
@@ -282,6 +285,51 @@ def validate_atlas_texture(request: StructureRequest) -> dict[str, Any]:
     }
 
 
+def _exact_numbers(actual: Any, expected: list[int | float], label: str) -> None:
+    if not isinstance(actual, list) or len(actual) != len(expected):
+        raise ValidationError(f"the loaded StyleBoxTexture reported no {label}")
+    if any(type(value) not in (int, float) or isinstance(value, bool) for value in actual):
+        raise ValidationError(f"the loaded StyleBoxTexture reported an invalid {label}")
+    if list(actual) != expected:
+        raise ValidationError(
+            f"the loaded StyleBoxTexture {label} is {actual!r}, not {expected!r}"
+        )
+
+
+def validate_stylebox_texture(request: StructureRequest) -> dict[str, Any]:
+    """Require Godot's loaded StyleBoxTexture to retain every recipe fact."""
+    try:
+        expected = read_stylebox_texture_input(request)
+    except Exception as exc:
+        raise ValidationError(str(exc)) from exc
+    structure = request.checked_structure("stylebox_texture")
+    if structure.get("has_texture") is not True:
+        raise ValidationError("the loaded StyleBoxTexture has no texture")
+    if structure.get("texture_path") != expected.texture_path:
+        raise ValidationError(
+            "the loaded StyleBoxTexture texture_path is "
+            f"{structure.get('texture_path')!r}, not {expected.texture_path!r}"
+        )
+    _exact_numbers(structure.get("texture_region"), list(expected.texture_region), "texture_region")
+    _exact_numbers(structure.get("border"), list(expected.border), "border")
+    _exact_numbers(structure.get("expand_margin"), list(expected.expand_margin), "expand_margin")
+    _exact_numbers(
+        structure.get("axis_stretch"),
+        [
+            {"stretch": 0, "tile": 1, "tile_fit": 2}[expected.axis_stretch[0]],
+            {"stretch": 0, "tile": 1, "tile_fit": 2}[expected.axis_stretch[1]],
+        ],
+        "axis_stretch",
+    )
+    return {
+        "texture_path": expected.texture_path,
+        "texture_region": list(expected.texture_region),
+        "border": list(expected.border),
+        "expand_margin": list(expected.expand_margin),
+        "axis_stretch": {"horizontal": expected.axis_stretch[0], "vertical": expected.axis_stretch[1]},
+    }
+
+
 def build_default_structures() -> StructureValidatorRegistry:
     """Return a new registry holding every validator the shared layer ships."""
     from . import sprite_frames
@@ -292,6 +340,12 @@ def build_default_structures() -> StructureValidatorRegistry:
         validator_id=TEXTURE2D_VALIDATOR_ID,
         validator=validate_texture2d,
         checks=TEXTURE2D_CHECKS,
+    )
+    registry.register(
+        artifact_type="StyleBoxTexture",
+        validator_id=STYLEBOX_TEXTURE_VALIDATOR_ID,
+        validator=validate_stylebox_texture,
+        checks=STYLEBOX_TEXTURE_CHECKS,
     )
     registry.register(
         artifact_type="AtlasTexture",

--- a/skills/assets/_shared/godot-artifact-compiler-contract.md
+++ b/skills/assets/_shared/godot-artifact-compiler-contract.md
@@ -159,12 +159,39 @@ regions, or introduce nine-slice behavior. L4 reloads the resource through
 headless Godot and checks that `AtlasTexture.atlas.resource_path` exactly equals
 the declared physical atlas path, alongside its exact region and zero margin.
 
+## StyleBoxTexture
+
+`single -> StyleBoxTexture` and `region_atlas -> StyleBoxTexture` are served by
+`asset_compiler/stylebox_texture.py`. Both routes use the same exact `spec`:
+
+```json
+{
+  "texture_region": [x, y, width, height],
+  "border": [left, top, right, bottom],
+  "expand_margin": [left, top, right, bottom],
+  "axis_stretch": {"horizontal": "tile", "vertical": "stretch"}
+}
+```
+
+`texture_region` and `border` are non-negative integer pixel values; the region
+must lie inside the source PNG and the opposing borders may not exceed its
+width or height. `expand_margin` contains finite non-negative numbers. Each
+stretch axis is explicitly one of `tile`, `tile_fit`, or `stretch`.
+
+The compiler assigns the source texture directly and writes exactly the
+declared `StyleBoxTexture.region_rect`. It does not infer a region from pixels
+or fixed-slot metadata, choose borders, alter margins, or generate Theme or
+Control layout. L4 reloads the resource through headless Godot and requires its
+source path, texture region, border, expand margins, and both stretch modes to
+match the recipe exactly.
+
 ## Boundary
 
 `_shared/` holds cross-skill material only. It has no `SKILL.md` and is not
 independently triggerable. It ships the shared `Texture2D` and fixed-slot
-`AtlasTexture` routes; `SpriteFrames`, `Theme`, `StyleBoxTexture`, and `TileSet`
-remain family-specific compilers registered through `CompilerRegistry.register()`.
+`AtlasTexture`, and `StyleBoxTexture` routes; `SpriteFrames`, `Theme`, and
+`TileSet` remain family-specific compilers registered through
+`CompilerRegistry.register()`.
 
 There is no module-level default registry instance. A caller builds one with
 `build_default_registry()` and every family compiler for that run registers into

--- a/tests/assets/test_asset_compiler_registry.py
+++ b/tests/assets/test_asset_compiler_registry.py
@@ -910,10 +910,12 @@ def test_texture2d_compiler_rejects_a_separate_artifact_path_directly(project):
         )
 
 
-def test_default_registry_ships_the_shared_texture_atlas_and_spriteframes_routes():
+def test_default_registry_ships_the_shared_texture_atlas_spriteframes_and_stylebox_routes():
     assert [route.key for route in build_default_registry().routes()] == [
         ("grid_sheet", "SpriteFrames"),
         ("region_atlas", "AtlasTexture"),
+        ("region_atlas", "StyleBoxTexture"),
+        ("single", "StyleBoxTexture"),
         ("single", "Texture2D")
     ]
 
@@ -923,8 +925,8 @@ def test_each_build_returns_an_independent_registry():
     # leak into a registry another caller builds.
     first = build_default_registry()
     _register(first, "theme_recipe", "Theme")
-    assert len(first.routes()) == 4
-    assert len(build_default_registry().routes()) == 3
+    assert len(first.routes()) == 6
+    assert len(build_default_registry().routes()) == 5
 
 
 def test_relative_project_root_compiles_without_double_anchoring(tmp_path, monkeypatch):

--- a/tests/assets/test_asset_validation_godot.py
+++ b/tests/assets/test_asset_validation_godot.py
@@ -19,7 +19,12 @@ SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
 sys.path.insert(0, str(SHARED_DIR))
 sys.path.insert(0, str(REPO_ROOT / "tools"))
 
-from asset_compiler import CompileRequest, CompilerError, build_default_registry  # noqa: E402
+from asset_compiler import (  # noqa: E402
+    CompileRequest,
+    CompilerError,
+    CompilerRegistry,
+    build_default_registry,
+)
 from asset_validation import (  # noqa: E402
     NOT_RUN,
     PASSED,
@@ -27,6 +32,7 @@ from asset_validation import (  # noqa: E402
     GodotProbe,
     ProbeRequest,
     ValidationLadder,
+    StructureValidatorRegistry,
     build_default_structures,
 )
 from asset_validation.godot_probe import SCRIPT_TIMEOUT  # noqa: E402
@@ -139,17 +145,9 @@ def _entry(**overrides):
 
 
 def _stylebox_ladder(godot_bin: str) -> ValidationLadder:
-    """A ladder with one writing route, so a compiled ``.tres`` can reach L3."""
-    registry = build_default_registry()
-    registry.register(
-        source_layout_type="single",
-        artifact_type="StyleBoxTexture",
-        compiler_id="test_stylebox",
-        compiler_version=1,
-        compiler=lambda request: {},
-    )
+    """Return the default ladder, including the shared StyleBoxTexture route."""
     return ValidationLadder(
-        registry=registry,
+        registry=build_default_registry(),
         structures=build_default_structures(),
         probe=GodotProbe(godot_bin),
     )
@@ -214,7 +212,9 @@ def test_resource_saver_accepts_extension_preserving_staging_artifacts(
             )
         return {"writer": "ResourceSaver"}
 
-    registry = build_default_registry()
+    # This test substitutes the compiler to exercise ResourceSaver itself, so
+    # it must not collide with the shared default StyleBoxTexture route.
+    registry = CompilerRegistry()
     registry.register(
         source_layout_type=layout,
         artifact_type=artifact_type,
@@ -310,7 +310,9 @@ def test_fixed_slot_atlas_texture_reaches_ready_with_its_exact_region(
             }
         ).encode(),
     )
-    registry = build_default_registry()
+    # This test deliberately installs a validator that asks for the wrong
+    # probe check; isolate both replacements from the shared defaults.
+    registry = CompilerRegistry()
     request = CompileRequest(
         production_family="ui-kit",
         asset_id="main_atlas",
@@ -542,7 +544,7 @@ def test_a_check_godot_cannot_answer_fails_l4_even_if_the_validator_ignores_it(
         compiler_version=1,
         compiler=lambda request: {},
     )
-    structures = build_default_structures()
+    structures = StructureValidatorRegistry()
     structures.register(
         artifact_type="StyleBoxTexture",
         validator_id="ignores_the_probe",

--- a/tests/assets/test_asset_validation_godot.py
+++ b/tests/assets/test_asset_validation_godot.py
@@ -367,6 +367,45 @@ def test_fixed_slot_atlas_texture_reaches_ready_with_its_exact_region(
     assert "atlas_path" in tampered.failure.error
 
 
+def test_stylebox_texture_reaches_ready_with_its_exact_nine_slice_recipe(
+    godot_bin, godot_project
+):
+    base = "res://assets/generated/ui-kit/panel"
+    _write(godot_project, f"{base}/panel.png", _png(16, 12))
+    registry = build_default_registry()
+    request = CompileRequest(
+        production_family="ui-kit",
+        asset_id="panel",
+        source_layout_type="single",
+        source_path=f"{base}/panel.png",
+        artifact_type="StyleBoxTexture",
+        artifact_path=f"{base}/panel.tres",
+        project_root=godot_project,
+        spec={
+            "texture_region": [2, 1, 12, 10],
+            "border": [3, 2, 3, 2],
+            "expand_margin": [1, 1.5, 2, 0],
+            "axis_stretch": {"horizontal": "tile_fit", "vertical": "stretch"},
+        },
+    )
+    compiled = registry.compile(request)
+    entry = _entry(godot_artifact=compiled.godot_artifact.to_dict())
+    result = ValidationLadder(
+        registry=registry,
+        structures=build_default_structures(),
+        probe=GodotProbe(godot_bin),
+    ).run(entry, project_root=godot_project, spec=request.spec, receipt=compiled.receipt)
+
+    assert result.ready is True, result.to_dict()
+    assert result.levels[3].details["godot_class"] == "StyleBoxTexture"
+    assert result.levels[4].details["texture_region"] == [2, 1, 12, 10]
+    assert result.levels[4].details["border"] == [3, 2, 3, 2]
+    assert result.levels[4].details["axis_stretch"] == {
+        "horizontal": "tile_fit",
+        "vertical": "stretch",
+    }
+
+
 def test_headless_godot_rejects_a_corrupt_resource(godot_bin, godot_project):
     _write(godot_project, "res://assets/generated/ui-kit/panel/panel.png", _png(8, 8))
     _write(

--- a/tests/assets/test_asset_validation_godot.py
+++ b/tests/assets/test_asset_validation_godot.py
@@ -310,9 +310,7 @@ def test_fixed_slot_atlas_texture_reaches_ready_with_its_exact_region(
             }
         ).encode(),
     )
-    # This test deliberately installs a validator that asks for the wrong
-    # probe check; isolate both replacements from the shared defaults.
-    registry = CompilerRegistry()
+    registry = build_default_registry()
     request = CompileRequest(
         production_family="ui-kit",
         asset_id="main_atlas",
@@ -536,7 +534,9 @@ def test_a_check_godot_cannot_answer_fails_l4_even_if_the_validator_ignores_it(
     returns ``{}`` without reading the probe -- L4 must still fail, on Godot's
     answer alone.
     """
-    registry = build_default_registry()
+    # This test deliberately installs a validator that asks for the wrong
+    # probe check; isolate both replacements from the shared defaults.
+    registry = CompilerRegistry()
     registry.register(
         source_layout_type="single",
         artifact_type="StyleBoxTexture",

--- a/tests/assets/test_asset_validation_ladder.py
+++ b/tests/assets/test_asset_validation_ladder.py
@@ -125,16 +125,8 @@ def _entry(**overrides):
 
 
 def _stylebox_registry() -> CompilerRegistry:
-    """The shared registry plus one writing route, so L2's writing rules are reachable."""
-    registry = build_default_registry()
-    registry.register(
-        source_layout_type="single",
-        artifact_type="StyleBoxTexture",
-        compiler_id="test_stylebox",
-        compiler_version=2,
-        compiler=lambda request: {},
-    )
-    return registry
+    """Return the default registry, which now includes the writing StyleBox route."""
+    return build_default_registry()
 
 
 def _ladder(*, registry=None, structures=None, probe=None) -> ValidationLadder:
@@ -694,21 +686,33 @@ def test_an_unavailable_godot_binary_fails_l3_rather_than_skipping_it(tmp_path):
 
 
 def test_an_artifact_type_with_no_structure_validator_fails_l4(tmp_path):
-    root = _project(tmp_path)
-    _write(root, SOURCE)
-    _write(root, ARTIFACT, b"[gd_resource]\n")
+    root = _project(tmp_path, asset_id="skin")
+    source = "res://assets/generated/ui-kit/skin/skin.json"
+    artifact = "res://assets/generated/ui-kit/skin/skin.tres"
+    _write(root, source, b"{}")
+    _write(root, artifact, b"[gd_resource]\n")
     entry = _entry(
-        godot_artifact={"type": "StyleBoxTexture", "path": ARTIFACT},
+        asset_id="skin",
+        source_layout={"type": "theme_recipe", "path": source},
+        godot_artifact={"type": "Theme", "path": artifact},
         processing_status="ready",
     )
-    result = _ladder(registry=_stylebox_registry()).run(
+    registry = build_default_registry()
+    registry.register(
+        source_layout_type="theme_recipe",
+        artifact_type="Theme",
+        compiler_id="test_theme",
+        compiler_version=1,
+        compiler=lambda request: {},
+    )
+    result = _ladder(registry=registry).run(
         entry,
         project_root=root,
         mode=REVALIDATION,
     )
     level, error = _failure(result)
     assert level == "L4"
-    assert "no structure validator is registered for StyleBoxTexture" in error
+    assert "no structure validator is registered for Theme" in error
     assert result.levels[3].status == PASSED
 
 
@@ -928,6 +932,7 @@ def test_an_unregistered_type_asks_for_no_probe_checks():
     assert build_default_structures().checks_for("SpriteFrames") == ("spriteframes",)
     assert build_default_structures().checks_for("Texture2D") == ("texture2d",)
     assert build_default_structures().checks_for("AtlasTexture") == ("atlas_texture",)
+    assert build_default_structures().checks_for("StyleBoxTexture") == ("stylebox_texture",)
 
 
 def test_routes_are_ordered_by_artifact_type():
@@ -935,6 +940,7 @@ def test_routes_are_ordered_by_artifact_type():
     assert [route.artifact_type for route in structures.routes()] == [
         "AtlasTexture",
         "SpriteFrames",
+        "StyleBoxTexture",
         "Texture2D",
     ]
 
@@ -945,6 +951,7 @@ def test_each_build_returns_an_independent_structure_registry():
     assert [route.artifact_type for route in build_default_structures().routes()] == [
         "AtlasTexture",
         "SpriteFrames",
+        "StyleBoxTexture",
         "Texture2D"
     ]
 
@@ -1019,6 +1026,7 @@ def test_build_default_ladder_wires_the_shared_compiler_and_validator():
     assert [route.validator_id for route in structures.routes()] == [
         "atlas_texture_fixed_slot_structure",
         "spriteframes_structure",
+        "stylebox_texture_nine_slice_structure",
         "texture2d_structure",
     ]
 

--- a/tests/assets/test_stylebox_texture_compiler.py
+++ b/tests/assets/test_stylebox_texture_compiler.py
@@ -1,0 +1,134 @@
+"""StyleBoxTexture compiler contracts for explicit nine-slice recipes."""
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHARED_DIR = REPO_ROOT / "skills" / "assets" / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+
+from asset_compiler import CompileRequest, CompilerError, build_default_registry  # noqa: E402
+from asset_compiler import stylebox_texture  # noqa: E402
+from asset_validation import (  # noqa: E402
+    ProbeResult,
+    StructureRequest,
+    ValidationError,
+    validate_stylebox_texture,
+)
+
+
+def _png(width: int, height: int) -> bytes:
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        body = tag + data
+        return struct.pack(">I", len(data)) + body + struct.pack(">I", zlib.crc32(body) & 0xFFFFFFFF)
+
+    rows = b"".join(b"\x00" + b"\x80\x40\x20\xff" * width for _ in range(height))
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)) + chunk(b"IDAT", zlib.compress(rows)) + chunk(b"IEND", b"")
+
+
+@pytest.fixture
+def project(tmp_path: Path) -> Path:
+    directory = tmp_path / "assets/generated/ui-kit/panel"
+    directory.mkdir(parents=True)
+    (directory / "panel.png").write_bytes(_png(16, 12))
+    return tmp_path
+
+
+def _request(project: Path, *, layout: str = "single", **overrides) -> CompileRequest:
+    root = "res://assets/generated/ui-kit/panel"
+    values = {
+        "production_family": "ui-kit",
+        "asset_id": "panel",
+        "source_layout_type": layout,
+        "source_path": f"{root}/panel.png",
+        "artifact_type": "StyleBoxTexture",
+        "artifact_path": f"{root}/panel.tres",
+        "project_root": project,
+        "spec": {
+            "texture_region": [2, 1, 12, 10],
+            "border": [3, 2, 3, 2],
+            "expand_margin": [1, 1.5, 2, 0],
+            "axis_stretch": {"horizontal": "tile_fit", "vertical": "stretch"},
+        },
+    }
+    values.update(overrides)
+    return CompileRequest(**values)
+
+
+@pytest.mark.parametrize("layout", ["single", "region_atlas"])
+def test_compiles_each_legal_layout_from_the_explicit_recipe(project, layout):
+    result = build_default_registry().compile(_request(project, layout=layout))
+
+    assert result.receipt.compiler_id == stylebox_texture.COMPILER_ID
+    assert result.receipt.details == {
+        "texture_path": "res://assets/generated/ui-kit/panel/panel.png",
+        "texture_region": [2, 1, 12, 10],
+        "border": [3, 2, 3, 2],
+        "expand_margin": [1.0, 1.5, 2.0, 0.0],
+        "axis_stretch": {"horizontal": "tile_fit", "vertical": "stretch"},
+    }
+    tres = (project / "assets/generated/ui-kit/panel/panel.tres").read_text(encoding="utf-8")
+    assert 'texture = ExtResource("1_texture")' in tres
+    assert "region_rect = Rect2(2, 1, 12, 10)" in tres
+    assert "texture_margin_left = 3" in tres
+    assert "expand_margin_top = 1.5" in tres
+    assert "axis_stretch_horizontal = 2" in tres
+    assert "axis_stretch_vertical = 0" in tres
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda spec: spec.__setitem__("texture_region", [12, 0, 5, 4]), "outside source PNG bounds"),
+        (lambda spec: spec.__setitem__("border", [7, 2, 7, 2]), "exceeds texture_region"),
+        (lambda spec: spec.__setitem__("expand_margin", [0, -1, 0, 0]), "finite non-negative"),
+        (lambda spec: spec.__setitem__("axis_stretch", {"horizontal": "repeat", "vertical": "stretch"}), "must be one of"),
+        (lambda spec: spec.__setitem__("unexpected", True), "contain exactly"),
+    ],
+)
+def test_invalid_recipe_fails_closed_without_an_artifact(project, mutate, message):
+    request = _request(project)
+    spec = dict(request.spec)
+    mutate(spec)
+    request = _request(project, spec=spec)
+
+    with pytest.raises(CompilerError, match=message):
+        build_default_registry().compile(request)
+    assert not (project / "assets/generated/ui-kit/panel/panel.tres").exists()
+
+
+def test_l4_rejects_a_loaded_stylebox_with_tampered_recipe_facts(project):
+    request = _request(project)
+    structure_request = StructureRequest(
+        production_family=request.production_family,
+        asset_id=request.asset_id,
+        source_layout_type=request.source_layout_type,
+        source_path=request.source_path,
+        artifact_type=request.artifact_type,
+        artifact_path=request.artifact_path,
+        project_root=request.project_root,
+        spec=request.spec,
+        probe=ProbeResult(
+            res_path=request.artifact_path,
+            expected_type="StyleBoxTexture",
+            loaded=True,
+            godot_class="StyleBoxTexture",
+            type_matches=True,
+            structure={
+                "stylebox_texture": {
+                    "has_texture": True,
+                    "texture_path": request.source_path,
+                    "texture_region": [2, 1, 12, 10],
+                    "border": [3, 2, 3, 2],
+                    "expand_margin": [1, 1.5, 2, 0],
+                    "axis_stretch": [1, 0],
+                }
+            },
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="axis_stretch"):
+        validate_stylebox_texture(structure_request)


### PR DESCRIPTION
## Summary

Adds a deterministic StyleBoxTexture compiler for reusable UI nine-slice resources.

## Motivation

UI panel, button, and card-frame recipes need explicit, validated compilation to Godot StyleBoxTexture resources.

## Changes

- [x] Added `single` and `region_atlas` StyleBoxTexture compilation routes with fail-closed recipe validation.
- [x] Added Godot probe and structure validation for texture region, borders, expand margins, and stretch modes.
- [x] Added compiler, registry, ladder, and headless-Godot integration coverage.
- [x] Updated the artifact compiler contract and release notes.

## Testing

- [x] New or updated tests pass (`python -m pytest`: 1813 passed, 24 skipped)
- [x] Gitleaks passes or no secret-bearing files were touched (no secret-bearing files were touched)
- [ ] Manual testing completed, if applicable (not completed: Godot is unavailable in the validation environment, so ResourceLoader integration cases were skipped)

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [ ] **No** - no migration needed
- [x] **Yes** - this is an intentional v1 breaking compiler contract; no migration or compatibility fallback is applicable.

### Migration Upgrade Gate

Not applicable: no migration script is added for the intentional v1 contract break.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
