### PR TITLE
fix: repair asset compiler Godot validation

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -52,6 +52,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Restored real Godot validation for Theme and TileSet assets, including safe Theme resource paths and imported TileSet atlases.
 - Reference-only stable entries now accept only `pending`, `source_ready`, or `failed`; only registered `source_ready` entries may promote ASSETS.md reference rows.
 - Existing reference entries persisted as `compiled` or `ready` must be manually corrected to `source_ready` before root-index validation; no migration or compatibility reader is provided.
 - Compiler staging now preserves Godot resource extensions.

--- a/skills/assets/_shared/asset_compiler/theme.py
+++ b/skills/assets/_shared/asset_compiler/theme.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from typing import Any
 
 from .contract import CompileRequest, CompilerError
+from ._stable_entry import StableEntryError, assert_within_output_dir, resolve_res_path
 from .registry import CompilerRegistry, CompilerRoute
 
 COMPILER_ID = "theme_recipe"
@@ -25,7 +26,6 @@ THEME_CHECKS = ("theme",)
 
 _IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _COLOR = re.compile(r"^#[0-9A-Fa-f]{6}(?:[0-9A-Fa-f]{2})?$")
-_RES_PATH = re.compile(r"^res://(?!.*(?:^|/)\.\.?/)[^\s]+$")
 _THEME_TYPES = frozenset(
     {
         "Button", "CheckBox", "CheckButton", "Label", "LineEdit",
@@ -282,24 +282,53 @@ def _validate_resource_content(file_path: Path, expected_type: str, suffix: str,
         _fail(f"{label}.path is not valid {expected_type} content: {file_path.name}")
 
 
-def _resource(value: Any, label: str, *, expected_type: str, root: Path) -> tuple[str, str]:
+def _resource(
+    value: Any,
+    label: str,
+    *,
+    expected_type: str,
+    root: Path,
+    production_family: str,
+    asset_id: str,
+) -> tuple[str, str]:
     item = _mapping(value, label)
     if set(item) != {"type", "path"} or item.get("type") != expected_type:
         _fail(f"{label} must have exactly type {expected_type!r} and path")
     path = item.get("path")
-    if not isinstance(path, str) or not _RES_PATH.fullmatch(path):
+    if not isinstance(path, str):
         _fail(f"{label}.path must be a safe res:// path")
+    try:
+        resolved = resolve_res_path(root, path, label=f"{label}.path")
+    except StableEntryError as exc:
+        _fail(f"{label}.path must be a safe res:// path: {exc}")
     suffix = Path(path).suffix.lower()
     if suffix not in _RESOURCE_EXTENSIONS[expected_type]:
         _fail(f"{label}.path is not a supported {expected_type} resource")
-    file_path = root / path[len("res://"):]
+    try:
+        file_path = assert_within_output_dir(
+            root,
+            resolved,
+            production_family=production_family,
+            asset_id=asset_id,
+            label=f"{label}.path",
+        )
+    except StableEntryError as exc:
+        _fail(f"{label}.path must be a safe res:// path: {exc}")
     if not file_path.is_file():
         _fail(f"{label}.path does not exist: {path}")
     _validate_resource_content(file_path, expected_type, suffix, label)
     return path, expected_type
 
 
-def _item_rows(recipe: Mapping[str, Any], section: str, variations: set[str], variation_bases: Mapping[str, str], root: Path) -> list[tuple[str, str, str]]:
+def _item_rows(
+    recipe: Mapping[str, Any],
+    section: str,
+    variations: set[str],
+    variation_bases: Mapping[str, str],
+    root: Path,
+    production_family: str,
+    asset_id: str,
+) -> list[tuple[str, str, str]]:
     rows: list[tuple[str, str, str]] = []
     for index, raw in enumerate(_list(recipe[section], section)):
         item = _mapping(raw, f"{section}[{index}]")
@@ -317,10 +346,10 @@ def _item_rows(recipe: Mapping[str, Any], section: str, variations: set[str], va
         elif section == "constants":
             encoded = str(_number(value, f"{section}[{index}].value", integer=True))
         elif section == "fonts":
-            path, _ = _resource(value, f"{section}[{index}].value", expected_type="FontFile", root=root)
+            path, _ = _resource(value, f"{section}[{index}].value", expected_type="FontFile", root=root, production_family=production_family, asset_id=asset_id)
             encoded = f'ExtResource("Font_{index}")'
         elif section == "icons":
-            path, _ = _resource(value, f"{section}[{index}].value", expected_type="Texture2D", root=root)
+            path, _ = _resource(value, f"{section}[{index}].value", expected_type="Texture2D", root=root, production_family=production_family, asset_id=asset_id)
             encoded = f'ExtResource("Icon_{index}")'
         else:
             encoded = _identifier(value, f"{section}[{index}].value")
@@ -409,7 +438,13 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
     variation_bases = dict(variations)
 
     root = request.project_root
-    sections = {section: _item_rows(recipe, section, variation_names, variation_bases, root) for section in ("colors", "font_sizes", "constants", "fonts", "icons")}
+    sections = {
+        section: _item_rows(
+            recipe, section, variation_names, variation_bases, root,
+            request.production_family, request.asset_id,
+        )
+        for section in ("colors", "font_sizes", "constants", "fonts", "icons")
+    }
     boxes, box_types = _styleboxes(recipe)
     styles: list[tuple[str, str, str]] = []
     for index, raw in enumerate(_list(recipe["styles"], "styles")):
@@ -430,7 +465,14 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
     external: list[tuple[str, str, str]] = []
     for section, resource_type, prefix in (("fonts", "FontFile", "Font"), ("icons", "Texture2D", "Icon")):
         for index, raw in enumerate(_list(recipe[section], section)):
-            path, _ = _resource(_mapping(raw, f"{section}[{index}]")["value"], f"{section}[{index}].value", expected_type=resource_type, root=root)
+            path, _ = _resource(
+                _mapping(raw, f"{section}[{index}]")["value"],
+                f"{section}[{index}].value",
+                expected_type=resource_type,
+                root=root,
+                production_family=request.production_family,
+                asset_id=request.asset_id,
+            )
             external.append((f"{prefix}_{index}", resource_type, path))
     lines = ["[gd_resource type=\"Theme\" load_steps=" + str(1 + len(external) + len(boxes)) + " format=3]", ""]
     for resource_id, resource_type, path in external:
@@ -439,7 +481,7 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
         lines.extend([f'[sub_resource type="{box_types[box_id]}" id="StyleBox_{box_id}"]', *boxes[box_id], ""])
     lines.extend(["[resource]"])
     for name, base in sorted(variations):
-        lines.append(f'{name}/variation_base = &"{base}"')
+        lines.append(f'{name}/base_type = &"{base}"')
     category = {"colors": "colors", "font_sizes": "font_sizes", "constants": "constants", "fonts": "fonts", "icons": "icons"}
     for section in ("colors", "font_sizes", "constants", "fonts", "icons"):
         for theme_type, name, value in sorted(sections[section]):

--- a/skills/assets/_shared/asset_compiler/theme.py
+++ b/skills/assets/_shared/asset_compiler/theme.py
@@ -499,7 +499,7 @@ def register_into(registry: CompilerRegistry) -> CompilerRoute:
 
 
 def validate_theme_structure(request: Any) -> dict[str, Any]:
-    """Require Godot to report a non-empty Theme with a real type variation."""
+    """Require Godot to retain every explicitly declared Theme recipe value."""
     from asset_validation.contract import ValidationError
 
     structure = request.checked_structure("theme")
@@ -532,10 +532,101 @@ def validate_theme_structure(request: Any) -> dict[str, Any]:
             declared_items += len(values)
     if declared_items == 0:
         raise ValidationError("the loaded Theme has no declared Theme items")
+    recipe_path = request.project_root / request.source_path.removeprefix("res://")
+    try:
+        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot read Theme recipe for L4 value validation: {exc}") from exc
+    if not isinstance(recipe, Mapping):
+        raise ValidationError("Theme recipe for L4 value validation is malformed")
+    for variation in recipe.get("variations", []):
+        if not isinstance(variation, Mapping):
+            raise ValidationError("Theme recipe variation is malformed")
+        actual = types.get(variation.get("name"))
+        if not isinstance(actual, Mapping) or actual.get("variation_base") != variation.get("base_type"):
+            raise ValidationError("loaded Theme type variation does not match the recipe")
+    for section, facts_key in (
+        ("colors", "color_values"), ("font_sizes", "font_size_values"),
+        ("constants", "constant_values"), ("fonts", "font_paths"),
+        ("icons", "icon_paths"),
+    ):
+        for item in recipe.get(section, []):
+            if not isinstance(item, Mapping):
+                raise ValidationError(f"Theme recipe {section} item is malformed")
+            actual_type = types.get(item.get("type"))
+            values = actual_type.get(facts_key) if isinstance(actual_type, Mapping) else None
+            if not isinstance(values, Mapping) or item.get("name") not in values:
+                raise ValidationError(f"loaded Theme {section} item does not match the recipe")
+            expected_value = item.get("value")
+            actual_value = values[item["name"]]
+            if section == "colors":
+                expected_value = _theme_color_values(expected_value)
+                if not _same_theme_numbers(actual_value, expected_value):
+                    raise ValidationError("loaded Theme color does not match the recipe")
+            elif section in {"fonts", "icons"}:
+                if not isinstance(expected_value, Mapping) or actual_value != expected_value.get("path"):
+                    raise ValidationError(f"loaded Theme {section} item does not match the recipe")
+            elif actual_value != expected_value:
+                raise ValidationError(f"loaded Theme {section} item does not match the recipe")
+    boxes = recipe.get("styleboxes", {})
+    if not isinstance(boxes, Mapping):
+        raise ValidationError("Theme recipe styleboxes are malformed")
+    for style in recipe.get("styles", []):
+        if not isinstance(style, Mapping):
+            raise ValidationError("Theme recipe style item is malformed")
+        actual_type = types.get(style.get("type"))
+        actual_box = actual_type.get("styleboxes", {}).get(style.get("name")) if isinstance(actual_type, Mapping) else None
+        expected_box = boxes.get(style.get("stylebox"))
+        if not isinstance(actual_box, Mapping) or not isinstance(expected_box, Mapping):
+            raise ValidationError("loaded Theme StyleBox does not match the recipe")
+        if actual_box.get("class") != expected_box.get("type"):
+            raise ValidationError("loaded Theme StyleBox type does not match the recipe")
+        actual_properties = actual_box.get("properties")
+        expected_properties = expected_box.get("properties")
+        if not isinstance(actual_properties, Mapping) or not isinstance(expected_properties, Mapping):
+            raise ValidationError("loaded Theme StyleBox properties are malformed")
+        for name, expected_value in expected_properties.items():
+            if name not in actual_properties or not _same_theme_stylebox_value(name, actual_properties[name], expected_value):
+                raise ValidationError("loaded Theme StyleBox value does not match the recipe")
     return {
         "types": sorted(types), "variations": sorted(variations),
         "requested_variation": requested_variation, "theme_items": declared_items,
     }
+
+
+def _theme_color_values(value: Any) -> list[float]:
+    if not isinstance(value, str) or not _COLOR.fullmatch(value):
+        return []
+    source = value[1:]
+    result = [int(source[index:index + 2], 16) / 255 for index in range(0, 6, 2)]
+    result.append(int(source[6:8], 16) / 255 if len(source) == 8 else 1.0)
+    return result
+
+
+def _same_theme_numbers(actual: Any, expected: list[float]) -> bool:
+    return (
+        isinstance(actual, list)
+        and len(actual) == len(expected)
+        and all(
+            type(value) in (int, float)
+            and math.isfinite(float(value))
+            and math.isclose(float(value), wanted, rel_tol=1e-6, abs_tol=1e-6)
+            for value, wanted in zip(actual, expected)
+        )
+    )
+
+
+def _same_theme_stylebox_value(name: str, actual: Any, expected: Any) -> bool:
+    if name in {"bg_color", "border_color", "shadow_color"}:
+        return _same_theme_numbers(actual, _theme_color_values(expected))
+    if name in {"corner_radius", "border_width", "shadow_size"}:
+        wanted = [expected] * 4 if name != "shadow_size" else expected
+        return actual == wanted
+    if name in {"content_margin", "expand_margin"}:
+        return _same_theme_numbers(actual, [float(expected)] * 4)
+    if name == "shadow_offset":
+        return _same_theme_numbers(actual, [float(value) for value in expected])
+    return actual == expected
 
 
 def register_structure_into(structures: Any) -> Any:

--- a/skills/assets/_shared/asset_compiler/tileset.py
+++ b/skills/assets/_shared/asset_compiler/tileset.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import subprocess
 import tempfile
+from copy import deepcopy
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -43,7 +44,7 @@ def _color(value: Any, label: str) -> list[float]:
 
 
 def _recipe(request: CompileRequest) -> dict[str, Any]:
-    spec = dict(request.spec)
+    spec = deepcopy(dict(request.spec))
     binary = spec.pop("godot_path", None)
     if not isinstance(binary, str) or not binary.strip():
         raise CompilerError("TileSet spec requires a non-empty godot_path")
@@ -79,6 +80,15 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
             for alternative in tile.get("alternatives", []):
                 if not isinstance(alternative, Mapping) or type(alternative.get("id")) is not int or alternative["id"] <= 0:
                     raise CompilerError("alternative id must be a positive integer")
+            for item, label in [(tile, "tile"), *[(alternative, "alternative") for alternative in tile.get("alternatives", [])]]:
+                seen_navigation_layers: set[Any] = set()
+                for polygon in item.get("navigation_polygons", []):
+                    if not isinstance(polygon, Mapping):
+                        continue
+                    layer = polygon.get("layer")
+                    if layer in seen_navigation_layers:
+                        raise CompilerError(f"{label} cannot declare duplicate navigation polygons for one layer")
+                    seen_navigation_layers.add(layer)
             animation = tile.get("animation")
             if animation is not None:
                 if not isinstance(animation, Mapping):

--- a/skills/assets/_shared/asset_compiler/tileset.py
+++ b/skills/assets/_shared/asset_compiler/tileset.py
@@ -130,6 +130,13 @@ def compile_tileset(request: CompileRequest) -> dict[str, Any]:
         config = Path(temp) / "recipe.json"
         config.write_text(json.dumps(recipe), encoding="utf-8")
         try:
+            imported = subprocess.run(
+                [recipe["godot_path"], "--headless", "--path", str(request.project_root), "--import"],
+                capture_output=True, text=True, timeout=300, check=False,
+            )
+            if imported.returncode != 0:
+                message = (imported.stderr or imported.stdout).strip()
+                raise CompilerError(f"TileSet Godot import failed: {message[-2000:]}")
             completed = subprocess.run(
                 [
                     recipe["godot_path"], "--headless", "--path", str(request.project_root),

--- a/skills/assets/_shared/asset_compiler/tileset_compiler.gd
+++ b/skills/assets/_shared/asset_compiler/tileset_compiler.gd
@@ -99,6 +99,7 @@ func _source(tile_set: TileSet, item: Dictionary, fallback_id: int) -> bool:
 	source.texture_region_size = _v2(item.get("region_size", item.get("tile_size", [16, 16])))
 	source.margins = _v2(item.get("margins", [0, 0]))
 	source.separation = _v2(item.get("separation", [0, 0]))
+	tile_set.add_source(source, int(item.get("id", fallback_id)))
 	for tile in item["tiles"]:
 		var coords := _v2(tile["coords"])
 		source.create_tile(coords)
@@ -115,7 +116,6 @@ func _source(tile_set: TileSet, item: Dictionary, fallback_id: int) -> bool:
 			source.set_tile_animation_separation(coords, _v2(animation.get("separation", [0, 0])))
 			source.set_tile_animation_speed(coords, float(animation.get("speed", 1.0)))
 			for frame in animation.get("frame_durations", []): source.set_tile_animation_frame_duration(coords, int(frame["frame"]), float(frame["duration"]))
-	tile_set.add_source(source, int(item.get("id", fallback_id)))
 	return true
 
 func _initialize() -> void:

--- a/skills/assets/_shared/asset_compiler/tileset_compiler.gd
+++ b/skills/assets/_shared/asset_compiler/tileset_compiler.gd
@@ -20,9 +20,15 @@ func _points(values: Array) -> PackedVector2Array:
 	return result
 
 func _shape(value: Variant) -> int:
-	if value is int and value >= TileSet.TILE_SHAPE_SQUARE and value <= TileSet.TILE_SHAPE_HEXAGON:
-		return value
-	push_error("invalid normalized tile_shape"); quit(2); return TileSet.TILE_SHAPE_SQUARE
+	if not (value is int or value is float):
+		return -1
+	var number: float = float(value)
+	if not is_finite(number) or floor(number) != number:
+		return -1
+	var shape: int = int(number)
+	if shape >= TileSet.TILE_SHAPE_SQUARE and shape <= TileSet.TILE_SHAPE_HEXAGON:
+		return shape
+	return -1
 
 func _color(value: Array) -> Color:
 	if value.size() != 4: push_error("normalized color needs four channels"); quit(2); return Color.WHITE
@@ -84,10 +90,12 @@ func _tile_data(source: TileSetAtlasSource, coords: Vector2i, alternative: int, 
 		var polygon := NavigationPolygon.new(); polygon.add_outline(_points(navigation["points"])); polygon.make_polygons_from_outlines()
 		data.set_navigation_polygon(layer, polygon)
 
-func _source(tile_set: TileSet, item: Dictionary, fallback_id: int) -> void:
+func _source(tile_set: TileSet, item: Dictionary, fallback_id: int) -> bool:
 	var source := TileSetAtlasSource.new()
 	source.texture = load(item["texture"])
-	if source.texture == null: push_error("cannot load atlas texture " + item["texture"]); quit(2); return
+	if source.texture == null:
+		push_error("cannot load atlas texture " + item["texture"])
+		return false
 	source.texture_region_size = _v2(item.get("region_size", item.get("tile_size", [16, 16])))
 	source.margins = _v2(item.get("margins", [0, 0]))
 	source.separation = _v2(item.get("separation", [0, 0]))
@@ -108,15 +116,22 @@ func _source(tile_set: TileSet, item: Dictionary, fallback_id: int) -> void:
 			source.set_tile_animation_speed(coords, float(animation.get("speed", 1.0)))
 			for frame in animation.get("frame_durations", []): source.set_tile_animation_frame_duration(coords, int(frame["frame"]), float(frame["duration"]))
 	tile_set.add_source(source, int(item.get("id", fallback_id)))
+	return true
 
 func _initialize() -> void:
 	var args := _args(); var file := FileAccess.open(args.get("recipe", ""), FileAccess.READ)
 	if file == null: push_error("cannot read TileSet recipe"); quit(2); return
 	var recipe = JSON.parse_string(file.get_as_text()); file.close()
 	if typeof(recipe) != TYPE_DICTIONARY: push_error("TileSet recipe must be an object"); quit(2); return
-	var tile_set := TileSet.new(); tile_set.tile_shape = _shape(recipe.get("tile_shape", "square")); tile_set.tile_size = _v2(recipe["tile_size"])
+	var tile_shape := _shape(recipe.get("tile_shape", "square"))
+	if tile_shape < TileSet.TILE_SHAPE_SQUARE:
+		push_error("invalid normalized tile_shape"); quit(2); return
+	var tile_set := TileSet.new(); tile_set.tile_shape = tile_shape; tile_set.tile_size = _v2(recipe["tile_size"])
 	_layers(tile_set, recipe)
-	for index in recipe["sources"].size(): _source(tile_set, recipe["sources"][index], index)
+	for index in recipe["sources"].size():
+		if not _source(tile_set, recipe["sources"][index], index):
+			quit(2)
+			return
 	var error := ResourceSaver.save(tile_set, args.get("output", ""))
 	if error != OK: push_error("ResourceSaver.save failed: " + str(error)); quit(error); return
 	quit()

--- a/skills/assets/_shared/asset_validation/probe.gd
+++ b/skills/assets/_shared/asset_validation/probe.gd
@@ -58,7 +58,7 @@ func _structure(resource: Resource, checks: Array) -> Dictionary:
 						var type_name := str(theme_type)
 						var styleboxes := {}
 						for style_name in resource.get_stylebox_list(theme_type):
-							var stylebox := resource.get_stylebox(style_name, theme_type)
+							var stylebox: StyleBox = resource.get_stylebox(style_name, theme_type)
 							var stylebox_facts := {"class": stylebox.get_class()}
 							if stylebox.is_class("StyleBoxFlat"):
 								var flat := stylebox as StyleBoxFlat
@@ -147,9 +147,9 @@ func _structure(resource: Resource, checks: Array) -> Dictionary:
 					for animation_name in resource.get_animation_names():
 						var frame_paths := []
 						var frame_durations := []
-						var frame_count := resource.get_frame_count(animation_name)
+						var frame_count: int = resource.get_frame_count(animation_name)
 						for frame_index in range(frame_count):
-							var texture := resource.get_frame_texture(animation_name, frame_index)
+							var texture: Texture2D = resource.get_frame_texture(animation_name, frame_index)
 							frame_paths.append(texture.resource_path if texture != null else "")
 							frame_durations.append(resource.get_frame_duration(animation_name, frame_index))
 						animations.append({

--- a/skills/assets/_shared/asset_validation/probe.gd
+++ b/skills/assets/_shared/asset_validation/probe.gd
@@ -59,23 +59,30 @@ func _structure(resource: Resource, checks: Array) -> Dictionary:
 						var styleboxes := {}
 						for style_name in resource.get_stylebox_list(theme_type):
 							var stylebox: StyleBox = resource.get_stylebox(style_name, theme_type)
-							var stylebox_facts := {"class": stylebox.get_class()}
-							if stylebox.is_class("StyleBoxFlat"):
-								var flat := stylebox as StyleBoxFlat
-								stylebox_facts["border_width"] = {
-									"left": flat.border_width_left,
-									"top": flat.border_width_top,
-									"right": flat.border_width_right,
-									"bottom": flat.border_width_bottom,
-								}
+							var stylebox_facts := _theme_stylebox_facts(stylebox)
 							styleboxes[str(style_name)] = stylebox_facts
+						var colors := {}
+						for item_name in resource.get_color_list(theme_type):
+							colors[str(item_name)] = _color_json(resource.get_color(item_name, theme_type))
+						var font_sizes := {}
+						for item_name in resource.get_font_size_list(theme_type):
+							font_sizes[str(item_name)] = resource.get_font_size(item_name, theme_type)
+						var constants := {}
+						for item_name in resource.get_constant_list(theme_type):
+							constants[str(item_name)] = resource.get_constant(item_name, theme_type)
+						var fonts := {}
+						for item_name in resource.get_font_list(theme_type):
+							fonts[str(item_name)] = _resource_path(resource.get_font(item_name, theme_type))
+						var icons := {}
+						for item_name in resource.get_icon_list(theme_type):
+							icons[str(item_name)] = _resource_path(resource.get_icon(item_name, theme_type))
 						types[type_name] = {
 							"variation_base": str(resource.get_type_variation_base(theme_type)),
-							"colors": resource.get_color_list(theme_type),
-							"font_sizes": resource.get_font_size_list(theme_type),
-							"constants": resource.get_constant_list(theme_type),
-							"fonts": resource.get_font_list(theme_type),
-							"icons": resource.get_icon_list(theme_type),
+							"colors": colors.keys(), "color_values": colors,
+							"font_sizes": font_sizes.keys(), "font_size_values": font_sizes,
+							"constants": constants.keys(), "constant_values": constants,
+							"fonts": fonts.keys(), "font_paths": fonts,
+							"icons": icons.keys(), "icon_paths": icons,
 							"styles": resource.get_stylebox_list(theme_type),
 							"styleboxes": styleboxes,
 						}
@@ -181,6 +188,38 @@ func _structure(resource: Resource, checks: Array) -> Dictionary:
 				else:
 					structure[check] = {"error": "resource is a %s, not StyleBoxTexture" % resource.get_class()}
 	return structure
+
+
+func _color_json(color: Color) -> Array:
+	return [color.r, color.g, color.b, color.a]
+
+
+func _resource_path(resource: Resource) -> String:
+	return "" if resource == null else resource.resource_path
+
+
+func _theme_stylebox_facts(stylebox: StyleBox) -> Dictionary:
+	var facts := {"class": stylebox.get_class()}
+	if stylebox.is_class("StyleBoxFlat"):
+		var flat := stylebox as StyleBoxFlat
+		facts["border_width"] = {
+			"left": flat.border_width_left, "top": flat.border_width_top,
+			"right": flat.border_width_right, "bottom": flat.border_width_bottom,
+		}
+		facts["properties"] = {
+			"bg_color": _color_json(flat.bg_color), "border_color": _color_json(flat.border_color),
+			"corner_radius": [flat.corner_radius_top_left, flat.corner_radius_top_right, flat.corner_radius_bottom_right, flat.corner_radius_bottom_left],
+			"border_width": [flat.border_width_left, flat.border_width_top, flat.border_width_right, flat.border_width_bottom],
+			"content_margin": [flat.content_margin_left, flat.content_margin_top, flat.content_margin_right, flat.content_margin_bottom],
+			"expand_margin": [flat.expand_margin_left, flat.expand_margin_top, flat.expand_margin_right, flat.expand_margin_bottom],
+			"shadow_color": _color_json(flat.shadow_color), "shadow_size": flat.shadow_size,
+			"shadow_offset": [flat.shadow_offset.x, flat.shadow_offset.y], "anti_aliasing": flat.anti_aliasing,
+		}
+	elif stylebox.is_class("StyleBoxEmpty"):
+		facts["properties"] = {
+			"content_margin": [stylebox.content_margin_left, stylebox.content_margin_top, stylebox.content_margin_right, stylebox.content_margin_bottom],
+		}
+	return facts
 
 func _tile_descriptor(tile_set: TileSet, source: TileSetAtlasSource, coords: Vector2i, alternative: int) -> Dictionary:
 	var data := source.get_tile_data(coords, alternative)

--- a/skills/assets/_shared/asset_validation/sprite_frames.py
+++ b/skills/assets/_shared/asset_validation/sprite_frames.py
@@ -10,6 +10,7 @@ from .structure import StructureRequest, StructureValidatorRegistry
 
 VALIDATOR_ID = "spriteframes_structure"
 CHECKS = ("spriteframes",)
+_FLOAT32_ROUND_TRIP_TOLERANCE = 1e-6
 
 
 def validate_spriteframes(request: StructureRequest) -> dict[str, Any]:
@@ -44,7 +45,10 @@ def validate_spriteframes(request: StructureRequest) -> dict[str, Any]:
             raise ValidationError(f"SpriteFrames animation {name!r} frame order or texture binding differs from the spec")
         reported = found.get("frame_durations")
         if not isinstance(reported, list) or len(reported) != len(durations) or any(
-            not isclose(float(left), float(right), rel_tol=0, abs_tol=1e-9)
+            not isclose(
+                float(left), float(right), rel_tol=_FLOAT32_ROUND_TRIP_TOLERANCE,
+                abs_tol=_FLOAT32_ROUND_TRIP_TOLERANCE,
+            )
             for left, right in zip(reported, durations)
         ):
             raise ValidationError(f"SpriteFrames animation {name!r} relative frame durations differ from the spec")

--- a/skills/assets/_shared/asset_validation/structure.py
+++ b/skills/assets/_shared/asset_validation/structure.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+import math
 from pathlib import Path
 from typing import Any, Callable
 
@@ -296,6 +297,21 @@ def _exact_numbers(actual: Any, expected: list[int | float], label: str) -> None
         )
 
 
+def _float32_numbers(actual: Any, expected: list[int | float], label: str) -> None:
+    if not isinstance(actual, list) or len(actual) != len(expected):
+        raise ValidationError(f"the loaded StyleBoxTexture reported no {label}")
+    if any(type(value) not in (int, float) or isinstance(value, bool) for value in actual):
+        raise ValidationError(f"the loaded StyleBoxTexture reported an invalid {label}")
+    if not all(
+        math.isfinite(float(value))
+        and math.isclose(float(value), float(wanted), rel_tol=1e-6, abs_tol=1e-6)
+        for value, wanted in zip(actual, expected)
+    ):
+        raise ValidationError(
+            f"the loaded StyleBoxTexture {label} is {actual!r}, not {expected!r}"
+        )
+
+
 def validate_stylebox_texture(request: StructureRequest) -> dict[str, Any]:
     """Require Godot's loaded StyleBoxTexture to retain every recipe fact."""
     try:
@@ -312,7 +328,7 @@ def validate_stylebox_texture(request: StructureRequest) -> dict[str, Any]:
         )
     _exact_numbers(structure.get("texture_region"), list(expected.texture_region), "texture_region")
     _exact_numbers(structure.get("border"), list(expected.border), "border")
-    _exact_numbers(structure.get("expand_margin"), list(expected.expand_margin), "expand_margin")
+    _float32_numbers(structure.get("expand_margin"), list(expected.expand_margin), "expand_margin")
     _exact_numbers(
         structure.get("axis_stretch"),
         [

--- a/skills/assets/_shared/asset_validation/tileset.py
+++ b/skills/assets/_shared/asset_validation/tileset.py
@@ -1,6 +1,7 @@
 """L4 structural contract for a declared TileSet atlas recipe."""
 from __future__ import annotations
 
+import math
 from typing import Any
 
 from .contract import ValidationError
@@ -11,6 +12,48 @@ CHECKS = ("tileset",)
 
 _SHAPES = {"square": 0, "isometric": 1, "half_offset_square": 2, "hexagon": 3}
 _ANIMATION_MODES = {"default": 0, "random_start_times": 1, "max": 2}
+_FLOAT32_ROUND_TRIP_TOLERANCE = 1e-6
+
+
+def _same_float32_round_trip(actual: Any, expected: Any) -> bool:
+    """Compare a finite decimal after Godot's float32 resource round trip."""
+    if type(actual) not in (int, float) or type(expected) not in (int, float):
+        return False
+    return (
+        math.isfinite(float(actual))
+        and math.isfinite(float(expected))
+        and math.isclose(
+            float(actual), float(expected),
+            rel_tol=_FLOAT32_ROUND_TRIP_TOLERANCE,
+            abs_tol=_FLOAT32_ROUND_TRIP_TOLERANCE,
+        )
+    )
+
+
+def _same_terrain_sets(actual: Any, expected: Any) -> bool:
+    if not isinstance(actual, list) or not isinstance(expected, list) or len(actual) != len(expected):
+        return False
+    for actual_set, expected_set in zip(actual, expected):
+        if not isinstance(actual_set, dict) or not isinstance(expected_set, dict):
+            return False
+        if actual_set.get("mode") != expected_set.get("mode"):
+            return False
+        actual_terrains = actual_set.get("terrains")
+        expected_terrains = expected_set.get("terrains")
+        if not isinstance(actual_terrains, list) or not isinstance(expected_terrains, list) or len(actual_terrains) != len(expected_terrains):
+            return False
+        for actual_terrain, expected_terrain in zip(actual_terrains, expected_terrains):
+            if not isinstance(actual_terrain, dict) or not isinstance(expected_terrain, dict):
+                return False
+            if actual_terrain.get("name") != expected_terrain.get("name"):
+                return False
+            actual_color = actual_terrain.get("color")
+            expected_color = expected_terrain.get("color")
+            if not isinstance(actual_color, list) or not isinstance(expected_color, list) or len(actual_color) != len(expected_color):
+                return False
+            if not all(_same_float32_round_trip(value, expected_value) for value, expected_value in zip(actual_color, expected_color)):
+                return False
+    return True
 
 
 def _expected_tile(tile: dict[str, Any], spec: dict[str, Any], *, alternative: bool = False) -> dict[str, Any]:
@@ -88,7 +131,14 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
             raise ValidationError(f"loaded TileSet source {index} tile descriptors are incomplete")
         for tile, loaded in zip(expected.get("tiles", []), actual_tiles):
             for key, default in (("coords", None), ("texture_origin", [0, 0]), ("z_index", 0), ("y_sort_origin", 0), ("probability", 1.0), ("terrain_set", -1), ("terrain", -1)):
-                if loaded.get(key) != tile.get(key, default):
+                actual_value = loaded.get(key)
+                expected_value = tile.get(key, default)
+                matches = (
+                    _same_float32_round_trip(actual_value, expected_value)
+                    if key == "probability"
+                    else actual_value == expected_value
+                )
+                if not matches:
                     raise ValidationError(f"loaded TileSet tile {key} does not match the recipe")
             if "animation" in tile:
                 for key, default in (
@@ -101,15 +151,30 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
                     expected_value = tile["animation"].get(key, default)
                     if key == "mode":
                         expected_value = _ANIMATION_MODES.get(expected_value, expected_value)
-                    if loaded.get("animation", {}).get(key) != expected_value:
+                    actual_value = loaded.get("animation", {}).get(key)
+                    matches = (
+                        _same_float32_round_trip(actual_value, expected_value)
+                        if key == "speed"
+                        else actual_value == expected_value
+                    )
+                    if not matches:
                         raise ValidationError(f"loaded TileSet animation {key} does not match the recipe")
                 if "frame_durations" in tile["animation"]:
                     expected_durations = [item.get("duration") for item in tile["animation"]["frame_durations"]]
-                    if loaded.get("animation", {}).get("frame_durations") != expected_durations:
+                    actual_durations = loaded.get("animation", {}).get("frame_durations")
+                    if not isinstance(actual_durations, list) or len(actual_durations) != len(expected_durations) or not all(
+                        _same_float32_round_trip(actual, expected)
+                        for actual, expected in zip(actual_durations, expected_durations)
+                    ):
                         raise ValidationError("loaded TileSet animation frame durations do not match the recipe")
             expected_tile = _expected_tile(tile, request.spec)
             for key, value in expected_tile.items():
-                if key != "id" and loaded.get(key) != value:
+                matches = (
+                    _same_float32_round_trip(loaded.get(key), value)
+                    if key == "probability"
+                    else loaded.get(key) == value
+                )
+                if key != "id" and not matches:
                     raise ValidationError(f"loaded TileSet tile {key} does not match the recipe")
             loaded_alternatives = loaded.get("alternatives", [])
             expected_alternatives = tile.get("alternatives", [])
@@ -123,7 +188,12 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
         expected = len(request.spec.get(key, []))
         if facts.get(key + "_count") != expected:
             raise ValidationError(f"loaded TileSet {key} count does not match the recipe")
-        if facts.get(key) != normalized_layers[key]:
+        layers_match = (
+            _same_terrain_sets(facts.get(key), normalized_layers[key])
+            if key == "terrain_sets"
+            else facts.get(key) == normalized_layers[key]
+        )
+        if not layers_match:
             raise ValidationError(f"loaded TileSet {key} data does not match the recipe")
     return dict(facts)
 

--- a/skills/assets/_shared/asset_validation/tileset.py
+++ b/skills/assets/_shared/asset_validation/tileset.py
@@ -13,6 +13,7 @@ CHECKS = ("tileset",)
 _SHAPES = {"square": 0, "isometric": 1, "half_offset_square": 2, "hexagon": 3}
 _ANIMATION_MODES = {"default": 0, "random_start_times": 1, "max": 2}
 _FLOAT32_ROUND_TRIP_TOLERANCE = 1e-6
+_CUSTOM_DATA_DEFAULTS = {1: False, 2: 0, 3: 0.0, 4: ""}
 
 
 def _same_float32_round_trip(actual: Any, expected: Any) -> bool:
@@ -47,11 +48,43 @@ def _same_terrain_sets(actual: Any, expected: Any) -> bool:
                 return False
             if actual_terrain.get("name") != expected_terrain.get("name"):
                 return False
-            actual_color = actual_terrain.get("color")
-            expected_color = expected_terrain.get("color")
-            if not isinstance(actual_color, list) or not isinstance(expected_color, list) or len(actual_color) != len(expected_color):
+            if "color" in expected_terrain:
+                actual_color = actual_terrain.get("color")
+                expected_color = expected_terrain["color"]
+                if not isinstance(actual_color, list) or not isinstance(expected_color, list) or len(actual_color) != len(expected_color):
+                    return False
+                if not all(_same_float32_round_trip(value, expected_value) for value, expected_value in zip(actual_color, expected_color)):
+                    return False
+    return True
+
+
+def _same_polygon_layers(actual: Any, expected: Any) -> bool:
+    if not isinstance(actual, list) or not isinstance(expected, list) or len(actual) != len(expected):
+        return False
+    for actual_layer, expected_layer in zip(actual, expected):
+        if not isinstance(actual_layer, list) or not isinstance(expected_layer, list) or len(actual_layer) != len(expected_layer):
+            return False
+        for actual_polygon, expected_polygon in zip(actual_layer, expected_layer):
+            if not isinstance(actual_polygon, list) or not isinstance(expected_polygon, list) or len(actual_polygon) != len(expected_polygon):
                 return False
-            if not all(_same_float32_round_trip(value, expected_value) for value, expected_value in zip(actual_color, expected_color)):
+            for actual_point, expected_point in zip(actual_polygon, expected_polygon):
+                if not isinstance(actual_point, list) or not isinstance(expected_point, list) or len(actual_point) != 2 or len(expected_point) != 2:
+                    return False
+                if not all(_same_float32_round_trip(value, wanted) for value, wanted in zip(actual_point, expected_point)):
+                    return False
+    return True
+
+
+def _same_navigation_polygons(actual: Any, expected: Any) -> bool:
+    if not isinstance(actual, list) or not isinstance(expected, list) or len(actual) != len(expected):
+        return False
+    for actual_polygon, expected_polygon in zip(actual, expected):
+        if not isinstance(actual_polygon, list) or not isinstance(expected_polygon, list) or len(actual_polygon) != len(expected_polygon):
+            return False
+        for actual_point, expected_point in zip(actual_polygon, expected_polygon):
+            if not isinstance(actual_point, list) or not isinstance(expected_point, list) or len(actual_point) != 2 or len(expected_point) != 2:
+                return False
+            if not all(_same_float32_round_trip(value, wanted) for value, wanted in zip(actual_point, expected_point)):
                 return False
     return True
 
@@ -69,7 +102,10 @@ def _expected_tile(tile: dict[str, Any], spec: dict[str, Any], *, alternative: b
     peering = [-1] * 16
     for item in tile.get("peering_bits", []):
         peering[item["bit"]] = item["terrain"]
-    custom = [None] * len(spec.get("custom_data_layers", []))
+    custom = [
+        _CUSTOM_DATA_DEFAULTS.get(layer.get("type", 0))
+        for layer in spec.get("custom_data_layers", [])
+    ]
     for item in tile.get("custom_data", []):
         custom[item["layer"]] = item.get("value")
     return {"id": tile.get("id", 0 if not alternative else None), "texture_origin": tile.get("texture_origin", [0, 0]), "z_index": tile.get("z_index", 0), "y_sort_origin": tile.get("y_sort_origin", 0), "probability": tile.get("probability", 1.0), "terrain_set": tile.get("terrain_set", -1), "terrain": tile.get("terrain", -1), "peering_bits": peering, "custom_data": custom, "collision_polygons": physics, "occlusion_polygons": occlusion, "navigation_polygons": navigation}
@@ -80,10 +116,13 @@ def _expected_layers(spec: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
     for terrain_set in spec.get("terrain_sets", []):
         terrains = []
         for terrain in terrain_set.get("terrains", []):
-            color = terrain.get("color", [1.0, 1.0, 1.0, 1.0])
-            if len(color) == 3:
-                color = [*color, 1.0]
-            terrains.append({"name": terrain.get("name", ""), "color": color})
+            expected_terrain = {"name": terrain.get("name", "")}
+            if "color" in terrain:
+                color = terrain["color"]
+                if len(color) == 3:
+                    color = [*color, 1.0]
+                expected_terrain["color"] = color
+            terrains.append(expected_terrain)
         terrain_sets.append({"mode": terrain_set.get("mode", 0), "terrains": terrains})
     return {
         "physics_layers": [{"collision_layer": item.get("collision_layer", 1), "collision_mask": item.get("collision_mask", 1)} for item in spec.get("physics_layers", [])],
@@ -172,6 +211,10 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
                 matches = (
                     _same_float32_round_trip(loaded.get(key), value)
                     if key == "probability"
+                    else _same_polygon_layers(loaded.get(key), value)
+                    if key in {"collision_polygons", "occlusion_polygons"}
+                    else _same_navigation_polygons(loaded.get(key), value)
+                    if key == "navigation_polygons"
                     else loaded.get(key) == value
                 )
                 if key != "id" and not matches:
@@ -187,6 +230,10 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
                 alternative_matches = all(
                     _same_float32_round_trip(actual_alternative.get(key), expected_value)
                     if key == "probability"
+                    else _same_polygon_layers(actual_alternative.get(key), expected_value)
+                    if key in {"collision_polygons", "occlusion_polygons"}
+                    else _same_navigation_polygons(actual_alternative.get(key), expected_value)
+                    if key == "navigation_polygons"
                     else actual_alternative.get(key) == expected_value
                     for key, expected_value in expected_alternative.items()
                 )

--- a/skills/assets/_shared/asset_validation/tileset.py
+++ b/skills/assets/_shared/asset_validation/tileset.py
@@ -91,8 +91,14 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
                 if loaded.get(key) != tile.get(key, default):
                     raise ValidationError(f"loaded TileSet tile {key} does not match the recipe")
             if "animation" in tile:
-                for key in ("mode", "columns", "frames_count", "separation", "speed"):
-                    expected_value = tile["animation"].get(key)
+                for key, default in (
+                    ("mode", "default"),
+                    ("columns", 1),
+                    ("frames_count", None),
+                    ("separation", [0, 0]),
+                    ("speed", 1.0),
+                ):
+                    expected_value = tile["animation"].get(key, default)
                     if key == "mode":
                         expected_value = _ANIMATION_MODES.get(expected_value, expected_value)
                     if loaded.get("animation", {}).get(key) != expected_value:

--- a/skills/assets/_shared/asset_validation/tileset.py
+++ b/skills/assets/_shared/asset_validation/tileset.py
@@ -181,7 +181,16 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
             if len(loaded_alternatives) != len(expected_alternatives):
                 raise ValidationError("loaded TileSet alternatives do not match the recipe")
             for alternative, actual_alternative in zip(expected_alternatives, loaded_alternatives):
-                if actual_alternative != _expected_tile(alternative, request.spec, alternative=True):
+                expected_alternative = _expected_tile(
+                    alternative, request.spec, alternative=True
+                )
+                alternative_matches = all(
+                    _same_float32_round_trip(actual_alternative.get(key), expected_value)
+                    if key == "probability"
+                    else actual_alternative.get(key) == expected_value
+                    for key, expected_value in expected_alternative.items()
+                )
+                if not alternative_matches:
                     raise ValidationError("loaded TileSet alternative data does not match the recipe")
     normalized_layers = _expected_layers(request.spec)
     for key in ("physics_layers", "navigation_layers", "occlusion_layers", "custom_data_layers", "terrain_sets"):

--- a/skills/assets/background-map/SKILL.md
+++ b/skills/assets/background-map/SKILL.md
@@ -13,7 +13,7 @@ geometry.
 ## Invocation
 
 Accept one asset request matching the shared Asset Skill request schema in
-`skills/assets/_shared/schema/asset-skill-request.schema.json`. Require
+`.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
 `asset_type` to be `background-map`. Validate the returned document against the
 shared result schema and checker before returning it.
 

--- a/skills/assets/card-kit/SKILL.md
+++ b/skills/assets/card-kit/SKILL.md
@@ -14,7 +14,7 @@ composite screen, readable text, or scene layout.
 ## Invocation
 
 Accept one asset request matching the shared Asset Skill request schema in
-`skills/assets/_shared/schema/asset-skill-request.schema.json`. Require
+`.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
 `asset_type` to be `card-kit`. Validate the returned document against the
 shared result schema and checker, then validate its closed family contract with
 `tools/asset_ui_card_contract_check.py`. `spec` declares the Theme recipe and

--- a/skills/assets/character-bundle/SKILL.md
+++ b/skills/assets/character-bundle/SKILL.md
@@ -9,7 +9,7 @@ Use this skill for a player character, enemy, NPC, summon, boss, or other
 recurring creature identity. It produces one `SpriteFrames` resource for one
 actor or skin, containing every required named body action.
 
-Read `../_shared/asset-skill-contract.md` before accepting a request. First
+Read `.godotmaker/asset-runtime/asset-skill-contract.md` before accepting a request. First
 validate the shared request/result shape with
 `tools/asset_skill_contract_check.py`, then validate this family contract with
 `tools/asset_animated_bundle_contract_check.py --kind request`. For final

--- a/skills/assets/compact-prop-pack/SKILL.md
+++ b/skills/assets/compact-prop-pack/SKILL.md
@@ -10,7 +10,7 @@ Skill.
 ## Contract
 
 Accept the shared asset request contract from
-`skills/assets/_shared/asset-skill-contract.md` with
+`.godotmaker/asset-runtime/asset-skill-contract.md` with
 `asset_type: "compact-prop-pack"`. The family-specific `spec` is the exact
 JSON declaration passed to `tools/asset_atlas_assemble.py --declaration`; no
 conversion or inferred fields are allowed:
@@ -67,7 +67,7 @@ names exactly match the corresponding metadata region names.
    `tools/asset_atlas_assemble.py`. Its declaration contains every slot's name,
    rectangle, source, and pivot. It is the source of the exact regions.
 4. For every metadata region, compile one independent `AtlasTexture` through
-   `skills/assets/_shared/asset_compiler/atlas_texture.py`, passing only
+   `.godotmaker/asset-runtime/asset_compiler/atlas_texture.py`, passing only
    `metadata_path` and that region's `logical_asset_id` in the compiler spec.
    The artifact filename must equal the logical id.
 5. Run the shared L0-L4 validation ladder for every runtime output. L4 must
@@ -77,7 +77,7 @@ names exactly match the corresponding metadata region names.
    whole-atlas texture or silently omit an output.
 
 Common schema validation, atlas assembly, compiler routing, and L0-L4
-validation live exclusively in `skills/assets/_shared/`. This Skill does not
+ validation live exclusively in `.godotmaker/asset-runtime/`. This Skill does not
 copy a schema, compiler, validator, or atlas-packing implementation.
 
 ## Prompt Requirements

--- a/skills/assets/fx-bundle/SKILL.md
+++ b/skills/assets/fx-bundle/SKILL.md
@@ -10,7 +10,7 @@ arc, aura loop, dust, or another detached foreground effect. A request produces
 either one static `Texture2D` effect or one independently animated
 `SpriteFrames` effect.
 
-Read `../_shared/asset-skill-contract.md` before accepting a request. First
+Read `.godotmaker/asset-runtime/asset-skill-contract.md` before accepting a request. First
 validate the shared request/result shape with
 `tools/asset_skill_contract_check.py`, then validate this family contract with
 `tools/asset_animated_bundle_contract_check.py --kind request`. For final

--- a/skills/assets/platform-strip/SKILL.md
+++ b/skills/assets/platform-strip/SKILL.md
@@ -12,7 +12,7 @@ for characters, enemies, UI, compact props, or full scenic backgrounds.
 ## Invocation
 
 Accept one asset request matching the shared Asset Skill request schema in
-`skills/assets/_shared/schema/asset-skill-request.schema.json`. Require
+`.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
 `asset_type` to be `platform-strip`. Validate the returned document against the
 shared result schema and checker before returning it.
 

--- a/skills/assets/scene-prop-set/SKILL.md
+++ b/skills/assets/scene-prop-set/SKILL.md
@@ -8,7 +8,7 @@ backgrounds, UI, characters, effects, terrain, or scene placement.
 ## Contract
 
 Accept the shared asset request contract from
-`skills/assets/_shared/asset-skill-contract.md` with
+`.godotmaker/asset-runtime/asset-skill-contract.md` with
 `asset_type: "scene-prop-set"`. The family-specific `spec` is the exact JSON
 declaration passed to `tools/asset_atlas_assemble.py --declaration`; no
 conversion or inferred fields are allowed:
@@ -64,7 +64,7 @@ objects, or worker-dispatch details.
 3. Use `tools/asset_atlas_assemble.py` to build the one physical PNG and its
    adjacent metadata from explicit fixed slots. The written metadata is the
    only source for runtime regions.
-4. Use `skills/assets/_shared/asset_compiler/atlas_texture.py` once per region
+4. Use `.godotmaker/asset-runtime/asset_compiler/atlas_texture.py` once per region
    to compile an independent `AtlasTexture`. Pass its `metadata_path` and the
    exact logical region name; the `.tres` filename must match that name.
 5. Run shared L0-L4 validation per output. L4 must prove the loaded resource
@@ -74,7 +74,7 @@ objects, or worker-dispatch details.
    if a region is absent or invalid; never return the entire atlas as one prop.
 
 Common schema processing, compiler routing, and validation are reused only
-from `skills/assets/_shared/`; no family-local copy of a schema, compiler,
+ from `.godotmaker/asset-runtime/`; no family-local copy of a schema, compiler,
 validator, packing, or trimming routine is permitted.
 
 ## Prompt Requirements

--- a/skills/assets/screen-reference/SKILL.md
+++ b/skills/assets/screen-reference/SKILL.md
@@ -12,7 +12,7 @@ It is reference-only: it does not create a runtime Godot resource, has no
 ## Invocation
 
 Accept one asset request matching the shared Asset Skill request schema in
-`skills/assets/_shared/schema/asset-skill-request.schema.json`. Require
+`.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
 `asset_type` to be `screen-reference`. Validate the returned document against
 the shared result schema and checker before returning it.
 

--- a/skills/assets/tileset/SKILL.md
+++ b/skills/assets/tileset/SKILL.md
@@ -12,7 +12,7 @@ use the same request and result contract.
 ## Contract
 
 Read and enforce the common request and result contract in
-`skills/assets/_shared/asset-skill-contract.md`. Accept only a request whose
+`.godotmaker/asset-runtime/asset-skill-contract.md`. Accept only a request whose
 `asset_type` is `tileset`; require a stable `asset_id`, a concise `brief`, and
 an explicit `spec`. Return the common result object with:
 
@@ -67,7 +67,7 @@ layout. It only provides pixels for the explicit recipe below.
 ## Explicit Recipe
 
 Put all runtime semantics in `request.spec`, using the exact field shapes
-accepted by `skills/assets/_shared/asset_compiler/tileset.py`. The minimum
+accepted by `.godotmaker/asset-runtime/asset_compiler/tileset.py`. The minimum
 recipe is:
 
 ```json

--- a/skills/assets/tileset/standalone_validation.py
+++ b/skills/assets/tileset/standalone_validation.py
@@ -133,6 +133,7 @@ def compile_and_validate(
     except (OSError, StableEntryError, ValidationError) as exc:
         return _failure(result, passed, "L1", exc)
 
+    passed.append("L1")
     primary_source = atlas_paths[0]
     compile_request = CompileRequest(
         production_family="tileset",
@@ -153,10 +154,9 @@ def compile_and_validate(
             "path": output["path"],
         }:
             raise ValidationError("TileSet compiler returned an artifact that does not match the result")
-    except CompilerError as exc:
+    except (CompilerError, ValidationError) as exc:
         return _failure(result, passed, "L2", exc)
 
-    passed.append("L1")
     passed.append("L2")
     structures = StructureValidatorRegistry()
     tileset_structures.register_into(structures)

--- a/skills/assets/ui-kit/SKILL.md
+++ b/skills/assets/ui-kit/SKILL.md
@@ -13,7 +13,7 @@ composite screen, readable text, or gameplay geometry.
 ## Invocation
 
 Accept one asset request matching the shared Asset Skill request schema in
-`skills/assets/_shared/schema/asset-skill-request.schema.json`. Require
+`.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
 `asset_type` to be `ui-kit`. First validate the returned document against the shared result schema and checker, then enforce the closed UI request and
 request-to-result binding with `tools/asset_ui_card_contract_check.py`.
 `spec` must declare one Theme recipe/output/variation, the complete requested

--- a/tests/assets/test_asset_validation_godot.py
+++ b/tests/assets/test_asset_validation_godot.py
@@ -6,6 +6,7 @@ when no engine is reachable -- CI installs pytest and pillow only -- so a
 contributor with Godot 4.4+ installed runs them and CI does not.
 """
 import json
+import shutil
 import struct
 import subprocess
 import sys
@@ -294,10 +295,31 @@ def test_a_generated_texture_reaches_ready_through_real_godot(godot_bin, godot_p
 def test_a_compiled_theme_recipe_reaches_ready_through_real_godot(godot_bin, godot_project):
     """The compiler output must survive real Theme loading and L4 inspection."""
     recipe_path = "res://assets/generated/ui-kit/skin/skin.json"
+    font_path = "res://assets/generated/ui-kit/skin/font.ttf"
+    icon_path = "res://assets/generated/ui-kit/skin/icon.png"
+    font_file = godot_project / font_path.removeprefix("res://")
+    font_file.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(Path("C:/Windows/Fonts/arial.ttf"), font_file)
+    _write(godot_project, icon_path, _png(8, 8))
     _write(
         godot_project,
         recipe_path,
-        b'''{"version":1,"colors":[{"type":"Button","name":"font_color","value":"#FFFFFFFF"}],"font_sizes":[],"constants":[],"fonts":[],"icons":[],"styleboxes":{"normal":{"type":"StyleBoxFlat","properties":{"bg_color":"#112233FF","border_width":2}},"focus":{"type":"StyleBoxEmpty","properties":{}}},"styles":[{"type":"Button","name":"normal","stylebox":"normal"},{"type":"Button","name":"focus","stylebox":"focus"}],"variations":[{"name":"PrimaryButton","base_type":"Button"}]}''',
+        json.dumps({
+            "version": 1,
+            "colors": [{"type": "Button", "name": "font_color", "value": "#112233FF"}],
+            "font_sizes": [{"type": "Button", "name": "font_size", "value": 19}],
+            "constants": [{"type": "Button", "name": "outline_size", "value": 2}],
+            "fonts": [{"type": "Button", "name": "font", "value": {"type": "FontFile", "path": font_path}}],
+            "icons": [{"type": "Button", "name": "icon", "value": {"type": "Texture2D", "path": icon_path}}],
+            "styleboxes": {
+                "normal": {"type": "StyleBoxFlat", "properties": {
+                    "bg_color": "#112233FF", "border_width": 2, "content_margin": 1.5,
+                }},
+                "focus": {"type": "StyleBoxEmpty", "properties": {}},
+            },
+            "styles": [{"type": "Button", "name": "normal", "stylebox": "normal"}, {"type": "Button", "name": "focus", "stylebox": "focus"}],
+            "variations": [{"name": "PrimaryButton", "base_type": "Button"}],
+        }).encode(),
     )
     registry = build_default_registry()
     theme.register_into(registry)
@@ -328,7 +350,7 @@ def test_a_compiled_theme_recipe_reaches_ready_through_real_godot(godot_bin, god
     assert result.levels[4].details["variations"] == ["PrimaryButton"]
     border = result.levels[3].details["structure"]["theme"]["types"]["Button"]["styleboxes"]["normal"]["border_width"]
     assert border == {"left": 2, "top": 2, "right": 2, "bottom": 2}
-    assert result.levels[3].details["structure"]["theme"]["types"]["Button"]["styleboxes"]["focus"] == {"class": "StyleBoxEmpty"}
+    assert result.levels[3].details["structure"]["theme"]["types"]["Button"]["styleboxes"]["focus"]["class"] == "StyleBoxEmpty"
 def test_fixed_slot_atlas_texture_reaches_ready_with_its_exact_region(
     godot_bin, godot_project
 ):
@@ -406,7 +428,7 @@ def test_fixed_slot_atlas_texture_reaches_ready_with_its_exact_region(
     assert "atlas_path" in tampered.failure.error
 
 
-def test_stylebox_texture_reaches_ready_with_its_exact_nine_slice_recipe(
+def test_stylebox_texture_region_atlas_reaches_ready_with_float32_expand_margins(
     godot_bin, godot_project
 ):
     base = "res://assets/generated/ui-kit/panel"
@@ -415,7 +437,7 @@ def test_stylebox_texture_reaches_ready_with_its_exact_nine_slice_recipe(
     request = CompileRequest(
         production_family="ui-kit",
         asset_id="panel",
-        source_layout_type="single",
+        source_layout_type="region_atlas",
         source_path=f"{base}/panel.png",
         artifact_type="StyleBoxTexture",
         artifact_path=f"{base}/panel.tres",
@@ -423,12 +445,15 @@ def test_stylebox_texture_reaches_ready_with_its_exact_nine_slice_recipe(
         spec={
             "texture_region": [2, 1, 12, 10],
             "border": [3, 2, 3, 2],
-            "expand_margin": [1, 1.5, 2, 0],
+            "expand_margin": [0.3, 0.7, 1.1, 2.2],
             "axis_stretch": {"horizontal": "tile_fit", "vertical": "stretch"},
         },
     )
     compiled = registry.compile(request)
-    entry = _entry(godot_artifact=compiled.godot_artifact.to_dict())
+    entry = _entry(
+        source_layout={"type": "region_atlas", "path": request.source_path},
+        godot_artifact=compiled.godot_artifact.to_dict(),
+    )
     result = ValidationLadder(
         registry=registry,
         structures=build_default_structures(),

--- a/tests/assets/test_sprite_frames_compiler.py
+++ b/tests/assets/test_sprite_frames_compiler.py
@@ -106,7 +106,7 @@ def test_headless_godot_loads_spriteframes_and_reports_its_animation_structure(
              "res://assets/generated/character-bundle/hero/idle_2.png"]
     for path in paths:
         _png(godot_project / path.removeprefix("res://"))
-    action = _action("idle", loop=False, fps=8, paths=paths, durations=[1, 0.5])
+    action = _action("idle", loop=False, fps=12.3, paths=paths, durations=[0.1, 0.9])
     registry = CompilerRegistry()
     sprite_frames.register_into(registry)
     result = registry.compile(_request(godot_project, [action]))
@@ -118,10 +118,17 @@ def test_headless_godot_loads_spriteframes_and_reports_its_animation_structure(
     structure = report.resources[0].structure["spriteframes"]
     assert report.resources[0].loaded is True
     assert report.resources[0].type_matches is True
-    assert structure["animations"] == [{
-        "name": "idle", "fps": 8.0, "loop": False, "frame_count": 2,
-        "frame_paths": paths, "frame_durations": [1.0, 0.5],
-    }]
+    animation = structure["animations"][0]
+    assert animation["name"] == "idle"
+    assert animation["fps"] == 12.3
+    assert animation["frame_paths"] == paths
+    assert animation["frame_durations"] == pytest.approx([0.1, 0.9], abs=1e-6)
+    assert build_default_structures().validate(StructureRequest(
+        production_family="character-bundle", asset_id="hero", source_layout_type="grid_sheet",
+        source_path=result.godot_artifact.path, artifact_type="SpriteFrames",
+        artifact_path=result.godot_artifact.path, project_root=godot_project,
+        probe=report.resources[0], spec={"actions": [action]},
+    )) == {"animations": ["idle"]}
 
 
 def test_l4_validator_checks_the_explicit_timing_and_texture_contract(tmp_path):

--- a/tests/assets/test_theme_compiler.py
+++ b/tests/assets/test_theme_compiler.py
@@ -47,7 +47,7 @@ def _request(root: Path):
 
 def _write_recipe(root: Path, recipe):
     path = root / "assets/generated/ui-kit/main/main.json"
-    path.parent.mkdir(parents=True)
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(recipe), encoding="utf-8")
 
 
@@ -66,7 +66,7 @@ def test_compiles_a_complete_theme_with_a_variation_deterministically(tmp_path):
     assert second.receipt.details == {"variations": ["PrimaryButton"], "theme_items": 4, "styleboxes": ["button_normal"]}
     assert (tmp_path / "assets/generated/ui-kit/main/main.tres").read_bytes() == first_bytes
     text = first_bytes.decode()
-    assert 'PrimaryButton/variation_base = &"Button"' in text
+    assert 'PrimaryButton/base_type = &"Button"' in text
     assert "Button/colors/font_color = Color(1, 1, 1, 1)" in text
     assert 'Button/styles/normal = SubResource("StyleBox_button_normal")' in text
 
@@ -114,7 +114,7 @@ def test_rejects_untrusted_type_property_and_stylebox_references(tmp_path, mutat
 
 
 def test_rejects_missing_external_resources(tmp_path):
-    recipe = _recipe(fonts=[{"type": "Button", "name": "font", "value": {"type": "FontFile", "path": "res://outside.ttf"}}])
+    recipe = _recipe(fonts=[{"type": "Button", "name": "font", "value": {"type": "FontFile", "path": "res://assets/generated/ui-kit/main/outside.ttf"}}])
     _write_recipe(tmp_path, recipe)
     with pytest.raises(CompilerError, match="does not exist"):
         _compile(tmp_path)
@@ -128,10 +128,40 @@ def test_rejects_missing_external_resources(tmp_path):
     ],
 )
 def test_rejects_wrongly_typed_external_resource_content(tmp_path, section, resource_type, path):
-    (tmp_path / path[len("res://"):]).write_bytes(b"not a resource")
+    path = "res://assets/generated/ui-kit/main/" + Path(path).name
+    resource = tmp_path / path[len("res://"):]
+    resource.parent.mkdir(parents=True, exist_ok=True)
+    resource.write_bytes(b"not a resource")
     item = {"type": "Button", "name": "font" if section == "fonts" else "icon", "value": {"type": resource_type, "path": path}}
     _write_recipe(tmp_path, _recipe(**{section: [item]}))
     with pytest.raises(CompilerError, match=f"not valid {resource_type} content"):
+        _compile(tmp_path)
+
+
+@pytest.mark.parametrize("path", [
+    "res://C:/Windows/Fonts/arial.ttf",
+    "res:///etc/passwd",
+    "res://assets/generated/ui-kit/main/../escape.ttf",
+])
+def test_rejects_unsafe_external_resource_paths(tmp_path, path):
+    recipe = _recipe(fonts=[{"type": "Button", "name": "font", "value": {"type": "FontFile", "path": path}}])
+    _write_recipe(tmp_path, recipe)
+    with pytest.raises(CompilerError, match="safe res:// path"):
+        _compile(tmp_path)
+
+
+def test_rejects_external_resource_symlink_escape(tmp_path):
+    source = tmp_path / "assets/generated/ui-kit/main/font.ttf"
+    source.parent.mkdir(parents=True)
+    outside = tmp_path / "outside.ttf"
+    outside.write_bytes(b"not a font")
+    try:
+        source.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are not permitted on this platform")
+    recipe = _recipe(fonts=[{"type": "Button", "name": "font", "value": {"type": "FontFile", "path": "res://assets/generated/ui-kit/main/font.ttf"}}])
+    _write_recipe(tmp_path, recipe)
+    with pytest.raises(CompilerError, match="safe res:// path"):
         _compile(tmp_path)
 
 
@@ -145,8 +175,10 @@ def test_rejects_a_truncated_png_with_valid_magic_and_iend(tmp_path):
         + b"\x00\x00\x00\x00"
         + b"\x00\x00\x00\x00IEND\x00\x00\x00\x00"
     )
-    (tmp_path / "fake.png").write_bytes(fake_png)
-    recipe = _recipe(icons=[{"type": "Button", "name": "icon", "value": {"type": "Texture2D", "path": "res://fake.png"}}])
+    target = tmp_path / "assets/generated/ui-kit/main/fake.png"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(fake_png)
+    recipe = _recipe(icons=[{"type": "Button", "name": "icon", "value": {"type": "Texture2D", "path": "res://assets/generated/ui-kit/main/fake.png"}}])
     _write_recipe(tmp_path, recipe)
     with pytest.raises(CompilerError, match="not valid Texture2D content"):
         _compile(tmp_path)
@@ -155,8 +187,10 @@ def test_rejects_a_truncated_png_with_valid_magic_and_iend(tmp_path):
 def test_rejects_a_minimal_sfnt_without_required_font_tables(tmp_path):
     # The former bounds-only parser accepted this single empty cmap record.
     fake_sfnt = b"\x00\x01\x00\x00" + struct.pack(">HHHH", 1, 0, 0, 0) + b"cmap" + struct.pack(">III", 0, 28, 0)
-    (tmp_path / "fake.ttf").write_bytes(fake_sfnt)
-    recipe = _recipe(fonts=[{"type": "Button", "name": "font", "value": {"type": "FontFile", "path": "res://fake.ttf"}}])
+    target = tmp_path / "assets/generated/ui-kit/main/fake.ttf"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(fake_sfnt)
+    recipe = _recipe(fonts=[{"type": "Button", "name": "font", "value": {"type": "FontFile", "path": "res://assets/generated/ui-kit/main/fake.ttf"}}])
     _write_recipe(tmp_path, recipe)
     with pytest.raises(CompilerError, match="not valid FontFile content"):
         _compile(tmp_path)

--- a/tests/assets/test_tileset_compiler.py
+++ b/tests/assets/test_tileset_compiler.py
@@ -177,9 +177,40 @@ def test_tileset_builder_accepts_json_integer_float_tile_shape(godot_bin, godot_
             "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0]}]}],
         },
     )
-    compiler.compile_tileset(request)
+    registry = CompilerRegistry()
+    compiler.register_into(registry)
+    registry.compile(request)
     report = GodotProbe(godot_bin).probe(godot_project, [ProbeRequest(request.artifact_path, "TileSet", ("tileset",))])
     assert report.resources[0].structure["tileset"]["tile_shape"] == 3
+
+
+def test_tileset_l4_accepts_omitted_animation_defaults(godot_bin, godot_project):
+    source = godot_project / "assets/generated/tileset/grass/atlas.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(_png(16, 16))
+    request = CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/defaults.tres", project_root=godot_project,
+        spec={
+            "godot_path": godot_bin, "tile_size": [16, 16],
+            "sources": [{
+                "texture": "res://assets/generated/tileset/grass/atlas.png",
+                "tiles": [{"coords": [0, 0], "animation": {"frames_count": 1}}],
+            }],
+        },
+    )
+    registry = CompilerRegistry()
+    compiler.register_into(registry)
+    registry.compile(request)
+    report = GodotProbe(godot_bin).probe(
+        godot_project, [ProbeRequest(request.artifact_path, "TileSet", ("tileset",))]
+    )
+    structures.validate_tileset(StructureRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path=request.source_path, artifact_type="TileSet", artifact_path=request.artifact_path,
+        project_root=godot_project, probe=report.resources[0], spec=request.spec,
+    ))
 
 
 def test_orthogonal_fixture_compiles_and_loads_through_godot(godot_bin, godot_project):
@@ -203,7 +234,7 @@ def test_orthogonal_fixture_compiles_and_loads_through_godot(godot_bin, godot_pr
             "navigation_layers": [{}],
             "occlusion_layers": [{}],
             "custom_data_layers": [{"name": "kind", "type": 4}],
-            "terrain_sets": [{"terrains": [{"name": "grass", "color": [0.2, 0.8, 0.3]}]}],
+            "terrain_sets": [{"terrains": [{"name": "grass", "color": [0, 1, 0]}]}],
             "sources": [{
                 "id": 3,
                 "texture": "res://assets/generated/tileset/grass/atlas.png",
@@ -220,7 +251,7 @@ def test_orthogonal_fixture_compiles_and_loads_through_godot(godot_bin, godot_pr
                     "occlusion_polygons": [{"layer": 0, "points": [[0, 0], [16, 0], [16, 16]]}],
                     "navigation_polygons": [{"layer": 0, "points": [[0, 0], [16, 0], [16, 16]]}],
                     "alternatives": [{"id": 1, "z_index": 2, "custom_data": [{"layer": 0, "value": "alt"}]}],
-                    "animation": {"mode": "default", "columns": 1, "frames_count": 1, "speed": 1.0, "frame_durations": [{"frame": 0, "duration": 1.0}]},
+                    "animation": {"mode": "default", "columns": 1, "frames_count": 1, "separation": [0, 0], "speed": 1.0, "frame_durations": [{"frame": 0, "duration": 1.0}]},
                 }],
             }],
         },
@@ -231,6 +262,11 @@ def test_orthogonal_fixture_compiles_and_loads_through_godot(godot_bin, godot_pr
     report = GodotProbe(godot_bin).probe(godot_project, [ProbeRequest(request.artifact_path, "TileSet", ("tileset",))])
     assert report.resources[0].type_matches is True
     assert report.resources[0].structure["tileset"]["sources"][0]["id"] == 3
+    loaded_tile = report.resources[0].structure["tileset"]["sources"][0]["tiles"][0]
+    assert loaded_tile["custom_data"] == ["grass"]
+    assert loaded_tile["collision_polygons"] == [[[[0, 0], [16, 0], [16, 16]]]]
+    assert loaded_tile["occlusion_polygons"] == [[[[0, 0], [16, 0], [16, 16]]]]
+    assert loaded_tile["navigation_polygons"] == [[[0, 0], [16, 0], [16, 16]]]
     binding_script = godot_project / "bind_fixture.gd"
     binding_script.write_text(
         "extends SceneTree\nfunc _init():\n\tvar scene = load('res://orthogonal_tileset_tilemap.tscn').instantiate()\n\tscene.get_node('TileMap').tile_set = load('res://assets/generated/tileset/grass/grass.tres')\n\tquit()\n",

--- a/tests/assets/test_tileset_compiler.py
+++ b/tests/assets/test_tileset_compiler.py
@@ -167,7 +167,7 @@ def test_tileset_builder_failure_preserves_existing_artifact(godot_bin, godot_pr
 def test_tileset_builder_accepts_json_integer_float_tile_shape(godot_bin, godot_project):
     source = godot_project / "assets/generated/tileset/grass/atlas.png"
     source.parent.mkdir(parents=True)
-    source.write_bytes(_png(16, 16))
+    source.write_bytes(_png(32, 16))
     request = CompileRequest(
         production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
         source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
@@ -213,6 +213,52 @@ def test_tileset_l4_accepts_omitted_animation_defaults(godot_bin, godot_project)
     ))
 
 
+def test_tileset_l4_accepts_float32_round_trips(godot_bin, godot_project):
+    source = godot_project / "assets/generated/tileset/grass/atlas.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(_png(32, 16))
+    request = CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/float32.tres", project_root=godot_project,
+        spec={
+            "godot_path": godot_bin, "tile_size": [16, 16],
+            "terrain_sets": [{"terrains": [{"name": "grass", "color": [0.2, 0.8, 0.3]}]}],
+            "sources": [{
+                "texture": "res://assets/generated/tileset/grass/atlas.png",
+                "region_size": [16, 16],
+                "tiles": [{
+                    "coords": [0, 0], "probability": 0.3,
+                    "animation": {
+                        "columns": 2, "frames_count": 2, "speed": 1.3,
+                        "frame_durations": [
+                            {"frame": 0, "duration": 0.1},
+                            {"frame": 1, "duration": 0.9},
+                        ],
+                    },
+                }],
+            }],
+        },
+    )
+    registry = CompilerRegistry()
+    compiler.register_into(registry)
+    registry.compile(request)
+    report = GodotProbe(godot_bin).probe(
+        godot_project, [ProbeRequest(request.artifact_path, "TileSet", ("tileset",))]
+    )
+    facts = report.resources[0].structure["tileset"]
+    loaded_tile = facts["sources"][0]["tiles"][0]
+    assert loaded_tile["probability"] == pytest.approx(0.3, abs=1e-6)
+    assert loaded_tile["animation"]["speed"] == pytest.approx(1.3, abs=1e-6)
+    assert loaded_tile["animation"]["frame_durations"] == pytest.approx([0.1, 0.9], abs=1e-6)
+    assert facts["terrain_sets"][0]["terrains"][0]["color"] == pytest.approx([0.2, 0.8, 0.3, 1.0], abs=1e-6)
+    structures.validate_tileset(StructureRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path=request.source_path, artifact_type="TileSet", artifact_path=request.artifact_path,
+        project_root=godot_project, probe=report.resources[0], spec=request.spec,
+    ))
+
+
 def test_orthogonal_fixture_compiles_and_loads_through_godot(godot_bin, godot_project):
     """Real compiler → ResourceLoader coverage for the v1 square atlas path."""
     fixture = REPO_ROOT / "tests" / "assets" / "fixtures" / "orthogonal_tileset_tilemap.tscn"
@@ -234,7 +280,7 @@ def test_orthogonal_fixture_compiles_and_loads_through_godot(godot_bin, godot_pr
             "navigation_layers": [{}],
             "occlusion_layers": [{}],
             "custom_data_layers": [{"name": "kind", "type": 4}],
-            "terrain_sets": [{"terrains": [{"name": "grass", "color": [0, 1, 0]}]}],
+            "terrain_sets": [{"terrains": [{"name": "grass", "color": [0.2, 0.8, 0.3]}]}],
             "sources": [{
                 "id": 3,
                 "texture": "res://assets/generated/tileset/grass/atlas.png",

--- a/tests/assets/test_tileset_compiler.py
+++ b/tests/assets/test_tileset_compiler.py
@@ -116,6 +116,29 @@ def test_tileset_recipe_rejects_unknown_enums_and_invalid_colours(recipe, messag
         compiler.compile_tileset(request)
 
 
+@pytest.mark.parametrize("alternative", [False, True])
+def test_tileset_recipe_rejects_duplicate_navigation_polygon_layers(tmp_path, alternative):
+    tile = {"coords": [0, 0]}
+    polygons = [
+        {"layer": 0, "points": [[0, 0], [16, 0], [0, 16]]},
+        {"layer": 0, "points": [[1, 1], [15, 1], [1, 15]]},
+    ]
+    if alternative:
+        tile["alternatives"] = [{"id": 1, "navigation_polygons": polygons}]
+    else:
+        tile["navigation_polygons"] = polygons
+    request = CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/grass.tres", project_root=tmp_path,
+        spec=_spec(navigation_layers=[{}], sources=[{
+            "texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [tile],
+        }]),
+    )
+    with pytest.raises(CompilerError, match="duplicate navigation polygons"):
+        compiler._recipe(request)
+
+
 def _png(width: int, height: int) -> bytes:
     def chunk(tag, data):
         return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
@@ -259,6 +282,93 @@ def test_tileset_l4_accepts_float32_round_trips(godot_bin, godot_project):
         source_path=request.source_path, artifact_type="TileSet", artifact_path=request.artifact_path,
         project_root=godot_project, probe=report.resources[0], spec=request.spec,
     ))
+
+
+def test_tileset_real_godot_handles_multiple_sources_defaults_and_polygon_float32(godot_bin, godot_project):
+    for name in ("first", "second"):
+        source = godot_project / f"assets/generated/tileset/grass/{name}.png"
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_bytes(_png(32, 16))
+    integer_points = [[0, 0], [16, 0], [0, 16]]
+    decimal_points = [[0.3, 0.7], [15.5, 0.7], [0.3, 15.2]]
+    request = CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/first.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/matrix.tres", project_root=godot_project,
+        spec={
+            "godot_path": godot_bin, "tile_size": [16, 16],
+            "physics_layers": [{}], "navigation_layers": [{}], "occlusion_layers": [{}],
+            "custom_data_layers": [
+                {"name": "enabled", "type": 1}, {"name": "count", "type": 2},
+                {"name": "weight", "type": 3}, {"name": "label", "type": 4},
+            ],
+            "terrain_sets": [{"terrains": [{"name": "grass"}]}],
+            "sources": [
+                {"id": 3, "texture": "res://assets/generated/tileset/grass/first.png", "region_size": [16, 16], "tiles": [
+                    {"coords": [0, 0], "terrain_set": 0, "terrain": 0,
+                     "custom_data": [{"layer": 0, "value": True}],
+                     "collision_polygons": [{"layer": 0, "points": integer_points}],
+                     "occlusion_polygons": [{"layer": 0, "points": integer_points}],
+                     "navigation_polygons": [{"layer": 0, "points": integer_points}]},
+                    {"coords": [1, 0]},
+                ]},
+                {"id": 4, "texture": "res://assets/generated/tileset/grass/second.png", "region_size": [16, 16], "tiles": [
+                    {"coords": [0, 0], "terrain_set": 0, "terrain": 0,
+                     "alternatives": [{"id": 1, "terrain_set": 0, "terrain": 0,
+                         "custom_data": [{"layer": 3, "value": "alt"}],
+                         "collision_polygons": [{"layer": 0, "points": decimal_points}],
+                         "occlusion_polygons": [{"layer": 0, "points": decimal_points}],
+                         "navigation_polygons": [{"layer": 0, "points": decimal_points}]}]},
+                    {"coords": [1, 0]},
+                ]},
+            ],
+        },
+    )
+    registry = CompilerRegistry()
+    compiler.register_into(registry)
+    registry.compile(request)
+    report = GodotProbe(godot_bin).probe(
+        godot_project, [ProbeRequest(request.artifact_path, "TileSet", ("tileset",))]
+    )
+    facts = report.resources[0].structure["tileset"]
+    assert facts["source_count"] == 2
+    assert [len(source["tiles"]) for source in facts["sources"]] == [2, 2]
+    assert facts["sources"][0]["tiles"][1]["custom_data"] == [False, 0, 0.0, ""]
+    alternative = facts["sources"][1]["tiles"][0]["alternatives"][0]
+    assert alternative["custom_data"] == [False, 0, 0.0, "alt"]
+    assert alternative["collision_polygons"][0][0][0] == pytest.approx([0.3, 0.7], abs=1e-6)
+    structures.validate_tileset(StructureRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path=request.source_path, artifact_type="TileSet", artifact_path=request.artifact_path,
+        project_root=godot_project, probe=report.resources[0], spec=request.spec,
+    ))
+    alternative["collision_polygons"][0][0][0] = [0.7, 0.7]
+    with pytest.raises(ValidationError, match="alternative data"):
+        structures.validate_tileset(StructureRequest(
+            production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+            source_path=request.source_path, artifact_type="TileSet", artifact_path=request.artifact_path,
+            project_root=godot_project, probe=report.resources[0], spec=request.spec,
+        ))
+
+
+def test_compile_tileset_does_not_mutate_nested_spec_across_direct_calls(godot_bin, godot_project):
+    source = godot_project / "assets/generated/tileset/grass/atlas.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(_png(16, 16))
+    request = CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/stable.tres", project_root=godot_project,
+        spec={"godot_path": godot_bin, "tile_size": [16, 16], "sources": [{
+            "texture": "res://assets/generated/tileset/grass/atlas.png",
+            "tiles": [{"coords": [0, 0], "animation": {"mode": "random_start_times", "frames_count": 1}}],
+        }]},
+    )
+    compiler.compile_tileset(request)
+    compiler.compile_tileset(request)
+    assert request.spec["sources"][0]["tiles"][0]["animation"] == {
+        "mode": "random_start_times", "frames_count": 1,
+    }
 
 
 def test_orthogonal_fixture_compiles_and_loads_through_godot(godot_bin, godot_project):

--- a/tests/assets/test_tileset_compiler.py
+++ b/tests/assets/test_tileset_compiler.py
@@ -236,6 +236,7 @@ def test_tileset_l4_accepts_float32_round_trips(godot_bin, godot_project):
                             {"frame": 1, "duration": 0.9},
                         ],
                     },
+                    "alternatives": [{"id": 1, "probability": 0.3}],
                 }],
             }],
         },
@@ -251,6 +252,7 @@ def test_tileset_l4_accepts_float32_round_trips(godot_bin, godot_project):
     assert loaded_tile["probability"] == pytest.approx(0.3, abs=1e-6)
     assert loaded_tile["animation"]["speed"] == pytest.approx(1.3, abs=1e-6)
     assert loaded_tile["animation"]["frame_durations"] == pytest.approx([0.1, 0.9], abs=1e-6)
+    assert loaded_tile["alternatives"][0]["probability"] == pytest.approx(0.3, abs=1e-6)
     assert facts["terrain_sets"][0]["terrains"][0]["color"] == pytest.approx([0.2, 0.8, 0.3, 1.0], abs=1e-6)
     structures.validate_tileset(StructureRequest(
         production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",

--- a/tests/assets/test_tileset_compiler.py
+++ b/tests/assets/test_tileset_compiler.py
@@ -122,6 +122,66 @@ def _png(width: int, height: int) -> bytes:
     return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, 6, 0, 0, 0)) + chunk(b"IDAT", zlib.compress(b"".join(b"\0" + b"\xff\xff\xff\xff" * width for _ in range(height)))) + chunk(b"IEND", b"")
 
 
+def test_tileset_compiler_imports_before_running_the_builder(tmp_path, monkeypatch):
+    request = CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/grass.tres", project_root=tmp_path,
+        spec=_spec(),
+    )
+    calls = []
+
+    class Result:
+        returncode = 0
+        stderr = ""
+        stdout = ""
+
+    def fake_run(args, **_kwargs):
+        calls.append(args)
+        return Result()
+
+    monkeypatch.setattr(compiler.subprocess, "run", fake_run)
+    assert compiler.compile_tileset(request) == {"sources": 1, "tile_size": [16, 16]}
+    assert calls[0][-1] == "--import"
+    assert "--script" in calls[1]
+
+
+def test_tileset_builder_failure_preserves_existing_artifact(godot_bin, godot_project):
+    artifact = godot_project / "assets/generated/tileset/grass/grass.tres"
+    artifact.parent.mkdir(parents=True)
+    artifact.write_bytes(b"previous-good-artifact")
+    request = CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/missing.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/grass.tres", project_root=godot_project,
+        spec={
+            "godot_path": godot_bin, "tile_size": [16, 16],
+            "sources": [{"texture": "res://assets/generated/tileset/grass/missing.png", "tiles": [{"coords": [0, 0]}]}],
+        },
+    )
+    with pytest.raises(CompilerError, match="TileSet Godot compiler failed"):
+        compiler.compile_tileset(request)
+    assert artifact.read_bytes() == b"previous-good-artifact"
+
+
+def test_tileset_builder_accepts_json_integer_float_tile_shape(godot_bin, godot_project):
+    source = godot_project / "assets/generated/tileset/grass/atlas.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(_png(16, 16))
+    request = CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/hex.tres", project_root=godot_project,
+        spec={
+            "godot_path": godot_bin, "tile_shape": "hexagon", "tile_size": [16, 16],
+            "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0]}]}],
+        },
+    )
+    compiler.compile_tileset(request)
+    report = GodotProbe(godot_bin).probe(godot_project, [ProbeRequest(request.artifact_path, "TileSet", ("tileset",))])
+    assert report.resources[0].structure["tileset"]["tile_shape"] == 3
+
+
 def test_orthogonal_fixture_compiles_and_loads_through_godot(godot_bin, godot_project):
     """Real compiler → ResourceLoader coverage for the v1 square atlas path."""
     fixture = REPO_ROOT / "tests" / "assets" / "fixtures" / "orthogonal_tileset_tilemap.tscn"

--- a/tests/assets/test_tileset_skill_contract.py
+++ b/tests/assets/test_tileset_skill_contract.py
@@ -14,7 +14,7 @@ sys.path.insert(0, str(SKILL_DIR))
 
 from asset_compiler import CompileRequest, CompilerError  # noqa: E402
 from asset_compiler import tileset as compiler  # noqa: E402
-from asset_validation import ProbeReport, ProbeResult  # noqa: E402
+from asset_validation import ProbeReport, ProbeResult, ValidationError  # noqa: E402
 from asset_validation.godot_probe import GodotProbe  # noqa: E402
 from standalone_validation import TileSetSkillError, compile_and_validate  # noqa: E402
 
@@ -27,7 +27,7 @@ def test_tileset_skill_is_standalone_and_reuses_shared_contracts():
     text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
     assert text.startswith("---\nname: tileset\n")
     for shared_path in (
-        "skills/assets/_shared/asset-skill-contract.md",
+        ".godotmaker/asset-runtime/asset-skill-contract.md",
         "asset_compiler.tileset.register_into()",
         "asset_validation.tileset.register_into()",
         "standalone_validation.compile_and_validate()",
@@ -199,6 +199,36 @@ def test_standalone_runner_maps_a_godot_setup_failure_to_l3(tmp_path, monkeypatc
         "L0": True, "L1": True, "L2": True, "L3": False, "L4": False,
     }
     assert "godot_path must be a non-empty string" in validated["validation"]["notes"]
+
+
+def test_standalone_runner_reports_l1_before_an_l2_validation_error(tmp_path, monkeypatch):
+    request = {
+        "asset_type": "tileset",
+        "asset_id": "grassland",
+        "brief": "A grassland tile atlas.",
+        "spec": _fixture(),
+    }
+    source_path = "res://assets/generated/tileset/grassland/grassland_atlas.png"
+    source = tmp_path / source_path.removeprefix("res://")
+    source.parent.mkdir(parents=True)
+    source.write_bytes(b"png")
+    result = {
+        "asset_type": "tileset",
+        "outputs": [{"role": "runtime", "path": "res://assets/generated/tileset/grassland/grassland.tres", "godot_type": "TileSet"}],
+        "sources": [{"path": source_path, "layout": "tile_atlas"}],
+        "previews": [],
+        "validation": {"passed": False},
+    }
+
+    def fail_compile(_request):
+        raise ValidationError("compiler result disagrees with request")
+
+    monkeypatch.setattr(compiler, "compile_tileset", fail_compile)
+    validated = compile_and_validate(request, result, project_root=tmp_path, godot_path="godot")
+
+    assert validated["validation"]["levels"] == {
+        "L0": True, "L1": True, "L2": False, "L3": False, "L4": False,
+    }
 
 
 def test_standalone_runner_rejects_an_unvalidated_extra_runtime_output(tmp_path):

--- a/tests/assets/test_ui_card_skill_contract.py
+++ b/tests/assets/test_ui_card_skill_contract.py
@@ -119,9 +119,17 @@ def _good_probe(request: dict, result: dict, *, theme_variation: str | None = No
         resources = []
         for item in requests:
             if item.expected_type == "Theme":
-                structure = {"theme": {"types": {variation: {
+                button = {
+                    "variation_base": "", "colors": ["font_color"], "font_sizes": [],
+                    "constants": [], "fonts": [], "icons": [], "styles": [],
+                    "color_values": {"font_color": [1.0, 1.0, 1.0, 1.0]},
+                    "font_size_values": {}, "constant_values": {}, "font_paths": {}, "icon_paths": {},
+                }
+                structure = {"theme": {"types": {"Button": button, variation: {
                     "variation_base": "Button", "colors": ["font_color"], "font_sizes": [],
                     "constants": [], "fonts": [], "icons": [], "styles": [],
+                    "color_values": {"font_color": [1.0, 1.0, 1.0, 1.0]},
+                    "font_size_values": {}, "constant_values": {}, "font_paths": {}, "icon_paths": {},
                 }}}}
             elif item.expected_type == "StyleBoxTexture":
                 structure = {"stylebox_texture": {

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -1012,6 +1012,35 @@ class TestPublishedAssetRuntime:
         assert (runtime / "asset_validation" / "ladder.py").exists()
         assert not (target / skill_root / "_shared").exists()
 
+    @pytest.mark.parametrize(
+        "publish_project,skill_root",
+        [
+            (_publish_claude_project, ".claude/skills"),
+            (_publish_codex_project, ".agents/skills"),
+            (_publish_opencode_project, ".opencode/skills"),
+        ],
+    )
+    def test_published_asset_skills_reference_existing_runtime_paths(
+        self, tmp_path, monkeypatch, publish_project, skill_root
+    ):
+        result = publish_project(tmp_path, monkeypatch)
+        target = result[0] if isinstance(result, tuple) else result
+        asset_skills = [
+            path.name for path in (REPO_ROOT / "skills" / "assets").iterdir()
+            if path.is_dir() and not path.name.startswith("_")
+        ]
+
+        for skill_name in asset_skills:
+            content = (target / skill_root / skill_name / "SKILL.md").read_text(encoding="utf-8")
+            assert "skills/assets/_shared" not in content
+            assert "../_shared" not in content
+            references = re.findall(r"`(\.godotmaker/asset-runtime/[^`]+)`", content)
+            assert references, f"{skill_name} must reference the published asset runtime"
+            for reference in references:
+                assert (target / reference).exists(), (
+                    f"{skill_name} references a missing published runtime path: {reference}"
+                )
+
     def test_published_runtime_imports_without_the_source_checkout(self, tmp_path):
         target = tmp_path / "target"
         publish_asset_runtime(REPO_ROOT, target)


### PR DESCRIPTION
## Summary

- Repair real-Godot probe typing, Theme variations and TileSet compile failure propagation.
- Import TileSet PNGs before building, harden Theme resource containment, and repair standalone level reporting.
- Preserve TileSet per-layer data; validate declared Theme values; and make Godot float32 round trips explicit at their family-specific L4 boundaries.
- Point published asset-skill references at the project-local runtime and cover Claude, Codex, and OpenCode publication.

## Motivation

Fix correctness defects surfaced by real-Godot validation of the asset compiler and Asset Skill work, including TileSet default-value drift, silent layer-data loss, and valid decimal values rejected after Godot stores them as float32.

## Changes

- [x] Fix GDScript type inference failures in the Godot validation probe (`probe.gd`)
- [x] Fix Theme variation property name (`base_type` instead of `variation_base`)
- [x] Verify final Theme colors, constants, font sizes, fonts, icons, StyleBoxes, and type variations
- [x] Propagate TileSet compiler failures instead of silently saving an empty resource
- [x] Accept mathematically-integer JSON floats for TileSet `tile_shape`
- [x] Import newly generated PNGs before building TileSets
- [x] Align TileSet L4 animation defaults with compilation while keeping `frames_count` required
- [x] Register TileSet atlas sources before writing per-layer TileData
- [x] Match TileSet custom-data zero defaults and reject duplicate navigation layers
- [x] Accept finite float32 round trips for TileSet polygon points, terrain colors, probabilities, animation timings, StyleBoxTexture expand margins, and SpriteFrames durations
- [x] Keep TileSet direct compiler calls input-stable across repeated builds
- [x] Fix TileSet standalone validation level reporting and error handling
- [x] Harden Theme `res://` path resolution against absolute-path and traversal escapes
- [x] Point published Asset Skill docs at the project-local runtime path

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable

Evidence:

- Real Godot 4.4 regressions cover a FontFile-backed Theme, region-atlas StyleBoxTexture, SpriteFrames decimal durations, and multi-source/multi-tile TileSet alternatives with custom data, terrain, and all polygon layer kinds: 5 passed, no skips.
- Related compiler/L3/L4 suites: 87 passed, 1 existing skip.
- Full `python -m pytest` with `GODOT_PATH` set to Godot 4.4: 1934 passed, 7 skipped.
- `python -m ruff check .` and `git diff --check`: passed.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold `migrations/<utc-timestamp>_<slug>.py`. The script must define `migrate(target: Path) -> None` and be idempotent. The bump level does NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>` — N/A, no migration script changed
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"` — N/A, no migration script changed
- [ ] Post-upgrade on-disk state was inspected and matches expectations — N/A, no migration script changed
- [ ] Re-running `tools/publish.py` produces no further migration changes — N/A, no migration script changed
- [ ] Result attached or summarized below — N/A, no migration script changed

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable — N/A, no ECS systems touched
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
