### PR TITLE
Contain Theme L4 recipe paths

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -52,6 +52,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Theme L4 validation now rejects recipe paths outside the declaring asset's stable output directory.
 - Restored real Godot validation for Theme and TileSet assets, including safe Theme resource paths and imported TileSet atlases.
 - Reference-only stable entries now accept only `pending`, `source_ready`, or `failed`; only registered `source_ready` entries may promote ASSETS.md reference rows.
 - Existing reference entries persisted as `compiled` or `ready` must be manually corrected to `source_ready` before root-index validation; no migration or compatibility reader is provided.

--- a/skills/assets/_shared/asset_compiler/theme.py
+++ b/skills/assets/_shared/asset_compiler/theme.py
@@ -532,9 +532,8 @@ def validate_theme_structure(request: Any) -> dict[str, Any]:
             declared_items += len(values)
     if declared_items == 0:
         raise ValidationError("the loaded Theme has no declared Theme items")
-    recipe_path = request.project_root / request.source_path.removeprefix("res://")
     try:
-        recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+        recipe = json.loads(request.source_file().read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
         raise ValidationError(f"cannot read Theme recipe for L4 value validation: {exc}") from exc
     if not isinstance(recipe, Mapping):

--- a/skills/assets/_shared/asset_compiler/theme.py
+++ b/skills/assets/_shared/asset_compiler/theme.py
@@ -534,7 +534,7 @@ def validate_theme_structure(request: Any) -> dict[str, Any]:
         raise ValidationError("the loaded Theme has no declared Theme items")
     try:
         recipe = json.loads(request.source_file().read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, ValueError) as exc:
         raise ValidationError(f"cannot read Theme recipe for L4 value validation: {exc}") from exc
     if not isinstance(recipe, Mapping):
         raise ValidationError("Theme recipe for L4 value validation is malformed")

--- a/skills/assets/_shared/asset_validation/_bridge.py
+++ b/skills/assets/_shared/asset_validation/_bridge.py
@@ -55,6 +55,7 @@ from asset_stable_entry import (  # noqa: E402
     REFERENCE_LAYOUTS,
     StableEntryError,
     assert_within_output_dir,
+    check_output_path,
     validate_entry,
 )
 from asset_compiler._stable_entry import resolve_res_path  # noqa: E402
@@ -69,6 +70,7 @@ __all__ = [
     "StableEntryError",
     "assert_within_output_dir",
     "build_default_registry",
+    "check_output_path",
     "is_same_file",
     "prefer_console_godot_path",
     "resolve_res_path",

--- a/skills/assets/_shared/asset_validation/structure.py
+++ b/skills/assets/_shared/asset_validation/structure.py
@@ -34,6 +34,12 @@ from ._bridge import LAYOUT_ARTIFACT_TYPES
 from .contract import ValidationError
 from .godot_probe import PROBE_CHECKS, ProbeResult
 from asset_compiler.atlas_texture import read_atlas_texture_input
+from asset_compiler._stable_entry import (
+    StableEntryError,
+    assert_within_output_dir,
+    check_output_path,
+    resolve_res_path,
+)
 from asset_compiler.stylebox_texture import read_stylebox_texture_input
 
 # Every artifact type the frozen stable-entry relation allows. A validator for a
@@ -59,6 +65,33 @@ class StructureRequest:
     project_root: Path
     probe: ProbeResult
     spec: Mapping[str, Any] = field(default_factory=dict)
+
+    def source_file(self) -> Path:
+        """Resolve the declared source under its stable output directory.
+
+        L4 validators may need to read their source recipe independently of the
+        ladder.  Keep that read behind the same ``res://`` and on-disk
+        containment checks as compiler input so a direct validator call cannot
+        use a traversal, absolute path, or escaping symlink.
+        """
+        try:
+            check_output_path(
+                self.source_path,
+                production_family=self.production_family,
+                asset_id=self.asset_id,
+                label="source_path",
+            )
+            return assert_within_output_dir(
+                self.project_root,
+                resolve_res_path(self.project_root, self.source_path, label="source_path"),
+                production_family=self.production_family,
+                asset_id=self.asset_id,
+                label="source_path",
+            )
+        except (AttributeError, OSError, StableEntryError, TypeError, ValueError) as exc:
+            raise ValidationError(
+                f"source_path cannot be resolved: {self.source_path!r} ({exc})"
+            ) from exc
 
     def checked_structure(self, check: str) -> Mapping[str, Any]:
         """Return the facts Godot collected for one check, or fail closed.

--- a/skills/assets/_shared/asset_validation/structure.py
+++ b/skills/assets/_shared/asset_validation/structure.py
@@ -30,16 +30,16 @@ import math
 from pathlib import Path
 from typing import Any, Callable
 
-from ._bridge import LAYOUT_ARTIFACT_TYPES
-from .contract import ValidationError
-from .godot_probe import PROBE_CHECKS, ProbeResult
-from asset_compiler.atlas_texture import read_atlas_texture_input
-from asset_compiler._stable_entry import (
+from ._bridge import (
+    LAYOUT_ARTIFACT_TYPES,
     StableEntryError,
     assert_within_output_dir,
     check_output_path,
     resolve_res_path,
 )
+from .contract import ValidationError
+from .godot_probe import PROBE_CHECKS, ProbeResult
+from asset_compiler.atlas_texture import read_atlas_texture_input
 from asset_compiler.stylebox_texture import read_stylebox_texture_input
 
 # Every artifact type the frozen stable-entry relation allows. A validator for a
@@ -88,7 +88,7 @@ class StructureRequest:
                 asset_id=self.asset_id,
                 label="source_path",
             )
-        except (AttributeError, OSError, StableEntryError, TypeError, ValueError) as exc:
+        except (OSError, StableEntryError, ValueError) as exc:
             raise ValidationError(
                 f"source_path cannot be resolved: {self.source_path!r} ({exc})"
             ) from exc

--- a/tests/assets/test_theme_compiler.py
+++ b/tests/assets/test_theme_compiler.py
@@ -10,6 +10,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "skills" / "assets" / "_shared"))
 
 from asset_compiler import CompileRequest, CompilerError, build_default_registry, theme  # noqa: E402
+from asset_validation import ProbeResult, ValidationError  # noqa: E402
+from asset_validation.structure import StructureRequest  # noqa: E402
 
 
 def _recipe(**overrides):
@@ -57,6 +59,39 @@ def _compile(root: Path):
     return registry.compile(_request(root))
 
 
+def _structure_request(root: Path, *, source_path="res://assets/generated/ui-kit/main/main.json"):
+    button = {
+        "variation_base": "",
+        "colors": ["font_color"], "font_sizes": ["font_size"], "constants": ["outline_size"],
+        "fonts": [], "icons": [], "styles": ["normal"],
+        "color_values": {"font_color": [1.0, 1.0, 1.0, 1.0]},
+        "font_size_values": {"font_size": 18}, "constant_values": {"outline_size": 1},
+        "font_paths": {}, "icon_paths": {},
+        "styleboxes": {"normal": {"class": "StyleBoxFlat", "properties": {
+            "bg_color": [16 / 255, 32 / 255, 48 / 255, 1.0],
+            "corner_radius": [8, 8, 8, 8],
+        }}},
+    }
+    variation = {**button, "variation_base": "Button"}
+    return StructureRequest(
+        production_family="ui-kit",
+        asset_id="main",
+        source_layout_type="theme_recipe",
+        source_path=source_path,
+        artifact_type="Theme",
+        artifact_path="res://assets/generated/ui-kit/main/main.tres",
+        project_root=root,
+        probe=ProbeResult(
+            res_path="res://assets/generated/ui-kit/main/main.tres",
+            expected_type="Theme",
+            loaded=True,
+            godot_class="Theme",
+            type_matches=True,
+            structure={"theme": {"types": {"Button": button, "PrimaryButton": variation}}},
+        ),
+    )
+
+
 def test_compiles_a_complete_theme_with_a_variation_deterministically(tmp_path):
     _write_recipe(tmp_path, _recipe())
     first = _compile(tmp_path)
@@ -69,6 +104,45 @@ def test_compiles_a_complete_theme_with_a_variation_deterministically(tmp_path):
     assert 'PrimaryButton/base_type = &"Button"' in text
     assert "Button/colors/font_color = Color(1, 1, 1, 1)" in text
     assert 'Button/styles/normal = SubResource("StyleBox_button_normal")' in text
+
+
+def test_structure_validation_reads_a_valid_recipe_through_the_safe_resolver(tmp_path):
+    _write_recipe(tmp_path, _recipe())
+
+    details = theme.validate_theme_structure(_structure_request(tmp_path))
+
+    assert details["variations"] == ["PrimaryButton"]
+
+
+@pytest.mark.parametrize("source_path", [
+    "res://assets/generated/ui-kit/main/../outside.json",
+    "res:///outside.json",
+    "C:/outside.json",
+])
+def test_structure_validation_rejects_unsafe_recipe_paths_before_reading(tmp_path, source_path):
+    _write_recipe(tmp_path, _recipe())
+
+    with pytest.raises(ValidationError, match="source_path cannot be resolved"):
+        theme.validate_theme_structure(_structure_request(tmp_path, source_path=source_path))
+
+
+def test_structure_validation_rejects_recipe_symlink_escape_before_reading(tmp_path):
+    outside = tmp_path.parent / "outside-theme-recipe.json"
+    outside.write_text(json.dumps(_recipe()), encoding="utf-8")
+    source = tmp_path / "assets/generated/ui-kit/main/main.json"
+    source.parent.mkdir(parents=True)
+    try:
+        source.symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are not permitted on this platform")
+
+    with pytest.raises(ValidationError, match="source_path cannot be resolved"):
+        theme.validate_theme_structure(_structure_request(tmp_path))
+
+
+def test_structure_validation_normalizes_a_missing_recipe_file(tmp_path):
+    with pytest.raises(ValidationError, match="cannot read Theme recipe"):
+        theme.validate_theme_structure(_structure_request(tmp_path))
 
 
 def test_serializes_stylebox_flat_border_width_to_its_real_edge_properties(tmp_path):

--- a/tests/assets/test_theme_compiler.py
+++ b/tests/assets/test_theme_compiler.py
@@ -1,6 +1,7 @@
 """Contract tests for the deterministic JSON Theme compiler."""
 import json
 import struct
+import subprocess
 import sys
 from pathlib import Path
 
@@ -47,8 +48,8 @@ def _request(root: Path):
     )
 
 
-def _write_recipe(root: Path, recipe):
-    path = root / "assets/generated/ui-kit/main/main.json"
+def _write_recipe(root: Path, recipe, *, source_path="res://assets/generated/ui-kit/main/main.json"):
+    path = root / source_path.removeprefix("res://")
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(recipe), encoding="utf-8")
 
@@ -72,7 +73,10 @@ def _structure_request(root: Path, *, source_path="res://assets/generated/ui-kit
             "corner_radius": [8, 8, 8, 8],
         }}},
     }
-    variation = {**button, "variation_base": "Button"}
+    variation = {
+        "variation_base": "Button",
+        "colors": [], "font_sizes": [], "constants": [], "fonts": [], "icons": [], "styles": [],
+    }
     return StructureRequest(
         production_family="ui-kit",
         asset_id="main",
@@ -106,12 +110,26 @@ def test_compiles_a_complete_theme_with_a_variation_deterministically(tmp_path):
     assert 'Button/styles/normal = SubResource("StyleBox_button_normal")' in text
 
 
-def test_structure_validation_reads_a_valid_recipe_through_the_safe_resolver(tmp_path):
+def test_structure_validation_reads_and_compares_the_declared_recipe_through_the_safe_resolver(tmp_path):
     _write_recipe(tmp_path, _recipe())
 
     details = theme.validate_theme_structure(_structure_request(tmp_path))
 
     assert details["variations"] == ["PrimaryButton"]
+    changed = _recipe()
+    changed["font_sizes"][0]["value"] = 19
+    _write_recipe(
+        tmp_path,
+        changed,
+        source_path="res://assets/generated/ui-kit/main/alternate.json",
+    )
+    with pytest.raises(ValidationError, match="loaded Theme font_sizes item does not match the recipe"):
+        theme.validate_theme_structure(
+            _structure_request(
+                tmp_path,
+                source_path="res://assets/generated/ui-kit/main/alternate.json",
+            )
+        )
 
 
 @pytest.mark.parametrize("source_path", [
@@ -126,18 +144,53 @@ def test_structure_validation_rejects_unsafe_recipe_paths_before_reading(tmp_pat
         theme.validate_theme_structure(_structure_request(tmp_path, source_path=source_path))
 
 
-def test_structure_validation_rejects_recipe_symlink_escape_before_reading(tmp_path):
-    outside = tmp_path.parent / "outside-theme-recipe.json"
-    outside.write_text(json.dumps(_recipe()), encoding="utf-8")
-    source = tmp_path / "assets/generated/ui-kit/main/main.json"
-    source.parent.mkdir(parents=True)
-    try:
-        source.symlink_to(outside)
-    except OSError:
-        pytest.skip("symlinks are not permitted on this platform")
+@pytest.mark.parametrize("source_path", [
+    "res://assets/generated/ui-kit/other/main.json",
+    "res://assets/work/ui-kit/main/main.json",
+])
+def test_structure_validation_rejects_readable_recipes_outside_the_stable_directory(tmp_path, source_path):
+    _write_recipe(tmp_path, _recipe(), source_path=source_path)
 
     with pytest.raises(ValidationError, match="source_path cannot be resolved"):
-        theme.validate_theme_structure(_structure_request(tmp_path))
+        theme.validate_theme_structure(_structure_request(tmp_path, source_path=source_path))
+
+
+def _link_directory(link: Path, target: Path) -> None:
+    """Link a directory, using a junction where symlinks need a privilege."""
+    try:
+        link.symlink_to(target, target_is_directory=True)
+        return
+    except (OSError, NotImplementedError):
+        pass
+    if sys.platform != "win32":
+        pytest.skip("directory links not permitted on this platform")
+    completed = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        pytest.skip(f"directory junctions not permitted: {completed.stderr.strip()}")
+
+
+def test_structure_validation_rejects_recipe_directory_link_escape_before_reading(tmp_path):
+    outside = tmp_path.parent / "outside-theme-recipe"
+    outside.mkdir()
+    (outside / "main.json").write_text(json.dumps(_recipe()), encoding="utf-8")
+    source = tmp_path / "assets/generated/ui-kit/main/nested"
+    source.parent.mkdir(parents=True)
+    try:
+        _link_directory(source, outside)
+    except (OSError, NotImplementedError):
+        pytest.skip("directory links are not permitted on this platform")
+
+    with pytest.raises(ValidationError, match="source_path cannot be resolved"):
+        theme.validate_theme_structure(
+            _structure_request(
+                tmp_path,
+                source_path="res://assets/generated/ui-kit/main/nested/main.json",
+            )
+        )
 
 
 def test_structure_validation_normalizes_a_missing_recipe_file(tmp_path):


### PR DESCRIPTION
## Summary

Resolve Theme L4 recipe paths through the shared stable-entry resolver and containment guard. Invalid resolver inputs are normalized as `ValidationError`, and regression coverage now exercises cross-asset, worktree, and linked-directory escape attempts.

## Motivation

Theme L4 previously read its recipe from an unvalidated path. This change makes that read follow the same `res://` resolution and output-directory containment rules as the compiler entry points.

Related public issue: N/A

## Changes

- [x] Route `StructureRequest.source_file()` through the shared stable-entry validation helpers.
- [x] Use the safe resolver for Theme L4 recipe reads and normalize path errors.
- [x] Add containment and declared-recipe regression tests, including Windows junction fallback coverage.
- [x] Add a changelog entry.

## Testing

- [x] New or updated tests pass (`python -m pytest`).
- [x] Gitleaks passes or no secret-bearing files were touched (Secret Scan passed in CI).
- [x] Manual testing completed, if applicable (linked-directory escape coverage was exercised on Windows).

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive.
- [ ] Performance-sensitive; benchmark results are attached below or linked.

<details>
<summary>Benchmark Results</summary>

Not applicable.

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed.
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Not applicable; no migration script was added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions.
- [x] ECS systems declare proper read/write metadata, if applicable.
- [x] No hardcoded secrets or API keys.
- [x] `docs/update/next.md` updated.
