### PR TITLE
Fix published asset standalone runners

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -52,6 +52,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Published asset validation runners now work after installing GodotMaker into Claude Code, Codex, or OpenCode projects.
 - Restored real Godot validation for Theme and TileSet assets, including safe Theme resource paths and imported TileSet atlases.
 - Reference-only stable entries now accept only `pending`, `source_ready`, or `failed`; only registered `source_ready` entries may promote ASSETS.md reference rows.
 - Existing reference entries persisted as `compiled` or `ready` must be manually corrected to `source_ready` before root-index validation; no migration or compatibility reader is provided.

--- a/skills/assets/card-kit/standalone_validation.py
+++ b/skills/assets/card-kit/standalone_validation.py
@@ -8,27 +8,39 @@ from pathlib import Path
 def _configure_runtime_imports() -> None:
     """Add the source or published shared runtime to the import path."""
     runner = Path(__file__).resolve()
+    project_root = runner.parents[3]
     source_runtime = runner.parents[1] / "_shared"
-    if source_runtime.is_dir():
-        runtime = source_runtime
-        project_root = runner.parents[3]
-    else:
-        project_root = runner.parents[3]
-        runtime = project_root / ".godotmaker" / "asset-runtime"
+    runtime_candidates = (
+        project_root / ".godotmaker" / "asset-runtime",
+        source_runtime,
+    )
+    source_layout = (
+        runner.parents[1].name == "assets"
+        and runner.parents[2].name == "skills"
+    )
+    runtime = next(
+        (
+            path for path in runtime_candidates
+            if path.is_dir() and (path != source_runtime or source_layout)
+        ),
+        None,
+    )
     tools = project_root / "tools"
-    if not runtime.is_dir():
+    if runtime is None:
         raise ImportError(
             "GodotMaker asset runtime is missing for standalone card-kit validation: "
-            f"expected {runtime}"
+            "checked " + ", ".join(str(path) for path in runtime_candidates)
         )
     if not tools.is_dir():
         raise ImportError(
             "GodotMaker tools directory is missing for standalone card-kit validation: "
             f"expected {tools}"
         )
+    # Appended, never inserted: these flat directories must not shadow the
+    # standard library or installed packages for the rest of the process.
     for path in (str(runtime), str(tools)):
         if path not in sys.path:
-            sys.path.insert(0, path)
+            sys.path.append(path)
 
 
 _configure_runtime_imports()

--- a/skills/assets/card-kit/standalone_validation.py
+++ b/skills/assets/card-kit/standalone_validation.py
@@ -4,11 +4,34 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SHARED = Path(__file__).resolve().parents[1] / "_shared"
-_TOOLS = Path(__file__).resolve().parents[3] / "tools"
-for path in (str(_SHARED), str(_TOOLS)):
-    if path not in sys.path:
-        sys.path.insert(0, path)
+
+def _configure_runtime_imports() -> None:
+    """Add the source or published shared runtime to the import path."""
+    runner = Path(__file__).resolve()
+    source_runtime = runner.parents[1] / "_shared"
+    if source_runtime.is_dir():
+        runtime = source_runtime
+        project_root = runner.parents[3]
+    else:
+        project_root = runner.parents[3]
+        runtime = project_root / ".godotmaker" / "asset-runtime"
+    tools = project_root / "tools"
+    if not runtime.is_dir():
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone card-kit validation: "
+            f"expected {runtime}"
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            "GodotMaker tools directory is missing for standalone card-kit validation: "
+            f"expected {tools}"
+        )
+    for path in (str(runtime), str(tools)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+_configure_runtime_imports()
 
 from ui_card_standalone_validation import UICardSkillError, compile_and_validate  # noqa: E402
 

--- a/skills/assets/tileset/standalone_validation.py
+++ b/skills/assets/tileset/standalone_validation.py
@@ -23,27 +23,39 @@ def _configure_runtime_imports() -> None:
     runtime is deliberately deployed once at ``.godotmaker/asset-runtime``.
     """
     runner = Path(__file__).resolve()
+    project_root = runner.parents[3]
     source_runtime = runner.parents[1] / "_shared"
-    if source_runtime.is_dir():
-        runtime = source_runtime
-        project_root = runner.parents[3]
-    else:
-        project_root = runner.parents[3]
-        runtime = project_root / ".godotmaker" / "asset-runtime"
+    runtime_candidates = (
+        project_root / ".godotmaker" / "asset-runtime",
+        source_runtime,
+    )
+    source_layout = (
+        runner.parents[1].name == "assets"
+        and runner.parents[2].name == "skills"
+    )
+    runtime = next(
+        (
+            path for path in runtime_candidates
+            if path.is_dir() and (path != source_runtime or source_layout)
+        ),
+        None,
+    )
     tools = project_root / "tools"
-    if not runtime.is_dir():
+    if runtime is None:
         raise ImportError(
             "GodotMaker asset runtime is missing for standalone tileset validation: "
-            f"expected {runtime}"
+            "checked " + ", ".join(str(path) for path in runtime_candidates)
         )
     if not tools.is_dir():
         raise ImportError(
             "GodotMaker tools directory is missing for standalone tileset validation: "
             f"expected {tools}"
         )
+    # Appended, never inserted: these flat directories must not shadow the
+    # standard library or installed packages for the rest of the process.
     for path in (str(runtime), str(tools)):
         if path not in sys.path:
-            sys.path.insert(0, path)
+            sys.path.append(path)
 
 
 _configure_runtime_imports()

--- a/skills/assets/tileset/standalone_validation.py
+++ b/skills/assets/tileset/standalone_validation.py
@@ -10,20 +10,62 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from copy import deepcopy
+import sys
 from pathlib import Path
 from typing import Any
 
-from asset_compiler import CompileRequest, CompilerError, CompilerRegistry
-from asset_compiler import tileset as tileset_compiler
-from asset_compiler._stable_entry import (
+
+def _configure_runtime_imports() -> None:
+    """Add the source or published shared runtime to the import path.
+
+    Source skills keep their runtime beside the family directories. Published
+    skills are flattened into an adapter-specific skill root, while their
+    runtime is deliberately deployed once at ``.godotmaker/asset-runtime``.
+    """
+    runner = Path(__file__).resolve()
+    source_runtime = runner.parents[1] / "_shared"
+    if source_runtime.is_dir():
+        runtime = source_runtime
+        project_root = runner.parents[3]
+    else:
+        project_root = runner.parents[3]
+        runtime = project_root / ".godotmaker" / "asset-runtime"
+    tools = project_root / "tools"
+    if not runtime.is_dir():
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone tileset validation: "
+            f"expected {runtime}"
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            "GodotMaker tools directory is missing for standalone tileset validation: "
+            f"expected {tools}"
+        )
+    for path in (str(runtime), str(tools)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+_configure_runtime_imports()
+
+from asset_compiler import CompileRequest, CompilerError, CompilerRegistry  # noqa: E402
+from asset_compiler import tileset as tileset_compiler  # noqa: E402
+from asset_compiler._stable_entry import (  # noqa: E402
     StableEntryError,
     assert_within_output_dir,
     resolve_res_path,
 )
-from asset_validation import GodotProbe, ProbeRequest, ValidationError
-from asset_validation import tileset as tileset_structures
-from asset_validation.structure import StructureRequest, StructureValidatorRegistry
-from asset_skill_contract_check import AssetContractError, check_request, check_result
+from asset_validation import GodotProbe, ProbeRequest, ValidationError  # noqa: E402
+from asset_validation import tileset as tileset_structures  # noqa: E402
+from asset_validation.structure import (  # noqa: E402
+    StructureRequest,
+    StructureValidatorRegistry,
+)
+from asset_skill_contract_check import (  # noqa: E402
+    AssetContractError,
+    check_request,
+    check_result,
+)
 
 
 class TileSetSkillError(Exception):

--- a/skills/assets/ui-kit/standalone_validation.py
+++ b/skills/assets/ui-kit/standalone_validation.py
@@ -8,27 +8,39 @@ from pathlib import Path
 def _configure_runtime_imports() -> None:
     """Add the source or published shared runtime to the import path."""
     runner = Path(__file__).resolve()
+    project_root = runner.parents[3]
     source_runtime = runner.parents[1] / "_shared"
-    if source_runtime.is_dir():
-        runtime = source_runtime
-        project_root = runner.parents[3]
-    else:
-        project_root = runner.parents[3]
-        runtime = project_root / ".godotmaker" / "asset-runtime"
+    runtime_candidates = (
+        project_root / ".godotmaker" / "asset-runtime",
+        source_runtime,
+    )
+    source_layout = (
+        runner.parents[1].name == "assets"
+        and runner.parents[2].name == "skills"
+    )
+    runtime = next(
+        (
+            path for path in runtime_candidates
+            if path.is_dir() and (path != source_runtime or source_layout)
+        ),
+        None,
+    )
     tools = project_root / "tools"
-    if not runtime.is_dir():
+    if runtime is None:
         raise ImportError(
             "GodotMaker asset runtime is missing for standalone ui-kit validation: "
-            f"expected {runtime}"
+            "checked " + ", ".join(str(path) for path in runtime_candidates)
         )
     if not tools.is_dir():
         raise ImportError(
             "GodotMaker tools directory is missing for standalone ui-kit validation: "
             f"expected {tools}"
         )
+    # Appended, never inserted: these flat directories must not shadow the
+    # standard library or installed packages for the rest of the process.
     for path in (str(runtime), str(tools)):
         if path not in sys.path:
-            sys.path.insert(0, path)
+            sys.path.append(path)
 
 
 _configure_runtime_imports()

--- a/skills/assets/ui-kit/standalone_validation.py
+++ b/skills/assets/ui-kit/standalone_validation.py
@@ -4,11 +4,34 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-_SHARED = Path(__file__).resolve().parents[1] / "_shared"
-_TOOLS = Path(__file__).resolve().parents[3] / "tools"
-for path in (str(_SHARED), str(_TOOLS)):
-    if path not in sys.path:
-        sys.path.insert(0, path)
+
+def _configure_runtime_imports() -> None:
+    """Add the source or published shared runtime to the import path."""
+    runner = Path(__file__).resolve()
+    source_runtime = runner.parents[1] / "_shared"
+    if source_runtime.is_dir():
+        runtime = source_runtime
+        project_root = runner.parents[3]
+    else:
+        project_root = runner.parents[3]
+        runtime = project_root / ".godotmaker" / "asset-runtime"
+    tools = project_root / "tools"
+    if not runtime.is_dir():
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone ui-kit validation: "
+            f"expected {runtime}"
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            "GodotMaker tools directory is missing for standalone ui-kit validation: "
+            f"expected {tools}"
+        )
+    for path in (str(runtime), str(tools)):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+
+
+_configure_runtime_imports()
 
 from ui_card_standalone_validation import UICardSkillError, compile_and_validate  # noqa: E402
 

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -1041,19 +1041,21 @@ class TestPublishedAssetRuntime:
                     f"{skill_name} references a missing published runtime path: {reference}"
                 )
 
-    @pytest.mark.parametrize(
-        "publish_project,skill_root",
-        [
-            (_publish_claude_project, ".claude/skills"),
-            (_publish_codex_project, ".agents/skills"),
-            (_publish_opencode_project, ".opencode/skills"),
-        ],
-    )
+    @pytest.mark.parametrize("agent", publish.AGENT_CHOICES)
     def test_published_standalone_runners_import_and_validate_without_source_checkout(
-        self, tmp_path, monkeypatch, publish_project, skill_root
+        self, tmp_path, monkeypatch, agent
     ):
+        publish_project = {
+            publish.AGENT_CLAUDE_CODE: _publish_claude_project,
+            publish.AGENT_CODEX: _publish_codex_project,
+            publish.AGENT_OPENCODE: _publish_opencode_project,
+        }[agent]
+        skill_root = publish.get_agent_adapter(agent).skill_root
         result = publish_project(tmp_path, monkeypatch)
         target = result[0] if isinstance(result, tuple) else result
+        # A publish target can contain an unrelated _shared directory; this
+        # must not override the project-owned runtime.
+        (target / skill_root / "_shared").mkdir()
 
         script = f'''\
 import importlib.util
@@ -1062,13 +1064,15 @@ import sys
 from pathlib import Path
 
 target = Path.cwd().resolve()
-source_root = Path({str(REPO_ROOT)!r}).resolve()
-assert source_root not in [Path(path).resolve() for path in sys.path if path]
 skills = target / {skill_root!r}
+runtime = target / ".godotmaker" / "asset-runtime"
+tools = target / "tools"
 
 def load_runner(name, family):
+    runner = skills / family / "standalone_validation.py"
+    assert runner.parents[3] == target
     spec = importlib.util.spec_from_file_location(
-        name, skills / family / "standalone_validation.py"
+        name, runner
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -1081,6 +1085,13 @@ card_kit = load_runner("published_card_kit_validation", "card-kit")
 assert callable(tileset.compile_and_validate)
 assert callable(ui_kit.compile_and_validate)
 assert callable(card_kit.compile_and_validate)
+
+import asset_compiler
+import asset_skill_contract_check
+
+assert Path(asset_compiler.__file__).resolve().is_relative_to(runtime)
+assert Path(asset_skill_contract_check.__file__).resolve().is_relative_to(tools)
+assert sys.path[-2:] == [str(runtime), str(tools)]
 
 recipe = json.loads(
     (skills / "tileset" / "fixtures" / "orthogonal-square-recipe.json").read_text(
@@ -1125,38 +1136,52 @@ assert validated["validation"]["levels"] == {{
         assert completed.returncode == 0, completed.stderr
 
     @pytest.mark.parametrize(
-        "agent,skill_root",
+        "missing_path,expected_message",
         [
-            (publish.AGENT_CLAUDE_CODE, ".claude/skills"),
-            (publish.AGENT_CODEX, ".agents/skills"),
-            (publish.AGENT_OPENCODE, ".opencode/skills"),
+            (Path(".godotmaker") / "asset-runtime", "asset runtime is missing"),
+            (Path("tools"), "tools directory is missing"),
         ],
     )
-    def test_published_standalone_runner_reports_missing_runtime(
-        self, tmp_path, agent, skill_root
+    def test_published_standalone_runners_report_missing_dependencies(
+        self, tmp_path, missing_path, expected_message
     ):
         target = tmp_path / "target"
-        skills_target = target / skill_root
-        publish_skills(REPO_ROOT, skills_target, agent)
-        runner = skills_target / "tileset" / "standalone_validation.py"
-        expected_runtime = target / ".godotmaker" / "asset-runtime"
+        skills_target = target / publish.get_agent_adapter(
+            publish.AGENT_CODEX
+        ).skill_root
+        publish_skills(REPO_ROOT, skills_target, publish.AGENT_CODEX)
+        publish_asset_runtime(REPO_ROOT, target)
+        publish_directory(REPO_ROOT / "tools", target / "tools", "tools/")
+        if missing_path.name == "asset-runtime":
+            # A stray published _shared directory must not be mistaken for the
+            # source-checkout runtime when the project runtime is missing.
+            (skills_target / "_shared").mkdir()
+        missing = target / missing_path
+        rmtree_force(missing)
 
         script = f'''\
 import importlib.util
 from pathlib import Path
 
-runner = Path({str(runner)!r})
-spec = importlib.util.spec_from_file_location("missing_runtime_runner", runner)
-module = importlib.util.module_from_spec(spec)
-assert spec.loader is not None
-try:
-    spec.loader.exec_module(module)
-except ImportError as error:
-    message = str(error)
-    assert "GodotMaker asset runtime is missing" in message
-    assert {str(expected_runtime)!r} in message
-else:
-    raise AssertionError("published standalone runner imported without its runtime")
+skills = Path({str(skills_target)!r})
+missing = Path({str(missing)!r})
+for family in ("tileset", "ui-kit", "card-kit"):
+    runner = skills / family / "standalone_validation.py"
+    spec = importlib.util.spec_from_file_location(
+        f"missing_{{family}}_runner", runner
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    try:
+        spec.loader.exec_module(module)
+    except ImportError as error:
+        message = str(error)
+        assert {expected_message!r} in message
+        assert str(missing) in message
+        if missing.name == "asset-runtime":
+            assert str(skills / "_shared") in message
+    else:
+        raise AssertionError(f"{{family}} imported without {{missing}}")
 '''
         environment = os.environ.copy()
         environment.pop("PYTHONPATH", None)

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -1041,6 +1041,134 @@ class TestPublishedAssetRuntime:
                     f"{skill_name} references a missing published runtime path: {reference}"
                 )
 
+    @pytest.mark.parametrize(
+        "publish_project,skill_root",
+        [
+            (_publish_claude_project, ".claude/skills"),
+            (_publish_codex_project, ".agents/skills"),
+            (_publish_opencode_project, ".opencode/skills"),
+        ],
+    )
+    def test_published_standalone_runners_import_and_validate_without_source_checkout(
+        self, tmp_path, monkeypatch, publish_project, skill_root
+    ):
+        result = publish_project(tmp_path, monkeypatch)
+        target = result[0] if isinstance(result, tuple) else result
+
+        script = f'''\
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+target = Path.cwd().resolve()
+source_root = Path({str(REPO_ROOT)!r}).resolve()
+assert source_root not in [Path(path).resolve() for path in sys.path if path]
+skills = target / {skill_root!r}
+
+def load_runner(name, family):
+    spec = importlib.util.spec_from_file_location(
+        name, skills / family / "standalone_validation.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+tileset = load_runner("published_tileset_validation", "tileset")
+ui_kit = load_runner("published_ui_kit_validation", "ui-kit")
+card_kit = load_runner("published_card_kit_validation", "card-kit")
+assert callable(tileset.compile_and_validate)
+assert callable(ui_kit.compile_and_validate)
+assert callable(card_kit.compile_and_validate)
+
+recipe = json.loads(
+    (skills / "tileset" / "fixtures" / "orthogonal-square-recipe.json").read_text(
+        encoding="utf-8"
+    )
+)
+source_path = "res://assets/generated/tileset/grassland/grassland_atlas.png"
+validated = tileset.compile_and_validate(
+    {{
+        "asset_type": "tileset",
+        "asset_id": "grassland",
+        "brief": "A grassland tile atlas.",
+        "spec": recipe,
+    }},
+    {{
+        "asset_type": "tileset",
+        "outputs": [{{
+            "role": "runtime",
+            "path": "res://assets/generated/tileset/grassland/grassland.tres",
+            "godot_type": "TileSet",
+        }}],
+        "sources": [{{"path": source_path, "layout": "tile_atlas"}}],
+        "previews": [],
+        "validation": {{"passed": False}},
+    }},
+    project_root=target,
+    godot_path="godot",
+)
+assert validated["validation"]["levels"] == {{
+    "L0": True, "L1": False, "L2": False, "L3": False, "L4": False,
+}}
+'''
+        environment = os.environ.copy()
+        environment.pop("PYTHONPATH", None)
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=target,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        assert completed.returncode == 0, completed.stderr
+
+    @pytest.mark.parametrize(
+        "agent,skill_root",
+        [
+            (publish.AGENT_CLAUDE_CODE, ".claude/skills"),
+            (publish.AGENT_CODEX, ".agents/skills"),
+            (publish.AGENT_OPENCODE, ".opencode/skills"),
+        ],
+    )
+    def test_published_standalone_runner_reports_missing_runtime(
+        self, tmp_path, agent, skill_root
+    ):
+        target = tmp_path / "target"
+        skills_target = target / skill_root
+        publish_skills(REPO_ROOT, skills_target, agent)
+        runner = skills_target / "tileset" / "standalone_validation.py"
+        expected_runtime = target / ".godotmaker" / "asset-runtime"
+
+        script = f'''\
+import importlib.util
+from pathlib import Path
+
+runner = Path({str(runner)!r})
+spec = importlib.util.spec_from_file_location("missing_runtime_runner", runner)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+try:
+    spec.loader.exec_module(module)
+except ImportError as error:
+    message = str(error)
+    assert "GodotMaker asset runtime is missing" in message
+    assert {str(expected_runtime)!r} in message
+else:
+    raise AssertionError("published standalone runner imported without its runtime")
+'''
+        environment = os.environ.copy()
+        environment.pop("PYTHONPATH", None)
+        completed = subprocess.run(
+            [sys.executable, "-c", script],
+            cwd=target,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+        assert completed.returncode == 0, completed.stderr
+
     def test_published_runtime_imports_without_the_source_checkout(self, tmp_path):
         target = tmp_path / "target"
         publish_asset_runtime(REPO_ROOT, target)


### PR DESCRIPTION
## Summary

Make the asset validation runners work from published Claude Code, Codex, and OpenCode layouts.

## Motivation

Published runners previously depended on source-tree-relative runtime paths, preventing standalone validation after installation.

## Changes

- [x] Resolve shared runtime and tools paths from the published project layout while retaining source-layout support.
- [x] Add regression coverage for published standalone runners, including missing dependency diagnostics.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — `python -m pytest -q`.
- [x] Gitleaks passes or no secret-bearing files were touched — CI Secret Scan passed.
- [x] Manual testing completed, if applicable — not applicable; automated published-layout coverage added.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

Not applicable; no migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
