### PR TITLE
Harden TileSet recipe validation

### DIFF
--- a/skills/assets/_shared/asset_compiler/tileset.py
+++ b/skills/assets/_shared/asset_compiler/tileset.py
@@ -7,10 +7,10 @@ would not prove the engine accepts the declared polygons and terrain data.
 from __future__ import annotations
 
 import json
+import math
 import subprocess
 import tempfile
 from copy import deepcopy
-from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -24,6 +24,11 @@ _SCRIPT = Path(__file__).with_name("tileset_compiler.gd")
 
 _SHAPES = {"square": 0, "isometric": 1, "half_offset_square": 2, "hexagon": 3}
 _ANIMATION_MODES = {"default": 0, "random_start_times": 1, "max": 2}
+_TERRAIN_MODES = {0, 1, 2}
+_CUSTOM_DATA_TYPES = {0: type(None), 1: bool, 2: int, 3: float, 4: str}
+_UINT32_MAX = 2**32 - 1
+_Z_INDEX_MIN = -4096
+_Z_INDEX_MAX = 4096
 
 
 def _pair(value: Any, label: str, *, positive: bool = False) -> list[int]:
@@ -34,13 +39,172 @@ def _pair(value: Any, label: str, *, positive: bool = False) -> list[int]:
     return list(value)
 
 
+def _finite_number(value: Any, label: str, *, positive: bool = False, non_negative: bool = False, maximum: float | None = None) -> float:
+    if type(value) not in (int, float) or not math.isfinite(float(value)):
+        raise CompilerError(f"{label} must be a finite number")
+    number = float(value)
+    if positive and number <= 0:
+        raise CompilerError(f"{label} must be positive")
+    if non_negative and number < 0:
+        raise CompilerError(f"{label} must be non-negative")
+    if maximum is not None and number > maximum:
+        raise CompilerError(f"{label} must be at most {maximum:g}")
+    return number
+
+
+def _integer(value: Any, label: str, *, minimum: int | None = None, maximum: int | None = None) -> int:
+    if type(value) is not int:
+        raise CompilerError(f"{label} must be an integer")
+    if minimum is not None and value < minimum:
+        raise CompilerError(f"{label} must be at least {minimum}")
+    if maximum is not None and value > maximum:
+        raise CompilerError(f"{label} must be at most {maximum}")
+    return value
+
+
 def _color(value: Any, label: str) -> list[float]:
     if not isinstance(value, list) or len(value) not in (3, 4) or any(type(v) not in (int, float) for v in value):
         raise CompilerError(f"{label} must be [r, g, b] or [r, g, b, a]")
     result = [float(v) for v in value]
-    if any(v < 0 or v > 1 for v in result):
+    if any(not math.isfinite(v) or v < 0 or v > 1 for v in result):
         raise CompilerError(f"{label} channels must be between 0 and 1")
     return result + ([1.0] if len(result) == 3 else [])
+
+
+def _list(value: Any, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise CompilerError(f"{label} must be a list")
+    return value
+
+
+def _layer_index(value: Any, label: str, count: int) -> int:
+    index = _integer(value, label, minimum=0)
+    if index >= count:
+        raise CompilerError(f"{label} is outside the declared layer range")
+    return index
+
+
+def _polygon_points(value: Any, label: str) -> list[list[float]]:
+    points = _list(value, f"{label} points")
+    if len(points) < 3:
+        raise CompilerError(f"{label} points must contain at least three points")
+    normalized: list[list[float]] = []
+    for point in points:
+        if not isinstance(point, list) or len(point) != 2:
+            raise CompilerError(f"{label} point must be [number, number]")
+        normalized.append([
+            _finite_number(point[0], f"{label} point x"),
+            _finite_number(point[1], f"{label} point y"),
+        ])
+    return normalized
+
+
+def _terrain_index(item: dict[str, Any], terrain_sets: list[Any], label: str) -> None:
+    terrain_set = item.get("terrain_set", -1)
+    terrain = item.get("terrain", -1)
+    _integer(terrain_set, f"{label} terrain_set", minimum=-1)
+    _integer(terrain, f"{label} terrain", minimum=-1)
+    if terrain_set == -1:
+        if terrain != -1:
+            raise CompilerError(f"{label} terrain requires a declared terrain_set")
+        return
+    if terrain_set >= len(terrain_sets):
+        raise CompilerError(f"{label} terrain_set is outside the declared terrain set range")
+    terrains = terrain_sets[terrain_set]["terrains"]
+    if terrain != -1 and terrain >= len(terrains):
+        raise CompilerError(f"{label} terrain is outside the declared terrain range")
+
+
+def _custom_value(value: Any, value_type: int, label: str) -> Any:
+    expected = _CUSTOM_DATA_TYPES[value_type]
+    if value_type == 3:
+        return _finite_number(value, label)
+    if type(value) is not expected:
+        names = {0: "NIL", 1: "bool", 2: "int", 4: "String"}
+        raise CompilerError(f"{label} must be a {names[value_type]} scalar")
+    return value
+
+
+def _validate_tile_data(item: dict[str, Any], spec: dict[str, Any], label: str) -> None:
+    if "texture_origin" in item:
+        item["texture_origin"] = _pair(item["texture_origin"], f"{label} texture_origin")
+    if "z_index" in item:
+        _integer(item["z_index"], f"{label} z_index", minimum=_Z_INDEX_MIN, maximum=_Z_INDEX_MAX)
+    if "y_sort_origin" in item:
+        _integer(item["y_sort_origin"], f"{label} y_sort_origin")
+    if "probability" in item:
+        item["probability"] = _finite_number(item["probability"], f"{label} probability", non_negative=True, maximum=1.0)
+
+    terrain_sets = spec["terrain_sets"]
+    _terrain_index(item, terrain_sets, label)
+    terrain_set = item.get("terrain_set", -1)
+    seen_bits: set[int] = set()
+    for bit in _list(item.get("peering_bits", []), f"{label} peering_bits"):
+        if not isinstance(bit, dict):
+            raise CompilerError(f"{label} peering bit must be an object")
+        index = _integer(bit.get("bit"), f"{label} peering bit", minimum=0, maximum=15)
+        terrain = _integer(bit.get("terrain"), f"{label} peering terrain", minimum=0)
+        if terrain_set == -1:
+            raise CompilerError(f"{label} peering bits require a declared terrain_set")
+        if terrain >= len(terrain_sets[terrain_set]["terrains"]):
+            raise CompilerError(f"{label} peering terrain is outside the declared terrain range")
+        if index in seen_bits:
+            raise CompilerError(f"{label} cannot declare duplicate peering bits")
+        seen_bits.add(index)
+
+    custom_layers = spec["custom_data_layers"]
+    seen_custom_layers: set[int] = set()
+    for custom in _list(item.get("custom_data", []), f"{label} custom_data"):
+        if not isinstance(custom, dict):
+            raise CompilerError(f"{label} custom data must be an object")
+        layer = _layer_index(custom.get("layer"), f"{label} custom data layer", len(custom_layers))
+        if layer in seen_custom_layers:
+            raise CompilerError(f"{label} cannot declare duplicate custom data layers")
+        seen_custom_layers.add(layer)
+        if "value" not in custom:
+            raise CompilerError(f"{label} custom data requires a value")
+        custom["value"] = _custom_value(custom["value"], custom_layers[layer]["type"], f"{label} custom data value")
+
+    polygon_families = (
+        ("collision_polygons", "collision", len(spec["physics_layers"])),
+        ("occlusion_polygons", "occlusion", len(spec["occlusion_layers"])),
+        ("navigation_polygons", "navigation", len(spec["navigation_layers"])),
+    )
+    for key, family, layer_count in polygon_families:
+        seen_layers: set[int] = set()
+        for polygon in _list(item.get(key, []), f"{label} {key}"):
+            if not isinstance(polygon, dict):
+                raise CompilerError(f"{label} {family} polygon must be an object")
+            layer = _layer_index(polygon.get("layer"), f"{label} {family} polygon layer", layer_count)
+            if key == "navigation_polygons" and layer in seen_layers:
+                raise CompilerError(f"{label} cannot declare duplicate navigation polygons for one layer")
+            seen_layers.add(layer)
+            polygon["points"] = _polygon_points(polygon.get("points"), f"{label} {family} polygon")
+
+
+def _validate_animation(animation: Any) -> dict[str, Any]:
+    if not isinstance(animation, dict):
+        raise CompilerError("tile animation must be an object")
+    mode = animation.get("mode", "default")
+    if not isinstance(mode, str) or mode not in _ANIMATION_MODES:
+        raise CompilerError("animation mode must be one of: " + ", ".join(_ANIMATION_MODES))
+    animation["mode"] = _ANIMATION_MODES[mode]
+    animation["frames_count"] = _integer(animation.get("frames_count"), "animation frames_count", minimum=1)
+    animation["columns"] = _integer(animation.get("columns", 1), "animation columns", minimum=1)
+    animation["separation"] = _pair(animation.get("separation", [0, 0]), "animation separation")
+    if any(value < 0 for value in animation["separation"]):
+        raise CompilerError("animation separation values must be non-negative integers")
+    animation["speed"] = _finite_number(animation.get("speed", 1.0), "animation speed", positive=True)
+    durations = _list(animation.get("frame_durations", []), "animation frame_durations")
+    normalized: list[dict[str, Any]] = []
+    for frame, duration in enumerate(durations):
+        if not isinstance(duration, dict) or duration.get("frame") != frame:
+            raise CompilerError("animation frame_durations must be ordered, unique, and continuous")
+        normalized.append({"frame": frame, "duration": _finite_number(duration.get("duration"), "animation frame duration", positive=True)})
+    if normalized and len(normalized) != animation["frames_count"]:
+        raise CompilerError("animation frame_durations must declare every frame")
+    animation["frame_durations"] = normalized
+    return animation
 
 
 def _recipe(request: CompileRequest) -> dict[str, Any]:
@@ -53,12 +217,47 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
     if not isinstance(shape, str) or shape not in _SHAPES:
         raise CompilerError("tile_shape must be one of: " + ", ".join(_SHAPES))
     spec["tile_shape"] = _SHAPES[shape]
+    for key in ("physics_layers", "navigation_layers", "occlusion_layers", "custom_data_layers", "terrain_sets"):
+        spec[key] = _list(spec.get(key, []), f"TileSet {key}")
+    for layer in spec["physics_layers"]:
+        if not isinstance(layer, dict):
+            raise CompilerError("physics layer must be an object")
+        layer["collision_layer"] = _integer(layer.get("collision_layer", 1), "physics collision_layer", minimum=0, maximum=_UINT32_MAX)
+        layer["collision_mask"] = _integer(layer.get("collision_mask", 1), "physics collision_mask", minimum=0, maximum=_UINT32_MAX)
+    for layer in spec["navigation_layers"]:
+        if not isinstance(layer, dict):
+            raise CompilerError("navigation layer must be an object")
+        layer["layers"] = _integer(layer.get("layers", 1), "navigation layers", minimum=0, maximum=_UINT32_MAX)
+    for layer in spec["occlusion_layers"]:
+        if not isinstance(layer, dict):
+            raise CompilerError("occlusion layer must be an object")
+        layer["light_mask"] = _integer(layer.get("light_mask", 1), "occlusion light_mask", minimum=0, maximum=_UINT32_MAX)
+    for layer in spec["custom_data_layers"]:
+        if not isinstance(layer, dict) or not isinstance(layer.get("name", ""), str):
+            raise CompilerError("custom data layer needs a string name")
+        value_type = _integer(layer.get("type", 0), "custom data layer type", minimum=0)
+        if value_type not in _CUSTOM_DATA_TYPES:
+            raise CompilerError("custom data layer type must be one of: NIL, bool, int, float, String")
+        layer["type"] = value_type
+    for terrain_set in spec["terrain_sets"]:
+        if not isinstance(terrain_set, dict):
+            raise CompilerError("terrain set must be an object")
+        terrain_set["mode"] = _integer(terrain_set.get("mode", 0), "terrain set mode")
+        if terrain_set["mode"] not in _TERRAIN_MODES:
+            raise CompilerError("terrain set mode must be one of: 0, 1, 2")
+        terrain_set["terrains"] = _list(terrain_set.get("terrains", []), "terrain set terrains")
+        for terrain in terrain_set["terrains"]:
+            if not isinstance(terrain, dict) or not isinstance(terrain.get("name", ""), str):
+                raise CompilerError("terrain needs a string name")
+            if "color" in terrain:
+                terrain["color"] = _color(terrain["color"], "terrain color")
+
     sources = spec.get("sources")
     if not isinstance(sources, list) or not sources:
         raise CompilerError("TileSet spec requires a non-empty sources list")
     seen_source_ids: set[int] = set()
     for source_index, source in enumerate(sources):
-        if not isinstance(source, Mapping):
+        if not isinstance(source, dict):
             raise CompilerError("every TileSet source must be an object")
         texture = source.get("texture")
         if not isinstance(texture, str) or not texture.startswith("res://"):
@@ -73,60 +272,38 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
         source["region_size"] = _pair(source.get("region_size", source.get("tile_size", spec["tile_size"])), "source region_size", positive=True)
         source["margins"] = _pair(source.get("margins", [0, 0]), "source margins")
         source["separation"] = _pair(source.get("separation", [0, 0]), "source separation")
+        if any(value < 0 for value in source["margins"]):
+            raise CompilerError("source margins values must be non-negative integers")
+        if any(value < 0 for value in source["separation"]):
+            raise CompilerError("source separation values must be non-negative integers")
+        seen_coords: set[tuple[int, int]] = set()
         for tile in source["tiles"]:
-            if not isinstance(tile, Mapping):
+            if not isinstance(tile, dict):
                 raise CompilerError("every TileSet tile must be an object")
             tile["coords"] = _pair(tile.get("coords"), "tile coords")
-            for alternative in tile.get("alternatives", []):
-                if not isinstance(alternative, Mapping) or type(alternative.get("id")) is not int or alternative["id"] <= 0:
-                    raise CompilerError("alternative id must be a positive integer")
-            for item, label in [(tile, "tile"), *[(alternative, "alternative") for alternative in tile.get("alternatives", [])]]:
-                seen_navigation_layers: set[Any] = set()
-                for polygon in item.get("navigation_polygons", []):
-                    if not isinstance(polygon, Mapping):
-                        continue
-                    layer = polygon.get("layer")
-                    if layer in seen_navigation_layers:
-                        raise CompilerError(f"{label} cannot declare duplicate navigation polygons for one layer")
-                    seen_navigation_layers.add(layer)
-            animation = tile.get("animation")
-            if animation is not None:
-                if not isinstance(animation, Mapping):
-                    raise CompilerError("tile animation must be an object")
-                mode = animation.get("mode", "default")
-                if not isinstance(mode, str) or mode not in _ANIMATION_MODES:
-                    raise CompilerError("animation mode must be one of: " + ", ".join(_ANIMATION_MODES))
-                if type(animation.get("frames_count")) is not int or animation["frames_count"] < 1:
-                    raise CompilerError("animation frames_count must be a positive integer")
-                animation["mode"] = _ANIMATION_MODES[mode]
-                if type(animation.get("columns", 1)) is not int or animation.get("columns", 1) < 1:
-                    raise CompilerError("animation columns must be a positive integer")
-                animation["columns"] = animation.get("columns", 1)
-                animation["separation"] = _pair(animation.get("separation", [0, 0]), "animation separation")
-                if type(animation.get("speed", 1.0)) not in (int, float) or animation.get("speed", 1.0) <= 0:
-                    raise CompilerError("animation speed must be a positive number")
-                animation["speed"] = float(animation.get("speed", 1.0))
-                durations = animation.get("frame_durations", [])
-                if not isinstance(durations, list):
-                    raise CompilerError("animation frame_durations must be a list")
-                normalized: list[dict[str, Any]] = []
-                for frame, duration in enumerate(durations):
-                    if not isinstance(duration, Mapping) or duration.get("frame") != frame:
-                        raise CompilerError("animation frame_durations must be ordered, unique, and continuous")
-                    if type(duration.get("duration")) not in (int, float) or duration["duration"] <= 0:
-                        raise CompilerError("animation frame duration must be a positive number")
-                    normalized.append({"frame": frame, "duration": float(duration["duration"])})
-                if normalized and len(normalized) != animation["frames_count"]:
-                    raise CompilerError("animation frame_durations must declare every frame")
-                animation["frame_durations"] = normalized
-    for terrain_set in spec.get("terrain_sets", []):
-        if not isinstance(terrain_set, Mapping) or type(terrain_set.get("mode", 0)) is not int:
-            raise CompilerError("terrain set mode must be an integer")
-        for terrain in terrain_set.get("terrains", []):
-            if not isinstance(terrain, Mapping) or not isinstance(terrain.get("name", ""), str):
-                raise CompilerError("terrain needs a string name")
-            if "color" in terrain:
-                terrain["color"] = _color(terrain["color"], "terrain color")
+            if any(value < 0 for value in tile["coords"]):
+                raise CompilerError("tile coords values must be non-negative integers")
+            coords = tuple(tile["coords"])
+            if coords in seen_coords:
+                raise CompilerError("TileSet source cannot declare duplicate tile coords")
+            seen_coords.add(coords)
+            _validate_tile_data(tile, spec, "tile")
+            alternatives = _list(tile.get("alternatives", []), "tile alternatives")
+            seen_alternative_ids: set[int] = set()
+            for alternative in alternatives:
+                if not isinstance(alternative, dict):
+                    raise CompilerError("alternative must be an object")
+                alternative_id = _integer(alternative.get("id"), "alternative id", minimum=1)
+                if alternative_id in seen_alternative_ids:
+                    raise CompilerError("tile cannot declare duplicate alternative ids")
+                seen_alternative_ids.add(alternative_id)
+                alternative["id"] = alternative_id
+                _validate_tile_data(alternative, spec, "alternative")
+                if "animation" in alternative:
+                    raise CompilerError("animation is only supported on a base tile")
+            tile["alternatives"] = alternatives
+            if "animation" in tile:
+                tile["animation"] = _validate_animation(tile["animation"])
     spec["godot_path"] = binary.strip()
     return spec
 

--- a/skills/assets/_shared/asset_compiler/tileset.py
+++ b/skills/assets/_shared/asset_compiler/tileset.py
@@ -27,8 +27,18 @@ _ANIMATION_MODES = {"default": 0, "random_start_times": 1, "max": 2}
 _TERRAIN_MODES = {0, 1, 2}
 _CUSTOM_DATA_TYPES = {0: type(None), 1: bool, 2: int, 3: float, 4: str}
 _UINT32_MAX = 2**32 - 1
-_Z_INDEX_MIN = -4096
-_Z_INDEX_MAX = 4096
+_TILE_DATA_KEYS = {
+    "texture_origin", "z_index", "y_sort_origin", "probability", "terrain_set",
+    "terrain", "peering_bits", "custom_data", "collision_polygons",
+    "occlusion_polygons", "navigation_polygons",
+}
+_PEERING_BITS = {
+    0: ({0, 4, 8, 12}, {3, 7, 11, 15}),
+    1: ({2, 6, 10, 14}, {1, 5, 9, 13}),
+    # Half-offset square and hexagon use Godot's default horizontal offset axis.
+    2: ({0, 2, 6, 8, 10, 14}, {3, 5, 7, 11, 13, 15}),
+    3: ({0, 2, 6, 8, 10, 14}, {3, 5, 7, 11, 13, 15}),
+}
 
 
 def _pair(value: Any, label: str, *, positive: bool = False) -> list[int]:
@@ -77,6 +87,12 @@ def _list(value: Any, label: str) -> list[Any]:
     return value
 
 
+def _reject_unknown_keys(item: dict[str, Any], allowed: set[str], label: str) -> None:
+    unknown = set(item).difference(allowed)
+    if unknown:
+        raise CompilerError(f"{label} has unsupported fields: {', '.join(sorted(unknown))}")
+
+
 def _layer_index(value: Any, label: str, count: int) -> int:
     index = _integer(value, label, minimum=0)
     if index >= count:
@@ -86,8 +102,8 @@ def _layer_index(value: Any, label: str, count: int) -> int:
 
 def _polygon_points(value: Any, label: str) -> list[list[float]]:
     points = _list(value, f"{label} points")
-    if len(points) < 3:
-        raise CompilerError(f"{label} points must contain at least three points")
+    if len(points) in (1, 2):
+        raise CompilerError(f"{label} points must be empty or contain at least three points")
     normalized: list[list[float]] = []
     for point in points:
         if not isinstance(point, list) or len(point) != 2:
@@ -125,15 +141,20 @@ def _custom_value(value: Any, value_type: int, label: str) -> Any:
     return value
 
 
+def _valid_peering_bits(shape: int, terrain_mode: int) -> set[int]:
+    sides, corners = _PEERING_BITS[shape]
+    return (sides if terrain_mode in (0, 2) else set()) | (corners if terrain_mode in (0, 1) else set())
+
+
 def _validate_tile_data(item: dict[str, Any], spec: dict[str, Any], label: str) -> None:
     if "texture_origin" in item:
         item["texture_origin"] = _pair(item["texture_origin"], f"{label} texture_origin")
     if "z_index" in item:
-        _integer(item["z_index"], f"{label} z_index", minimum=_Z_INDEX_MIN, maximum=_Z_INDEX_MAX)
+        _integer(item["z_index"], f"{label} z_index")
     if "y_sort_origin" in item:
         _integer(item["y_sort_origin"], f"{label} y_sort_origin")
     if "probability" in item:
-        item["probability"] = _finite_number(item["probability"], f"{label} probability", non_negative=True, maximum=1.0)
+        item["probability"] = _finite_number(item["probability"], f"{label} probability", non_negative=True)
 
     terrain_sets = spec["terrain_sets"]
     _terrain_index(item, terrain_sets, label)
@@ -142,12 +163,16 @@ def _validate_tile_data(item: dict[str, Any], spec: dict[str, Any], label: str) 
     for bit in _list(item.get("peering_bits", []), f"{label} peering_bits"):
         if not isinstance(bit, dict):
             raise CompilerError(f"{label} peering bit must be an object")
+        _reject_unknown_keys(bit, {"bit", "terrain"}, f"{label} peering bit")
         index = _integer(bit.get("bit"), f"{label} peering bit", minimum=0, maximum=15)
         terrain = _integer(bit.get("terrain"), f"{label} peering terrain", minimum=0)
         if terrain_set == -1:
             raise CompilerError(f"{label} peering bits require a declared terrain_set")
         if terrain >= len(terrain_sets[terrain_set]["terrains"]):
             raise CompilerError(f"{label} peering terrain is outside the declared terrain range")
+        terrain_mode = terrain_sets[terrain_set]["mode"]
+        if index not in _valid_peering_bits(spec["tile_shape"], terrain_mode):
+            raise CompilerError(f"{label} peering bit is invalid for the tile_shape and terrain mode")
         if index in seen_bits:
             raise CompilerError(f"{label} cannot declare duplicate peering bits")
         seen_bits.add(index)
@@ -157,6 +182,7 @@ def _validate_tile_data(item: dict[str, Any], spec: dict[str, Any], label: str) 
     for custom in _list(item.get("custom_data", []), f"{label} custom_data"):
         if not isinstance(custom, dict):
             raise CompilerError(f"{label} custom data must be an object")
+        _reject_unknown_keys(custom, {"layer", "value"}, f"{label} custom data")
         layer = _layer_index(custom.get("layer"), f"{label} custom data layer", len(custom_layers))
         if layer in seen_custom_layers:
             raise CompilerError(f"{label} cannot declare duplicate custom data layers")
@@ -171,20 +197,23 @@ def _validate_tile_data(item: dict[str, Any], spec: dict[str, Any], label: str) 
         ("navigation_polygons", "navigation", len(spec["navigation_layers"])),
     )
     for key, family, layer_count in polygon_families:
-        seen_layers: set[int] = set()
+        seen_navigation_layers: set[int] = set()
         for polygon in _list(item.get(key, []), f"{label} {key}"):
             if not isinstance(polygon, dict):
                 raise CompilerError(f"{label} {family} polygon must be an object")
+            _reject_unknown_keys(polygon, {"layer", "points"}, f"{label} {family} polygon")
             layer = _layer_index(polygon.get("layer"), f"{label} {family} polygon layer", layer_count)
-            if key == "navigation_polygons" and layer in seen_layers:
+            if key == "navigation_polygons" and layer in seen_navigation_layers:
                 raise CompilerError(f"{label} cannot declare duplicate navigation polygons for one layer")
-            seen_layers.add(layer)
+            if key == "navigation_polygons":
+                seen_navigation_layers.add(layer)
             polygon["points"] = _polygon_points(polygon.get("points"), f"{label} {family} polygon")
 
 
 def _validate_animation(animation: Any) -> dict[str, Any]:
     if not isinstance(animation, dict):
         raise CompilerError("tile animation must be an object")
+    _reject_unknown_keys(animation, {"mode", "frames_count", "columns", "separation", "speed", "frame_durations"}, "tile animation")
     mode = animation.get("mode", "default")
     if not isinstance(mode, str) or mode not in _ANIMATION_MODES:
         raise CompilerError("animation mode must be one of: " + ", ".join(_ANIMATION_MODES))
@@ -195,13 +224,16 @@ def _validate_animation(animation: Any) -> dict[str, Any]:
     if any(value < 0 for value in animation["separation"]):
         raise CompilerError("animation separation values must be non-negative integers")
     animation["speed"] = _finite_number(animation.get("speed", 1.0), "animation speed", positive=True)
-    durations = _list(animation.get("frame_durations", []), "animation frame_durations")
+    if "frame_durations" not in animation:
+        return animation
+    durations = _list(animation["frame_durations"], "animation frame_durations")
     normalized: list[dict[str, Any]] = []
     for frame, duration in enumerate(durations):
         if not isinstance(duration, dict) or duration.get("frame") != frame:
             raise CompilerError("animation frame_durations must be ordered, unique, and continuous")
+        _reject_unknown_keys(duration, {"frame", "duration"}, "animation frame duration")
         normalized.append({"frame": frame, "duration": _finite_number(duration.get("duration"), "animation frame duration", positive=True)})
-    if normalized and len(normalized) != animation["frames_count"]:
+    if len(normalized) != animation["frames_count"]:
         raise CompilerError("animation frame_durations must declare every frame")
     animation["frame_durations"] = normalized
     return animation
@@ -209,6 +241,10 @@ def _validate_animation(animation: Any) -> dict[str, Any]:
 
 def _recipe(request: CompileRequest) -> dict[str, Any]:
     spec = deepcopy(dict(request.spec))
+    _reject_unknown_keys(spec, {
+        "godot_path", "tile_shape", "tile_size", "sources", "physics_layers",
+        "navigation_layers", "occlusion_layers", "custom_data_layers", "terrain_sets",
+    }, "TileSet spec")
     binary = spec.pop("godot_path", None)
     if not isinstance(binary, str) or not binary.strip():
         raise CompilerError("TileSet spec requires a non-empty godot_path")
@@ -222,26 +258,37 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
     for layer in spec["physics_layers"]:
         if not isinstance(layer, dict):
             raise CompilerError("physics layer must be an object")
+        _reject_unknown_keys(layer, {"collision_layer", "collision_mask"}, "physics layer")
         layer["collision_layer"] = _integer(layer.get("collision_layer", 1), "physics collision_layer", minimum=0, maximum=_UINT32_MAX)
         layer["collision_mask"] = _integer(layer.get("collision_mask", 1), "physics collision_mask", minimum=0, maximum=_UINT32_MAX)
     for layer in spec["navigation_layers"]:
         if not isinstance(layer, dict):
             raise CompilerError("navigation layer must be an object")
+        _reject_unknown_keys(layer, {"layers"}, "navigation layer")
         layer["layers"] = _integer(layer.get("layers", 1), "navigation layers", minimum=0, maximum=_UINT32_MAX)
     for layer in spec["occlusion_layers"]:
         if not isinstance(layer, dict):
             raise CompilerError("occlusion layer must be an object")
+        _reject_unknown_keys(layer, {"light_mask"}, "occlusion layer")
         layer["light_mask"] = _integer(layer.get("light_mask", 1), "occlusion light_mask", minimum=0, maximum=_UINT32_MAX)
     for layer in spec["custom_data_layers"]:
         if not isinstance(layer, dict) or not isinstance(layer.get("name", ""), str):
             raise CompilerError("custom data layer needs a string name")
+        _reject_unknown_keys(layer, {"name", "type"}, "custom data layer")
+        layer["name"] = layer.get("name", "")
         value_type = _integer(layer.get("type", 0), "custom data layer type", minimum=0)
         if value_type not in _CUSTOM_DATA_TYPES:
             raise CompilerError("custom data layer type must be one of: NIL, bool, int, float, String")
         layer["type"] = value_type
+    custom_data_names: set[str] = set()
+    for layer in spec["custom_data_layers"]:
+        if layer["name"] in custom_data_names:
+            raise CompilerError("custom data layer names must be unique")
+        custom_data_names.add(layer["name"])
     for terrain_set in spec["terrain_sets"]:
         if not isinstance(terrain_set, dict):
             raise CompilerError("terrain set must be an object")
+        _reject_unknown_keys(terrain_set, {"mode", "terrains"}, "terrain set")
         terrain_set["mode"] = _integer(terrain_set.get("mode", 0), "terrain set mode")
         if terrain_set["mode"] not in _TERRAIN_MODES:
             raise CompilerError("terrain set mode must be one of: 0, 1, 2")
@@ -249,6 +296,7 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
         for terrain in terrain_set["terrains"]:
             if not isinstance(terrain, dict) or not isinstance(terrain.get("name", ""), str):
                 raise CompilerError("terrain needs a string name")
+            _reject_unknown_keys(terrain, {"name", "color"}, "terrain")
             if "color" in terrain:
                 terrain["color"] = _color(terrain["color"], "terrain color")
 
@@ -259,6 +307,7 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
     for source_index, source in enumerate(sources):
         if not isinstance(source, dict):
             raise CompilerError("every TileSet source must be an object")
+        _reject_unknown_keys(source, {"id", "texture", "tiles", "region_size", "tile_size", "margins", "separation"}, "TileSet source")
         texture = source.get("texture")
         if not isinstance(texture, str) or not texture.startswith("res://"):
             raise CompilerError("every TileSet source requires a res:// texture path")
@@ -269,6 +318,8 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
             raise CompilerError("every TileSet source id must be a unique non-negative integer")
         seen_source_ids.add(source_id)
         source["id"] = source_id
+        if "tile_size" in source:
+            source["tile_size"] = _pair(source["tile_size"], "source tile_size", positive=True)
         source["region_size"] = _pair(source.get("region_size", source.get("tile_size", spec["tile_size"])), "source region_size", positive=True)
         source["margins"] = _pair(source.get("margins", [0, 0]), "source margins")
         source["separation"] = _pair(source.get("separation", [0, 0]), "source separation")
@@ -280,6 +331,7 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
         for tile in source["tiles"]:
             if not isinstance(tile, dict):
                 raise CompilerError("every TileSet tile must be an object")
+            _reject_unknown_keys(tile, _TILE_DATA_KEYS | {"coords", "alternatives", "animation"}, "tile")
             tile["coords"] = _pair(tile.get("coords"), "tile coords")
             if any(value < 0 for value in tile["coords"]):
                 raise CompilerError("tile coords values must be non-negative integers")
@@ -293,14 +345,13 @@ def _recipe(request: CompileRequest) -> dict[str, Any]:
             for alternative in alternatives:
                 if not isinstance(alternative, dict):
                     raise CompilerError("alternative must be an object")
+                _reject_unknown_keys(alternative, _TILE_DATA_KEYS | {"id"}, "alternative")
                 alternative_id = _integer(alternative.get("id"), "alternative id", minimum=1)
                 if alternative_id in seen_alternative_ids:
                     raise CompilerError("tile cannot declare duplicate alternative ids")
                 seen_alternative_ids.add(alternative_id)
                 alternative["id"] = alternative_id
                 _validate_tile_data(alternative, spec, "alternative")
-                if "animation" in alternative:
-                    raise CompilerError("animation is only supported on a base tile")
             tile["alternatives"] = alternatives
             if "animation" in tile:
                 tile["animation"] = _validate_animation(tile["animation"])

--- a/skills/assets/_shared/asset_validation/tileset.py
+++ b/skills/assets/_shared/asset_validation/tileset.py
@@ -149,6 +149,14 @@ def _expected_layers(spec: dict[str, Any]) -> dict[str, list[dict[str, Any]]]:
     }
 
 
+def _source_id(source: dict[str, Any], index: int) -> int:
+    return source.get("id", index)
+
+
+def _source_region_size(source: dict[str, Any], tile_size: Any) -> Any:
+    return source.get("region_size", source.get("tile_size", tile_size))
+
+
 def validate_tileset(request: StructureRequest) -> dict[str, Any]:
     facts = request.checked_structure("tileset")
     sources = request.spec.get("sources")
@@ -175,16 +183,42 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
     actual_sources = facts.get("sources")
     if not isinstance(actual_sources, list) or len(actual_sources) != len(sources):
         raise ValidationError("loaded TileSet source descriptors are incomplete")
-    for index, (expected, actual) in enumerate(zip(sources, actual_sources)):
-        if not isinstance(expected, dict) or not isinstance(actual, dict):
+    expected_sources = {
+        _source_id(source, index): source
+        for index, source in enumerate(sources)
+        if isinstance(source, dict)
+    }
+    actual_sources_by_id = {
+        source.get("id"): source
+        for source in actual_sources
+        if isinstance(source, dict)
+    }
+    if set(actual_sources_by_id) != set(expected_sources):
+        raise ValidationError("loaded TileSet source ids do not match the recipe")
+    for source_id, expected in expected_sources.items():
+        actual = actual_sources_by_id[source_id]
+        if not isinstance(actual, dict):
             raise ValidationError("TileSet source descriptor is malformed")
-        for key, default in (("id", index), ("region_size", expected_size), ("margins", [0, 0]), ("separation", [0, 0])):
+        for key, default in (("id", source_id), ("region_size", _source_region_size(expected, expected_size)), ("margins", [0, 0]), ("separation", [0, 0])):
             if actual.get(key) != expected.get(key, default):
-                raise ValidationError(f"loaded TileSet source {index} {key} does not match the recipe")
+                raise ValidationError(f"loaded TileSet source {source_id} {key} does not match the recipe")
         actual_tiles = actual.get("tiles")
         if not isinstance(actual_tiles, list) or len(actual_tiles) != len(expected.get("tiles", [])):
-            raise ValidationError(f"loaded TileSet source {index} tile descriptors are incomplete")
-        for tile, loaded in zip(expected.get("tiles", []), actual_tiles):
+            raise ValidationError(f"loaded TileSet source {source_id} tile descriptors are incomplete")
+        expected_tiles = {
+            tuple(tile.get("coords", [])): tile
+            for tile in expected.get("tiles", [])
+            if isinstance(tile, dict)
+        }
+        actual_tiles_by_coords = {
+            tuple(tile.get("coords", [])): tile
+            for tile in actual_tiles
+            if isinstance(tile, dict)
+        }
+        if set(actual_tiles_by_coords) != set(expected_tiles):
+            raise ValidationError(f"loaded TileSet source {source_id} tile coordinates do not match the recipe")
+        for coords, tile in expected_tiles.items():
+            loaded = actual_tiles_by_coords[coords]
             for key, default in (("coords", None), ("texture_origin", [0, 0]), ("z_index", 0), ("y_sort_origin", 0), ("probability", 1.0), ("terrain_set", -1), ("terrain", -1)):
                 actual_value = loaded.get(key)
                 expected_value = tile.get(key, default)
@@ -241,7 +275,20 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
             expected_alternatives = tile.get("alternatives", [])
             if len(loaded_alternatives) != len(expected_alternatives):
                 raise ValidationError("loaded TileSet alternatives do not match the recipe")
-            for alternative, actual_alternative in zip(expected_alternatives, loaded_alternatives):
+            expected_alternatives_by_id = {
+                alternative.get("id"): alternative
+                for alternative in expected_alternatives
+                if isinstance(alternative, dict)
+            }
+            actual_alternatives_by_id = {
+                alternative.get("id"): alternative
+                for alternative in loaded_alternatives
+                if isinstance(alternative, dict)
+            }
+            if set(actual_alternatives_by_id) != set(expected_alternatives_by_id):
+                raise ValidationError("loaded TileSet alternative ids do not match the recipe")
+            for alternative_id, alternative in expected_alternatives_by_id.items():
+                actual_alternative = actual_alternatives_by_id[alternative_id]
                 expected_alternative = _expected_tile(
                     alternative, request.spec, alternative=True
                 )

--- a/skills/assets/_shared/asset_validation/tileset.py
+++ b/skills/assets/_shared/asset_validation/tileset.py
@@ -13,7 +13,7 @@ CHECKS = ("tileset",)
 _SHAPES = {"square": 0, "isometric": 1, "half_offset_square": 2, "hexagon": 3}
 _ANIMATION_MODES = {"default": 0, "random_start_times": 1, "max": 2}
 _FLOAT32_ROUND_TRIP_TOLERANCE = 1e-6
-_CUSTOM_DATA_DEFAULTS = {1: False, 2: 0, 3: 0.0, 4: ""}
+_CUSTOM_DATA_DEFAULTS = {0: None, 1: False, 2: 0, 3: 0.0, 4: ""}
 
 
 def _same_float32_round_trip(actual: Any, expected: Any) -> bool:
@@ -86,6 +86,22 @@ def _same_navigation_polygons(actual: Any, expected: Any) -> bool:
                 return False
             if not all(_same_float32_round_trip(value, wanted) for value, wanted in zip(actual_point, expected_point)):
                 return False
+    return True
+
+
+def _same_custom_data(actual: Any, expected: Any, layers: list[dict[str, Any]]) -> bool:
+    if not isinstance(actual, list) or not isinstance(expected, list) or len(actual) != len(expected) or len(actual) != len(layers):
+        return False
+    expected_types = {0: type(None), 1: bool, 2: int, 4: str}
+    for actual_value, expected_value, layer in zip(actual, expected, layers):
+        value_type = layer.get("type", 0)
+        if value_type == 3:
+            if not _same_float32_round_trip(actual_value, expected_value):
+                return False
+        elif value_type not in expected_types or type(actual_value) is not expected_types[value_type] or type(expected_value) is not expected_types[value_type]:
+            return False
+        elif actual_value != expected_value:
+            return False
     return True
 
 
@@ -215,6 +231,8 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
                     if key in {"collision_polygons", "occlusion_polygons"}
                     else _same_navigation_polygons(loaded.get(key), value)
                     if key == "navigation_polygons"
+                    else _same_custom_data(loaded.get(key), value, request.spec.get("custom_data_layers", []))
+                    if key == "custom_data"
                     else loaded.get(key) == value
                 )
                 if key != "id" and not matches:
@@ -234,6 +252,8 @@ def validate_tileset(request: StructureRequest) -> dict[str, Any]:
                     if key in {"collision_polygons", "occlusion_polygons"}
                     else _same_navigation_polygons(actual_alternative.get(key), expected_value)
                     if key == "navigation_polygons"
+                    else _same_custom_data(actual_alternative.get(key), expected_value, request.spec.get("custom_data_layers", []))
+                    if key == "custom_data"
                     else actual_alternative.get(key) == expected_value
                     for key, expected_value in expected_alternative.items()
                 )

--- a/skills/assets/tileset/SKILL.md
+++ b/skills/assets/tileset/SKILL.md
@@ -99,6 +99,15 @@ At TileSet scope, explicitly declare any `physics_layers`,
 `terrain_sets`. Terrain peering bits, polygons, custom data, alternatives, and
 animation timing are recipe data. Never infer them from the atlas image.
 
+TileSet v1 custom data is deliberately limited to Godot's scalar Variant
+types: `NIL` (type `0`, value `null`), `bool` (`1`), `int` (`2`), `float`
+(`3`, finite JSON number), and `String` (`4`). Each `custom_data[].value` must
+match the declared layer type exactly; arrays, objects, resources, vectors, and
+all other Variant types are outside v1 and must be rejected before Godot runs.
+Only one custom-data value and one terrain peering bit may be declared per
+layer/bit on a tile or alternative. Polygon layers and terrain references must
+refer to declared layer and terrain indexes.
+
 An animation declares `mode` (`default`, `random_start_times`, or `max`),
 positive `frames_count`, positive `columns`, non-negative `separation`,
 positive `speed`, and optional continuous `frame_durations`. Each alternative

--- a/skills/assets/tileset/SKILL.md
+++ b/skills/assets/tileset/SKILL.md
@@ -90,9 +90,11 @@ recipe is:
 `hexagon`; v1 verification is deepest for `square`. Each source has a unique
 non-negative `id`, a `res://` texture path, and an explicit `tiles` list. Each
 tile supplies `coords` and may declare `texture_origin`, `z_index`,
-`y_sort_origin`, `probability`, `terrain_set`, `terrain`, `peering_bits`,
-`custom_data`, collision polygons, navigation polygons, occlusion polygons,
-alternatives, and animation.
+ `y_sort_origin`, `probability`, `terrain_set`, `terrain`, `peering_bits`,
+ `custom_data`, collision polygons, navigation polygons, occlusion polygons,
+ alternatives, and animation. `probability` is a finite non-negative relative
+ weight; it is not capped at `1.0`. Alternative tiles use the same data fields
+ except `coords` and animation; animation belongs to the base tile.
 
 At TileSet scope, explicitly declare any `physics_layers`,
 `navigation_layers`, `occlusion_layers`, `custom_data_layers`, and
@@ -106,16 +108,22 @@ match the declared layer type exactly; arrays, objects, resources, vectors, and
 all other Variant types are outside v1 and must be rejected before Godot runs.
 Only one custom-data value and one terrain peering bit may be declared per
 layer/bit on a tile or alternative. Polygon layers and terrain references must
-refer to declared layer and terrain indexes.
+refer to declared layer and terrain indexes. Custom-data layer names must be
+unique. Peering bits must be valid for the declared tile shape and terrain-set
+mode; use the orthogonal square path for the deepest v1 evidence.
 
 An animation declares `mode` (`default`, `random_start_times`, or `max`),
 positive `frames_count`, positive `columns`, non-negative `separation`,
-positive `speed`, and optional continuous `frame_durations`. Each alternative
-has a positive integer `id`.
+positive `speed`, and optional continuous `frame_durations`. Omit
+`frame_durations` to use Godot's defaults; when supplied, it must declare every
+frame exactly once in order. Each alternative has a positive integer `id`.
+
+Every recipe object accepts only its documented keys. Unknown or misspelled
+fields are rejected before Godot runs rather than silently ignored.
 
 See `fixtures/orthogonal-square-recipe.json` for the representative orthogonal
 square fixture, including one terrain tile, one collision polygon, and an
-explicit alternative.
+explicit alternative plus all five v1 custom-data scalar types.
 
 ## Processing and Validation
 

--- a/skills/assets/tileset/fixtures/orthogonal-square-recipe.json
+++ b/skills/assets/tileset/fixtures/orthogonal-square-recipe.json
@@ -3,6 +3,13 @@
   "tile_shape": "square",
   "tile_size": [16, 16],
   "physics_layers": [{"collision_layer": 1, "collision_mask": 1}],
+  "custom_data_layers": [
+    {"name": "nothing", "type": 0},
+    {"name": "walkable", "type": 1},
+    {"name": "cost", "type": 2},
+    {"name": "weight", "type": 3},
+    {"name": "kind", "type": 4}
+  ],
   "terrain_sets": [{
     "mode": 0,
     "terrains": [{"name": "grass", "color": [0.2, 0.8, 0.3]}]
@@ -18,6 +25,13 @@
       "terrain_set": 0,
       "terrain": 0,
       "peering_bits": [{"bit": 0, "terrain": 0}],
+      "custom_data": [
+        {"layer": 0, "value": null},
+        {"layer": 1, "value": true},
+        {"layer": 2, "value": 1},
+        {"layer": 3, "value": 0.5},
+        {"layer": 4, "value": "grass"}
+      ],
       "collision_polygons": [{"layer": 0, "points": [[0, 0], [16, 0], [16, 16], [0, 16]]}],
       "alternatives": [{"id": 1, "probability": 0.25}]
     }]

--- a/tests/assets/test_tileset_compiler.py
+++ b/tests/assets/test_tileset_compiler.py
@@ -29,6 +29,15 @@ def _spec(**changes):
     return recipe
 
 
+def _recipe_request(tmp_path, spec):
+    return CompileRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/grass.tres", project_root=tmp_path,
+        spec=spec,
+    )
+
+
 def test_tileset_route_is_explicit_and_does_not_mutate_the_shared_default_registry():
     registry = CompilerRegistry()
     compiler.register_into(registry)
@@ -137,6 +146,83 @@ def test_tileset_recipe_rejects_duplicate_navigation_polygon_layers(tmp_path, al
     )
     with pytest.raises(CompilerError, match="duplicate navigation polygons"):
         compiler._recipe(request)
+
+
+def test_tileset_recipe_accepts_only_the_five_v1_custom_data_scalars(tmp_path):
+    recipe = compiler._recipe(_recipe_request(tmp_path, _spec(
+        custom_data_layers=[
+            {"name": "nothing", "type": 0}, {"name": "enabled", "type": 1},
+            {"name": "count", "type": 2}, {"name": "weight", "type": 3},
+            {"name": "label", "type": 4},
+        ],
+        sources=[{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{
+            "coords": [0, 0],
+            "custom_data": [
+                {"layer": 0, "value": None}, {"layer": 1, "value": True},
+                {"layer": 2, "value": 7}, {"layer": 3, "value": -0.25},
+                {"layer": 4, "value": "grass"},
+            ],
+            "alternatives": [{"id": 1, "custom_data": [{"layer": 4, "value": "alt"}]}],
+        }]}],
+    )))
+    assert recipe["sources"][0]["tiles"][0]["custom_data"][-1]["value"] == "grass"
+    assert recipe["sources"][0]["tiles"][0]["alternatives"][0]["custom_data"] == [{"layer": 4, "value": "alt"}]
+
+
+@pytest.mark.parametrize(
+    "layer_type, value, message",
+    [
+        (0, "not-nil", "NIL scalar"),
+        (1, 1, "bool scalar"),
+        (2, True, "int scalar"),
+        (3, float("nan"), "finite number"),
+        (4, ["nested"], "String scalar"),
+    ],
+)
+def test_tileset_recipe_rejects_non_scalar_or_mismatched_custom_data(tmp_path, layer_type, value, message):
+    request = _recipe_request(tmp_path, _spec(
+        custom_data_layers=[{"name": "value", "type": layer_type}],
+        sources=[{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{
+            "coords": [0, 0], "custom_data": [{"layer": 0, "value": value}],
+        }]}],
+    ))
+    with pytest.raises(CompilerError, match=message):
+        compiler._recipe(request)
+
+
+@pytest.mark.parametrize(
+    "changes, message",
+    [
+        ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "texture_origin": [0, "bad"]}]}]}, "texture_origin"),
+        ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "z_index": 4097}]}]}, "z_index"),
+        ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "y_sort_origin": 1.5}]}]}, "y_sort_origin"),
+        ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "probability": float("inf")}]}]}, "probability"),
+        ({"physics_layers": [{}], "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "collision_polygons": [{"layer": 1, "points": [[0, 0], [1, 0], [0, 1]]}]}]}]}, "collision polygon layer"),
+        ({"terrain_sets": [{"terrains": [{"name": "grass"}]}], "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "terrain_set": 1}]}]}, "terrain_set"),
+        ({"terrain_sets": [{"terrains": [{"name": "grass"}]}], "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "terrain_set": 0, "peering_bits": [{"bit": 16, "terrain": 0}]}]}]}, "peering bit"),
+        ({"terrain_sets": [{"terrains": [{"name": "grass"}]}], "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "terrain_set": 0, "peering_bits": [{"bit": 0, "terrain": 1}]}]}]}, "peering terrain"),
+        ({"physics_layers": [{}], "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "collision_polygons": [{"layer": 0, "points": [[0, 0], [1, 0]]}]}]}]}, "at least three points"),
+        ({"terrain_sets": [{"terrains": [{"name": "grass"}]}], "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "terrain_set": 0, "peering_bits": [{"bit": 0, "terrain": 0}, {"bit": 0, "terrain": 0}]}]}]}, "duplicate peering bits"),
+        ({"custom_data_layers": [{"name": "value", "type": 2}], "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "custom_data": [{"layer": 0, "value": 1}, {"layer": 0, "value": 2}]}]}]}, "duplicate custom data layers"),
+    ],
+)
+def test_tileset_recipe_rejects_invalid_declared_tile_semantics(tmp_path, changes, message):
+    with pytest.raises(CompilerError, match=message):
+        compiler._recipe(_recipe_request(tmp_path, _spec(**changes)))
+
+
+def test_tileset_recipe_rejects_duplicate_tile_coords_and_alternative_ids(tmp_path):
+    source = "res://assets/generated/tileset/grass/atlas.png"
+    duplicate_coords = _recipe_request(tmp_path, _spec(sources=[{
+        "texture": source, "tiles": [{"coords": [0, 0]}, {"coords": [0, 0]}],
+    }]))
+    duplicate_alternatives = _recipe_request(tmp_path, _spec(sources=[{
+        "texture": source, "tiles": [{"coords": [0, 0], "alternatives": [{"id": 1}, {"id": 1}]}],
+    }]))
+    with pytest.raises(CompilerError, match="duplicate tile coords"):
+        compiler._recipe(duplicate_coords)
+    with pytest.raises(CompilerError, match="duplicate alternative ids"):
+        compiler._recipe(duplicate_alternatives)
 
 
 def _png(width: int, height: int) -> bytes:

--- a/tests/assets/test_tileset_compiler.py
+++ b/tests/assets/test_tileset_compiler.py
@@ -94,6 +94,45 @@ def test_tileset_structure_validator_fails_on_unexpected_loaded_tile_count():
         structures.validate_tileset(request)
 
 
+def test_tileset_l4_matches_sources_tiles_and_alternatives_by_identity_not_declaration_order():
+    def loaded_tile(coords, alternatives=None):
+        return {
+            "coords": coords, "texture_origin": [0, 0], "z_index": 0,
+            "y_sort_origin": 0, "probability": 1.0, "terrain_set": -1,
+            "terrain": -1, "peering_bits": [-1] * 16, "custom_data": [],
+            "collision_polygons": [], "occlusion_polygons": [],
+            "navigation_polygons": [], "alternatives": alternatives or [],
+        }
+
+    alternative_one = {**loaded_tile([1, 0]), "id": 1}
+    alternative_three = {**loaded_tile([1, 0]), "id": 3}
+    spec = _spec(sources=[
+        {"id": 5, "texture": "res://assets/generated/tileset/grass/first.png", "tile_size": [32, 32], "tiles": [{
+            "coords": [1, 0], "alternatives": [{"id": 3}, {"id": 1}],
+        }]},
+        {"id": 3, "texture": "res://assets/generated/tileset/grass/second.png", "tiles": [{"coords": [0, 0]}]},
+    ])
+    facts = {"tileset": {
+        "source_count": 2, "tile_count": 2, "alternative_count": 2,
+        "tile_shape": 0, "tile_size": [16, 16],
+        "sources": [
+            {"id": 3, "region_size": [16, 16], "margins": [0, 0], "separation": [0, 0], "tiles": [loaded_tile([0, 0])]},
+            {"id": 5, "region_size": [32, 32], "margins": [0, 0], "separation": [0, 0], "tiles": [loaded_tile([1, 0], [alternative_one, alternative_three])]},
+        ],
+        "physics_layers_count": 0, "navigation_layers_count": 0,
+        "occlusion_layers_count": 0, "custom_data_layers_count": 0,
+        "terrain_sets_count": 0, "physics_layers": [], "navigation_layers": [],
+        "occlusion_layers": [], "custom_data_layers": [], "terrain_sets": [],
+    }}
+    request = StructureRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+        artifact_path="res://assets/generated/tileset/grass/grass.tres", project_root=Path("."),
+        probe=ProbeResult("res://x", "TileSet", True, "TileSet", True, structure=facts), spec=spec,
+    )
+    structures.validate_tileset(request)
+
+
 def test_l4_normalizes_rgb_and_default_layer_recipe_values():
     normalized = structures._expected_layers({
         "physics_layers": [{}],
@@ -194,7 +233,7 @@ def test_tileset_recipe_rejects_non_scalar_or_mismatched_custom_data(tmp_path, l
     "changes, message",
     [
         ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "texture_origin": [0, "bad"]}]}]}, "texture_origin"),
-        ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "z_index": 4097}]}]}, "z_index"),
+        ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "z_index": 1.5}]}]}, "z_index"),
         ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "y_sort_origin": 1.5}]}]}, "y_sort_origin"),
         ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "probability": float("inf")}]}]}, "probability"),
         ({"physics_layers": [{}], "sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "collision_polygons": [{"layer": 1, "points": [[0, 0], [1, 0], [0, 1]]}]}]}]}, "collision polygon layer"),
@@ -223,6 +262,66 @@ def test_tileset_recipe_rejects_duplicate_tile_coords_and_alternative_ids(tmp_pa
         compiler._recipe(duplicate_coords)
     with pytest.raises(CompilerError, match="duplicate alternative ids"):
         compiler._recipe(duplicate_alternatives)
+
+
+def test_tileset_recipe_keeps_probability_as_a_non_negative_relative_weight(tmp_path):
+    recipe = compiler._recipe(_recipe_request(tmp_path, _spec(sources=[{
+        "texture": "res://assets/generated/tileset/grass/atlas.png",
+        "tiles": [{"coords": [0, 0], "probability": 3.0}],
+    }])))
+    assert recipe["sources"][0]["tiles"][0]["probability"] == 3.0
+    negative = _recipe_request(tmp_path, _spec(sources=[{
+        "texture": "res://assets/generated/tileset/grass/atlas.png",
+        "tiles": [{"coords": [0, 0], "probability": -0.1}],
+    }]))
+    with pytest.raises(CompilerError, match="probability must be non-negative"):
+        compiler._recipe(negative)
+
+
+@pytest.mark.parametrize(
+    "changes, message",
+    [
+        ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "probabilty": 0.25}]}]}, "unsupported fields: probabilty"),
+        ({"sources": [{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{"coords": [0, 0], "alternatives": [{"id": 1, "z-index": 2}]}]}]}, "unsupported fields: z-index"),
+        ({"physics_layers": [{"collision-layer": 1}]}, "unsupported fields: collision-layer"),
+        ({"terrain_sets": [{"terrains": [{"name": "grass", "colour": [1, 1, 1]}]}]}, "unsupported fields: colour"),
+    ],
+)
+def test_tileset_recipe_rejects_unknown_recipe_fields(tmp_path, changes, message):
+    with pytest.raises(CompilerError, match=message):
+        compiler._recipe(_recipe_request(tmp_path, _spec(**changes)))
+
+
+def test_tileset_recipe_rejects_invalid_peering_bits_for_shape_and_mode(tmp_path):
+    source = "res://assets/generated/tileset/grass/atlas.png"
+    invalid_square = _recipe_request(tmp_path, _spec(terrain_sets=[{"mode": 0, "terrains": [{"name": "grass"}]}], sources=[{
+        "texture": source, "tiles": [{"coords": [0, 0], "terrain_set": 0, "peering_bits": [{"bit": 2, "terrain": 0}]}],
+    }]))
+    invalid_corners = _recipe_request(tmp_path, _spec(terrain_sets=[{"mode": 1, "terrains": [{"name": "grass"}]}], sources=[{
+        "texture": source, "tiles": [{"coords": [0, 0], "terrain_set": 0, "peering_bits": [{"bit": 0, "terrain": 0}]}],
+    }]))
+    valid_square = _recipe_request(tmp_path, _spec(terrain_sets=[{"mode": 0, "terrains": [{"name": "grass"}]}], sources=[{
+        "texture": source, "tiles": [{"coords": [0, 0], "terrain_set": 0, "peering_bits": [{"bit": 3, "terrain": 0}]}],
+    }]))
+    with pytest.raises(CompilerError, match="invalid for the tile_shape and terrain mode"):
+        compiler._recipe(invalid_square)
+    with pytest.raises(CompilerError, match="invalid for the tile_shape and terrain mode"):
+        compiler._recipe(invalid_corners)
+    compiler._recipe(valid_square)
+
+
+def test_tileset_recipe_rejects_duplicate_custom_data_layer_names_and_empty_declared_durations(tmp_path):
+    duplicate_names = _recipe_request(tmp_path, _spec(
+        custom_data_layers=[{"name": "cost", "type": 2}, {"name": "cost", "type": 3}],
+    ))
+    empty_durations = _recipe_request(tmp_path, _spec(sources=[{
+        "texture": "res://assets/generated/tileset/grass/atlas.png",
+        "tiles": [{"coords": [0, 0], "animation": {"frames_count": 2, "frame_durations": []}}],
+    }]))
+    with pytest.raises(CompilerError, match="layer names must be unique"):
+        compiler._recipe(duplicate_names)
+    with pytest.raises(CompilerError, match="frame_durations must declare every frame"):
+        compiler._recipe(empty_durations)
 
 
 def _png(width: int, height: int) -> bytes:

--- a/tests/assets/test_tileset_skill_contract.py
+++ b/tests/assets/test_tileset_skill_contract.py
@@ -55,6 +55,8 @@ def test_tileset_skill_documents_recipe_only_semantics_and_l0_to_l4():
         "occlusion polygons",
         "alternatives",
         "animation",
+        "NIL",
+        "all other Variant types are outside v1",
     ):
         assert field in text
     assert "Never infer them from the atlas image." in text
@@ -127,20 +129,23 @@ def test_standalone_runner_maps_request_result_l0_to_l4_without_a_stable_entry(
                     "coords": [0, 0], "texture_origin": [0, 0], "z_index": 0,
                     "y_sort_origin": 0, "probability": 1.0, "terrain_set": 0,
                     "terrain": 0, "peering_bits": [0] + [-1] * 15,
-                    "custom_data": [], "collision_polygons": [[[[0, 0], [16, 0], [16, 16], [0, 16]]]],
+                    "custom_data": [None, True, 1, 0.5, "grass"], "collision_polygons": [[[[0, 0], [16, 0], [16, 16], [0, 16]]]],
                     "occlusion_polygons": [], "navigation_polygons": [], "alternatives": [{
                         "id": 1, "texture_origin": [0, 0], "z_index": 0, "y_sort_origin": 0,
                         "probability": 0.25, "terrain_set": -1, "terrain": -1,
-                        "peering_bits": [-1] * 16, "custom_data": [], "collision_polygons": [[]],
+                        "peering_bits": [-1] * 16, "custom_data": [None, False, 0, 0.0, ""], "collision_polygons": [[]],
                         "occlusion_polygons": [], "navigation_polygons": [],
                     }],
                 }],
             }],
             "physics_layers_count": 1, "navigation_layers_count": 0,
-            "occlusion_layers_count": 0, "custom_data_layers_count": 0,
+            "occlusion_layers_count": 0, "custom_data_layers_count": 5,
             "terrain_sets_count": 1,
             "physics_layers": [{"collision_layer": 1, "collision_mask": 1}],
-            "navigation_layers": [], "occlusion_layers": [], "custom_data_layers": [],
+            "navigation_layers": [], "occlusion_layers": [], "custom_data_layers": [
+                {"name": "nothing", "type": 0}, {"name": "walkable", "type": 1},
+                {"name": "cost", "type": 2}, {"name": "weight", "type": 3}, {"name": "kind", "type": 4},
+            ],
             "terrain_sets": [{"mode": 0, "terrains": [{"name": "grass", "color": [0.2, 0.8, 0.3, 1.0]}]}],
         }
     }

--- a/tests/assets/test_tileset_skill_contract.py
+++ b/tests/assets/test_tileset_skill_contract.py
@@ -57,6 +57,8 @@ def test_tileset_skill_documents_recipe_only_semantics_and_l0_to_l4():
         "animation",
         "NIL",
         "all other Variant types are outside v1",
+        "relative\n weight",
+        "Unknown or misspelled\nfields are rejected",
     ):
         assert field in text
     assert "Never infer them from the atlas image." in text


### PR DESCRIPTION
## Summary

Harden TileSet v1 recipe validation so declared tile, alternative, layer, terrain, polygon, custom-data, and animation values fail before Godot is invoked. Restrict v1 custom data to NIL, bool, int, finite float, and String scalars; document the support boundary and cover it in fixtures and contract tests.

## Motivation

Nested recipe values could previously be coerced, overwritten, silently ignored, or fail only after Godot launched. This change makes the declared v1 contract deterministic and fail-closed.

## Changes

- [x] Add local type, finite-value, index-range, duplicate, and supported-field validation across declared TileSet recipe families.
- [x] Validate terrain peering bits against the declared tile shape and terrain mode, and compare L4 results by stable identities rather than declaration order.
- [x] Align source-level tile-size fallback with L4 validation and document non-negative `probability` as a relative weight.

## Testing

- [x] New or updated tests pass: `python -m pytest -q` (1936 passed, 31 skipped).
- [x] Gitleaks passes or no secret-bearing files were touched: `Secret Scan` GitHub check passed.
- [x] Manual testing complete, if applicable: local validation was exercised; real headless Godot L3/L4 tests remain conditionally skipped because no Godot executable is available in the execution environment.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold `migrations/<utc-timestamp>_<slug>.py`. The script must define `migrate(target: Path) -> None` and be idempotent. The bump level does NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Not applicable: no migration script was added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable: no ECS systems changed)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only, typo, or maintenance-only PR (not applicable: this is a validation-contract change and no release-note entry is required by the repository workflow)
