### PR TITLE
Add standalone asset family validation

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -17,6 +17,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Added
 
+- Added fail-closed standalone L0-L4 execution for the remaining first-class Asset Skills, with published runners and native Godot resource verification.
+
 - Added a standalone TileSet Asset Skill with an explicit atlas and recipe contract, shared compiler and validation reuse, and an orthogonal-square fixture.
 - Added standalone ui-kit and card-kit Asset Skills with closed request contracts and executable L0-L4 validation for Theme, StyleBoxTexture, and AtlasTexture resources.
 - Added a recipe-only native TileSet atlas compiler with declared tile semantics and L4 source, tile, alternative, layer, and tile-size verification.

--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -9,7 +9,9 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from copy import deepcopy
+import json
 from pathlib import Path
+import struct
 from typing import Any
 
 from asset_compiler import CompileRequest, CompilerError, build_default_registry
@@ -90,7 +92,11 @@ def _stable_path(family: str, asset_id: str, name: str, suffix: str) -> str:
 def _project_file(root: Path, path: Any, label: str) -> Path:
     if not isinstance(path, str) or not path.strip():
         raise ValidationError(f"{label} must be a non-empty project-relative path")
-    candidate = (root / path).resolve()
+    candidate = (
+        resolve_res_path(root, path, label=label)
+        if path.startswith("res://")
+        else (root / path).resolve()
+    )
     if not candidate.is_relative_to(root.resolve()):
         raise ValidationError(f"{label} resolves outside the project root")
     return candidate
@@ -460,6 +466,88 @@ def _l1_file(root: Path, path: str, *, family: str, asset_id: str) -> Path:
     )
 
 
+def _png_dimensions(path: Path) -> tuple[int, int]:
+    """Read PNG dimensions from IHDR without loading the image into memory."""
+    with path.open("rb") as handle:
+        header = handle.read(24)
+    if (
+        len(header) != 24
+        or header[:8] != b"\x89PNG\r\n\x1a\n"
+        or header[12:16] != b"IHDR"
+    ):
+        raise ValidationError(
+            f"delivered atlas is not a PNG with an IHDR header: {path}"
+        )
+    return struct.unpack(">II", header[16:24])
+
+
+def _verify_prop_delivery(
+    request: Mapping[str, Any], declaration: CompileRequest, root: Path
+) -> None:
+    """Bind delivered atlas dimensions and metadata regions to request.spec."""
+    family, asset_id = request["asset_type"], request["asset_id"]
+    atlas = _l1_file(root, declaration.source_path, family=family, asset_id=asset_id)
+    metadata = _l1_file(
+        root, declaration.spec["metadata_path"], family=family, asset_id=asset_id
+    )
+    if not atlas.is_file() or atlas.stat().st_size <= 0:
+        raise ValidationError(
+            f"standalone source is not a non-empty file: {declaration.source_path}"
+        )
+    if not metadata.is_file() or metadata.stat().st_size <= 0:
+        raise ValidationError(
+            f"atlas metadata is not a non-empty file: {declaration.spec['metadata_path']}"
+        )
+    try:
+        delivered = json.loads(metadata.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise ValidationError(f"atlas metadata is not valid JSON: {metadata}") from exc
+    if not isinstance(delivered, Mapping) or set(delivered) != {
+        "version",
+        "atlas_path",
+        "regions",
+    }:
+        raise ValidationError(
+            "atlas metadata must contain exactly version, atlas_path, and regions"
+        )
+    if (
+        delivered.get("version") != 1
+        or delivered.get("atlas_path") != declaration.source_path
+    ):
+        raise ValidationError(
+            "atlas metadata does not bind the delivered stable atlas path"
+        )
+    regions = delivered.get("regions")
+    if not isinstance(regions, list):
+        raise ValidationError("atlas metadata regions must be a list")
+    actual: dict[str, list[int]] = {}
+    for region in regions:
+        if (
+            not isinstance(region, Mapping)
+            or not isinstance(region.get("name"), str)
+            or not isinstance(region.get("rect"), list)
+            or len(region["rect"]) != 4
+            or any(type(value) is not int for value in region["rect"])
+            or region["name"] in actual
+        ):
+            raise ValidationError(
+                "atlas metadata regions must have unique named integer rectangles"
+            )
+        actual[region["name"]] = region["rect"]
+    expected = {slot["name"]: slot["rect"] for slot in request["spec"]["slots"]}
+    if actual != expected:
+        raise ValidationError(
+            "atlas metadata regions must exactly match declared slot names and rectangles"
+        )
+    if _png_dimensions(atlas) != (
+        request["spec"]["atlas"]["width"],
+        request["spec"]["atlas"]["height"],
+    ):
+        raise ValidationError(
+            "delivered atlas dimensions do not match the declared atlas"
+        )
+
+
 def compile_and_validate(
     request: Mapping[str, Any],
     result: Mapping[str, Any],
@@ -494,12 +582,14 @@ def compile_and_validate(
             if (
                 not file.is_file()
                 or file.stat().st_size <= 0
-                or file.read_bytes()[:8] != b"\x89PNG\r\n\x1a\n"
+                or _png_dimensions(file) == (0, 0)
             ):
                 raise ValidationError(
                     f"reference image is not a non-empty PNG file: {reference_path}"
                 )
             return _mapped(result, {"L0": True, "L1": True})
+        if family in {"compact-prop-pack", "scene-prop-set"}:
+            _verify_prop_delivery(request, declarations[0][1], root)
         for _, declaration in declarations:
             declaration = CompileRequest(
                 **{**declaration.__dict__, "project_root": root}

--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -1,0 +1,564 @@
+"""Executable standalone validation for the remaining first-class Asset Skills.
+
+The public asset result is only a declaration.  This module intentionally
+rebuilds its validation from the request, files, compiler, and Godot probe;
+the caller's ``validation`` object is overwritten rather than trusted.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from copy import deepcopy
+import json
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from asset_compiler import CompileRequest, CompilerError, build_default_registry
+from asset_compiler._stable_entry import (
+    StableEntryError,
+    assert_within_output_dir,
+    resolve_res_path,
+)
+from asset_validation import (
+    GodotProbe,
+    ProbeRequest,
+    ValidationError,
+    build_default_structures,
+)
+from asset_validation.structure import StructureRequest
+from asset_skill_contract_check import AssetContractError, check_request, check_result
+from asset_animated_bundle_contract_check import (
+    AnimatedBundleContractError,
+    build_spriteframes_spec,
+    check_bundle_request,
+    check_bundle_result,
+)
+from asset_atlas_assemble import AtlasAssemblyError, assemble_atlas
+
+
+class MissingFamilySkillError(Exception):
+    """Raised when a public request/result pair cannot enter standalone L0."""
+
+
+_LEVELS = ("L0", "L1", "L2", "L3", "L4")
+_FAMILIES = {
+    "background-map",
+    "platform-strip",
+    "screen-reference",
+    "character-bundle",
+    "fx-bundle",
+    "compact-prop-pack",
+    "scene-prop-set",
+}
+
+
+def _mapped(
+    result: Mapping[str, Any],
+    levels: Mapping[str, bool],
+    error: Exception | None = None,
+) -> dict[str, Any]:
+    mapped = deepcopy(dict(result))
+    mapped["validation"] = {"passed": all(levels.values()), "levels": dict(levels)}
+    if error is not None:
+        mapped["validation"]["notes"] = str(error)
+    try:
+        check_result(mapped)
+    except AssetContractError as exc:  # protected by L0
+        raise MissingFamilySkillError(f"cannot map validation result: {exc}") from exc
+    return mapped
+
+
+def _failure(
+    result: Mapping[str, Any], passed: list[str], level: str, error: Exception
+) -> dict[str, Any]:
+    levels = {name: name in passed for name in _LEVELS}
+    levels[level] = False
+    return _mapped(result, levels, error)
+
+
+def _runtime(result: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    return [item for item in result["outputs"] if item["role"] == "runtime"]
+
+
+def _stable_path(family: str, asset_id: str, name: str, suffix: str) -> str:
+    return f"res://assets/generated/{family}/{asset_id}/{name}{suffix}"
+
+
+def _exact_keys(value: Any, keys: set[str], label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping) or set(value) != keys:
+        raise MissingFamilySkillError(
+            f"{label} must contain exactly {', '.join(sorted(keys))}"
+        )
+    return value
+
+
+def _check_background(
+    request: Mapping[str, Any], result: Mapping[str, Any]
+) -> list[tuple[Mapping[str, Any], CompileRequest]]:
+    asset_id = request["asset_id"]
+    outputs = _runtime(result)
+    path = _stable_path("background-map", asset_id, asset_id, ".png")
+    if (
+        len(outputs) != 1
+        or outputs[0].get("name") != asset_id
+        or outputs[0].get("path") != path
+        or outputs[0].get("godot_type") != "Texture2D"
+    ):
+        raise MissingFamilySkillError(
+            "background-map needs exactly its stable Texture2D runtime output"
+        )
+    if result["sources"] != [{"path": path, "layout": "single"}]:
+        raise MissingFamilySkillError(
+            "background-map result needs exactly its stable single source"
+        )
+    output = outputs[0]
+    return [
+        (
+            output,
+            CompileRequest(
+                "background-map", asset_id, "single", path, "Texture2D", path, Path(".")
+            ),
+        )
+    ]
+
+
+def _check_screen_reference(
+    request: Mapping[str, Any], result: Mapping[str, Any]
+) -> str:
+    asset_id = request["asset_id"]
+    expected = f"references/{asset_id}.png"
+    if _runtime(result) or result["sources"] or len(result["outputs"]) != 1:
+        raise MissingFamilySkillError(
+            "screen-reference must have one reference output and no runtime source"
+        )
+    output = result["outputs"][0]
+    if (
+        output.get("role") != "reference"
+        or output.get("name") != asset_id
+        or output.get("path") != expected
+        or "godot_type" in output
+    ):
+        raise MissingFamilySkillError(
+            "screen-reference output must use its stable reference path"
+        )
+    return expected
+
+
+def _check_platform(
+    request: Mapping[str, Any], result: Mapping[str, Any]
+) -> list[tuple[Mapping[str, Any], CompileRequest]]:
+    spec = _exact_keys(request.get("spec"), {"kind", "segments"}, "platform-strip spec")
+    kind = spec.get("kind")
+    segments = spec.get("segments")
+    if (
+        kind not in {"single", "atlas"}
+        or not isinstance(segments, list)
+        or not segments
+    ):
+        raise MissingFamilySkillError(
+            "platform-strip spec needs kind single/atlas and non-empty segments"
+        )
+    asset_id = request["asset_id"]
+    expected: list[tuple[Mapping[str, Any], CompileRequest]] = []
+    sources: list[dict[str, str]] = []
+    names: set[str] = set()
+    for item in segments:
+        entry = _exact_keys(item, {"name"}, "platform-strip segment")
+        name = entry.get("name")
+        if not isinstance(name, str) or not name or name in names:
+            raise MissingFamilySkillError(
+                "platform-strip segment names must be unique non-empty strings"
+            )
+        names.add(name)
+        if kind == "single":
+            path = _stable_path("platform-strip", asset_id, name, ".png")
+            sources.append({"path": path, "layout": "single"})
+            expected.append(
+                (
+                    {"name": name, "path": path, "godot_type": "Texture2D"},
+                    CompileRequest(
+                        "platform-strip",
+                        asset_id,
+                        "single",
+                        path,
+                        "Texture2D",
+                        path,
+                        Path("."),
+                    ),
+                )
+            )
+        else:
+            source = _stable_path("platform-strip", asset_id, asset_id, ".png")
+            sources = [{"path": source, "layout": "region_atlas"}]
+            expected.append(
+                (
+                    {
+                        "name": name,
+                        "path": _stable_path("platform-strip", asset_id, name, ".tres"),
+                        "godot_type": "AtlasTexture",
+                    },
+                    CompileRequest(
+                        "platform-strip",
+                        asset_id,
+                        "region_atlas",
+                        source,
+                        "AtlasTexture",
+                        _stable_path("platform-strip", asset_id, name, ".tres"),
+                        Path("."),
+                        {
+                            "metadata_path": _stable_path(
+                                "platform-strip", asset_id, asset_id, ".json"
+                            ),
+                            "logical_asset_id": name,
+                        },
+                    ),
+                )
+            )
+    actual = {
+        (item.get("name"), item.get("path"), item.get("godot_type"))
+        for item in _runtime(result)
+    }
+    wanted = {
+        (item[0]["name"], item[0]["path"], item[0]["godot_type"]) for item in expected
+    }
+    if (
+        len(_runtime(result)) != len(wanted)
+        or actual != wanted
+        or result["sources"] != sources
+    ):
+        raise MissingFamilySkillError(
+            "platform-strip result must bind every declared segment to its stable native output"
+        )
+    return expected
+
+
+def _check_bundle(
+    request: Mapping[str, Any], result: Mapping[str, Any]
+) -> list[tuple[Mapping[str, Any], CompileRequest]]:
+    try:
+        check_bundle_request(request)
+        check_bundle_result(result)
+    except AnimatedBundleContractError as exc:
+        raise MissingFamilySkillError(str(exc)) from exc
+    if request["asset_type"] != result["asset_type"]:
+        raise MissingFamilySkillError("request.asset_type must match result.asset_type")
+    family, asset_id = request["asset_type"], request["asset_id"]
+    outputs = _runtime(result)
+    if len(outputs) != 1 or outputs[0].get("name") != asset_id:
+        raise MissingFamilySkillError(
+            "bundle result must have exactly one stable runtime output"
+        )
+    output = outputs[0]
+    if family == "fx-bundle" and request["spec"]["mode"] == "static":
+        path = _stable_path(family, asset_id, asset_id, ".png")
+        if (
+            output.get("godot_type") != "Texture2D"
+            or output.get("path") != path
+            or result["sources"] != [{"path": path, "layout": "single"}]
+        ):
+            raise MissingFamilySkillError(
+                "static FX must bind its stable PNG Texture2D"
+            )
+        return [
+            (
+                output,
+                CompileRequest(
+                    family, asset_id, "single", path, "Texture2D", path, Path(".")
+                ),
+            )
+        ]
+    path = _stable_path(family, asset_id, asset_id, ".tres")
+    if output.get("godot_type") != "SpriteFrames" or output.get("path") != path:
+        raise MissingFamilySkillError(
+            "animated bundle must bind its stable SpriteFrames output"
+        )
+    sheets = [
+        source["path"]
+        for source in result["sources"]
+        if source.get("layout") == "grid_sheet"
+    ]
+    if not sheets:
+        raise MissingFamilySkillError("animated bundle needs a grid_sheet source")
+    frame_paths: dict[str, list[str]] = {}
+    for action in request["spec"]["actions"]:
+        action_name = action["name"]
+        frame_paths[action_name] = [
+            _stable_path(family, asset_id, f"{asset_id}_{action_name}_{frame}", ".png")
+            for frame in action["frame_names"]
+        ]
+    try:
+        compiler_spec = build_spriteframes_spec(request, frame_paths)
+    except AnimatedBundleContractError as exc:
+        raise MissingFamilySkillError(str(exc)) from exc
+    return [
+        (
+            output,
+            CompileRequest(
+                family,
+                asset_id,
+                "grid_sheet",
+                sheets[0],
+                "SpriteFrames",
+                path,
+                Path("."),
+                compiler_spec,
+            ),
+        )
+    ]
+
+
+def _check_props(
+    request: Mapping[str, Any], result: Mapping[str, Any]
+) -> list[tuple[Mapping[str, Any], CompileRequest]]:
+    family, asset_id = request["asset_type"], request["asset_id"]
+    spec = _exact_keys(
+        request.get("spec"), {"version", "atlas", "slots"}, f"{family} spec"
+    )
+    if (
+        spec.get("version") != 1
+        or not isinstance(spec.get("slots"), list)
+        or not spec["slots"]
+    ):
+        raise MissingFamilySkillError(
+            f"{family} spec must be a v1 non-empty fixed-slot declaration"
+        )
+    slots = spec["slots"]
+    names = [item.get("name") for item in slots if isinstance(item, Mapping)]
+    if (
+        len(names) != len(slots)
+        or any(not isinstance(name, str) or not name for name in names)
+        or len(set(names)) != len(names)
+    ):
+        raise MissingFamilySkillError(
+            f"{family} slots must have unique non-empty names"
+        )
+    source = _stable_path(family, asset_id, asset_id, ".png")
+    metadata = _stable_path(family, asset_id, asset_id, ".json")
+    if result["sources"] != [{"path": source, "layout": "region_atlas"}]:
+        raise MissingFamilySkillError(
+            f"{family} result must declare its one stable region_atlas source"
+        )
+    expected = [
+        (
+            {
+                "name": name,
+                "path": _stable_path(family, asset_id, name, ".tres"),
+                "godot_type": "AtlasTexture",
+            },
+            CompileRequest(
+                family,
+                asset_id,
+                "region_atlas",
+                source,
+                "AtlasTexture",
+                _stable_path(family, asset_id, name, ".tres"),
+                Path("."),
+                {"metadata_path": metadata, "logical_asset_id": name},
+            ),
+        )
+        for name in names
+    ]
+    actual = {
+        (item.get("name"), item.get("path"), item.get("godot_type"))
+        for item in _runtime(result)
+    }
+    wanted = {
+        (item[0]["name"], item[0]["path"], item[0]["godot_type"]) for item in expected
+    }
+    if len(_runtime(result)) != len(wanted) or actual != wanted:
+        raise MissingFamilySkillError(
+            f"{family} result must expose every declared slot exactly once"
+        )
+    return expected
+
+
+def _declarations(
+    request: Mapping[str, Any], result: Mapping[str, Any]
+) -> tuple[str | None, list[tuple[Mapping[str, Any], CompileRequest]]]:
+    family = request["asset_type"]
+    if family == "background-map":
+        return None, _check_background(request, result)
+    if family == "screen-reference":
+        return _check_screen_reference(request, result), []
+    if family == "platform-strip":
+        return None, _check_platform(request, result)
+    if family in {"character-bundle", "fx-bundle"}:
+        return None, _check_bundle(request, result)
+    return None, _check_props(request, result)
+
+
+def _l1_file(root: Path, path: str, *, family: str, asset_id: str) -> Path:
+    return assert_within_output_dir(
+        root,
+        resolve_res_path(root, path, label="standalone source"),
+        production_family=family,
+        asset_id=asset_id,
+        label="standalone source",
+    )
+
+
+def compile_and_validate(
+    request: Mapping[str, Any],
+    result: Mapping[str, Any],
+    *,
+    project_root: Path,
+    godot_path: str,
+) -> dict[str, Any]:
+    """Execute the real applicable ladder for one of the seven missing families."""
+    try:
+        check_request(request)
+        check_result(result)
+        if (
+            request["asset_type"] not in _FAMILIES
+            or result["asset_type"] != request["asset_type"]
+        ):
+            raise MissingFamilySkillError(
+                "standalone validation needs one supported matching asset_type"
+            )
+        reference_path, declarations = _declarations(request, result)
+    except (AssetContractError, MissingFamilySkillError) as exc:
+        raise MissingFamilySkillError(f"L0 standalone contract failed: {exc}") from exc
+    root, family, asset_id = (
+        Path(project_root),
+        request["asset_type"],
+        request["asset_id"],
+    )
+    passed = ["L0"]
+    try:
+        if reference_path is not None:
+            file = (root / reference_path).resolve()
+            if (
+                not file.is_relative_to(root.resolve())
+                or not file.is_file()
+                or file.stat().st_size <= 0
+            ):
+                raise ValidationError(
+                    f"reference image is not a non-empty project file: {reference_path}"
+                )
+            return _mapped(result, {"L0": True, "L1": True})
+        for _, declaration in declarations:
+            if family in {"compact-prop-pack", "scene-prop-set"}:
+                continue
+            declaration = CompileRequest(
+                **{**declaration.__dict__, "project_root": root}
+            )
+            source = _l1_file(
+                root, declaration.source_path, family=family, asset_id=asset_id
+            )
+            if not source.is_file() or source.stat().st_size <= 0:
+                raise ValidationError(
+                    f"standalone source is not a non-empty file: {declaration.source_path}"
+                )
+            if declaration.source_layout_type == "region_atlas":
+                metadata = declaration.spec["metadata_path"]
+                metadata_file = _l1_file(
+                    root, metadata, family=family, asset_id=asset_id
+                )
+                if not metadata_file.is_file() or metadata_file.stat().st_size <= 0:
+                    raise ValidationError(
+                        f"atlas metadata is not a non-empty file: {metadata}"
+                    )
+            if declaration.source_layout_type == "grid_sheet":
+                for action in declaration.spec["actions"]:
+                    for frame in action["frame_paths"]:
+                        frame_file = _l1_file(
+                            root, frame, family=family, asset_id=asset_id
+                        )
+                        if not frame_file.is_file() or frame_file.stat().st_size <= 0:
+                            raise ValidationError(
+                                f"processed action frame is not a non-empty file: {frame}"
+                            )
+        if family in {"compact-prop-pack", "scene-prop-set"}:
+            for slot in request["spec"]["slots"]:
+                slot_file = (root / slot["source"]).resolve()
+                if (
+                    not slot_file.is_relative_to(root.resolve())
+                    or not slot_file.is_file()
+                    or slot_file.stat().st_size <= 0
+                ):
+                    raise ValidationError(
+                        f"atlas slot source is not a non-empty project file: {slot['source']}"
+                    )
+    except (OSError, StableEntryError, ValidationError) as exc:
+        return _failure(result, passed, "L1", exc)
+    passed.append("L1")
+    try:
+        registry = build_default_registry()
+        compiled: dict[str, CompileRequest] = {}
+        if family in {"compact-prop-pack", "scene-prop-set"}:
+            atlas_path = (
+                Path("assets/generated") / family / asset_id / f"{asset_id}.png"
+            )
+            metadata_path = atlas_path.with_suffix(".json")
+            with tempfile.NamedTemporaryFile(
+                mode="w", encoding="utf-8", suffix=".json", dir=root, delete=False
+            ) as handle:
+                declaration_path = Path(handle.name)
+                json.dump(request["spec"], handle)
+            try:
+                assemble_atlas(
+                    declaration_path,
+                    atlas_path,
+                    metadata_path,
+                    production_family=family,
+                    asset_id=asset_id,
+                    project_root=root,
+                )
+            finally:
+                declaration_path.unlink(missing_ok=True)
+        for output, declaration in declarations:
+            actual = CompileRequest(**{**declaration.__dict__, "project_root": root})
+            compiled_result = registry.compile(actual)
+            if compiled_result.godot_artifact.to_dict() != {
+                "type": output["godot_type"],
+                "path": output["path"],
+            }:
+                raise ValidationError(
+                    f"compiler output does not match runtime output {output['name']!r}"
+                )
+            compiled[output["path"]] = actual
+    except (AtlasAssemblyError, CompilerError, OSError, ValidationError) as exc:
+        return _failure(result, passed, "L2", exc)
+    passed.append("L2")
+    structures = build_default_structures()
+    try:
+        probe_requests = [
+            ProbeRequest(
+                output["path"],
+                output["godot_type"],
+                structures.checks_for(output["godot_type"]),
+            )
+            for output, _ in declarations
+        ]
+        report = GodotProbe(godot_path).probe(root, probe_requests)
+        loaded = {item.res_path: item for item in report.resources}
+        for output, _ in declarations:
+            item = loaded.get(output["path"])
+            if item is None or not item.loaded or not item.type_matches:
+                raise ValidationError(
+                    (item.error if item else None)
+                    or f"Godot did not load {output['path']} as {output['godot_type']}"
+                )
+    except ValidationError as exc:
+        return _failure(result, passed, "L3", exc)
+    passed.append("L3")
+    try:
+        for output, _ in declarations:
+            actual = compiled[output["path"]]
+            structures.validate(
+                StructureRequest(
+                    actual.production_family,
+                    actual.asset_id,
+                    actual.source_layout_type,
+                    actual.source_path,
+                    actual.artifact_type,
+                    actual.artifact_path,
+                    root,
+                    loaded[output["path"]],
+                    actual.spec,
+                )
+            )
+    except ValidationError as exc:
+        return _failure(result, passed, "L4", exc)
+    return _mapped(result, {level: True for level in _LEVELS})

--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -9,9 +9,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from copy import deepcopy
-import json
 from pathlib import Path
-import tempfile
 from typing import Any
 
 from asset_compiler import CompileRequest, CompilerError, build_default_registry
@@ -34,7 +32,6 @@ from asset_animated_bundle_contract_check import (
     check_bundle_request,
     check_bundle_result,
 )
-from asset_atlas_assemble import AtlasAssemblyError, assemble_atlas
 
 
 class MissingFamilySkillError(Exception):
@@ -77,12 +74,36 @@ def _failure(
     return _mapped(result, levels, error)
 
 
+def _reference_failure(result: Mapping[str, Any], error: Exception) -> dict[str, Any]:
+    """Map reference-only failures without inventing runtime ladder levels."""
+    return _mapped(result, {"L0": True, "L1": False}, error)
+
+
 def _runtime(result: Mapping[str, Any]) -> list[Mapping[str, Any]]:
     return [item for item in result["outputs"] if item["role"] == "runtime"]
 
 
 def _stable_path(family: str, asset_id: str, name: str, suffix: str) -> str:
     return f"res://assets/generated/{family}/{asset_id}/{name}{suffix}"
+
+
+def _project_file(root: Path, path: Any, label: str) -> Path:
+    if not isinstance(path, str) or not path.strip():
+        raise ValidationError(f"{label} must be a non-empty project-relative path")
+    candidate = (root / path).resolve()
+    if not candidate.is_relative_to(root.resolve()):
+        raise ValidationError(f"{label} resolves outside the project root")
+    return candidate
+
+
+def _auxiliary_paths(result: Mapping[str, Any]) -> list[str]:
+    """Return non-runtime output and preview paths for L1 containment checks."""
+    paths: list[str] = []
+    for output in result["outputs"]:
+        if output["role"] == "reference":
+            paths.append(output["path"])
+    paths.extend(item["path"] for item in result["previews"])
+    return paths
 
 
 def _exact_keys(value: Any, keys: set[str], label: str) -> Mapping[str, Any]:
@@ -128,7 +149,12 @@ def _check_screen_reference(
 ) -> str:
     asset_id = request["asset_id"]
     expected = f"references/{asset_id}.png"
-    if _runtime(result) or result["sources"] or len(result["outputs"]) != 1:
+    if (
+        _runtime(result)
+        or result["sources"]
+        or result["previews"]
+        or len(result["outputs"]) != 1
+    ):
         raise MissingFamilySkillError(
             "screen-reference must have one reference output and no runtime source"
         )
@@ -161,7 +187,7 @@ def _check_platform(
         )
     asset_id = request["asset_id"]
     expected: list[tuple[Mapping[str, Any], CompileRequest]] = []
-    sources: list[dict[str, str]] = []
+    sources: set[tuple[str, str]] = set()
     names: set[str] = set()
     for item in segments:
         entry = _exact_keys(item, {"name"}, "platform-strip segment")
@@ -173,7 +199,7 @@ def _check_platform(
         names.add(name)
         if kind == "single":
             path = _stable_path("platform-strip", asset_id, name, ".png")
-            sources.append({"path": path, "layout": "single"})
+            sources.add((path, "single"))
             expected.append(
                 (
                     {"name": name, "path": path, "godot_type": "Texture2D"},
@@ -190,7 +216,7 @@ def _check_platform(
             )
         else:
             source = _stable_path("platform-strip", asset_id, asset_id, ".png")
-            sources = [{"path": source, "layout": "region_atlas"}]
+            sources.add((source, "region_atlas"))
             expected.append(
                 (
                     {
@@ -225,7 +251,9 @@ def _check_platform(
     if (
         len(_runtime(result)) != len(wanted)
         or actual != wanted
-        or result["sources"] != sources
+        or len(result["sources"]) != len(sources)
+        or {(source["path"], source.get("layout")) for source in result["sources"]}
+        != sources
     ):
         raise MissingFamilySkillError(
             "platform-strip result must bind every declared segment to its stable native output"
@@ -278,8 +306,10 @@ def _check_bundle(
         for source in result["sources"]
         if source.get("layout") == "grid_sheet"
     ]
-    if not sheets:
-        raise MissingFamilySkillError("animated bundle needs a grid_sheet source")
+    if not sheets or len(sheets) != len(result["sources"]):
+        raise MissingFamilySkillError(
+            "animated bundle sources must be non-empty grid_sheet files"
+        )
     frame_paths: dict[str, list[str]] = {}
     for action in request["spec"]["actions"]:
         action_name = action["name"]
@@ -323,13 +353,45 @@ def _check_props(
         raise MissingFamilySkillError(
             f"{family} spec must be a v1 non-empty fixed-slot declaration"
         )
-    slots = spec["slots"]
-    names = [item.get("name") for item in slots if isinstance(item, Mapping)]
-    if (
-        len(names) != len(slots)
-        or any(not isinstance(name, str) or not name for name in names)
-        or len(set(names)) != len(names)
+    atlas = _exact_keys(spec.get("atlas"), {"width", "height"}, f"{family} atlas")
+    if any(
+        type(atlas.get(axis)) is not int or atlas[axis] <= 0
+        for axis in ("width", "height")
     ):
+        raise MissingFamilySkillError(
+            f"{family} atlas width and height must be positive integers"
+        )
+    slots = spec["slots"]
+    names: list[str] = []
+    for index, raw_slot in enumerate(slots):
+        if not isinstance(raw_slot, Mapping):
+            raise MissingFamilySkillError(f"{family} slots[{index}] must be an object")
+        keys = (
+            {"name", "rect", "source", "pivot"}
+            if "pivot" in raw_slot
+            else {"name", "rect", "source"}
+        )
+        slot = _exact_keys(raw_slot, keys, f"{family} slots[{index}]")
+        name = slot.get("name")
+        rect = slot.get("rect")
+        if (
+            not isinstance(name, str)
+            or not name.strip()
+            or not isinstance(slot.get("source"), str)
+            or not slot["source"].strip()
+            or not isinstance(rect, list)
+            or len(rect) != 4
+            or any(type(value) is not int for value in rect)
+            or rect[0] < 0
+            or rect[1] < 0
+            or rect[2] <= 0
+            or rect[3] <= 0
+        ):
+            raise MissingFamilySkillError(
+                f"{family} slots[{index}] must be a valid fixed-slot declaration"
+            )
+        names.append(name)
+    if len(set(names)) != len(names):
         raise MissingFamilySkillError(
             f"{family} slots must have unique non-empty names"
         )
@@ -417,6 +479,7 @@ def compile_and_validate(
                 "standalone validation needs one supported matching asset_type"
             )
         reference_path, declarations = _declarations(request, result)
+        auxiliary_paths = _auxiliary_paths(result)
     except (AssetContractError, MissingFamilySkillError) as exc:
         raise MissingFamilySkillError(f"L0 standalone contract failed: {exc}") from exc
     root, family, asset_id = (
@@ -427,19 +490,17 @@ def compile_and_validate(
     passed = ["L0"]
     try:
         if reference_path is not None:
-            file = (root / reference_path).resolve()
+            file = _project_file(root, reference_path, "reference image")
             if (
-                not file.is_relative_to(root.resolve())
-                or not file.is_file()
+                not file.is_file()
                 or file.stat().st_size <= 0
+                or file.read_bytes()[:8] != b"\x89PNG\r\n\x1a\n"
             ):
                 raise ValidationError(
-                    f"reference image is not a non-empty project file: {reference_path}"
+                    f"reference image is not a non-empty PNG file: {reference_path}"
                 )
             return _mapped(result, {"L0": True, "L1": True})
         for _, declaration in declarations:
-            if family in {"compact-prop-pack", "scene-prop-set"}:
-                continue
             declaration = CompileRequest(
                 **{**declaration.__dict__, "project_root": root}
             )
@@ -460,6 +521,14 @@ def compile_and_validate(
                         f"atlas metadata is not a non-empty file: {metadata}"
                     )
             if declaration.source_layout_type == "grid_sheet":
+                for source_path in result["sources"]:
+                    sheet_file = _l1_file(
+                        root, source_path["path"], family=family, asset_id=asset_id
+                    )
+                    if not sheet_file.is_file() or sheet_file.stat().st_size <= 0:
+                        raise ValidationError(
+                            f"grid sheet is not a non-empty file: {source_path['path']}"
+                        )
                 for action in declaration.spec["actions"]:
                     for frame in action["frame_paths"]:
                         frame_file = _l1_file(
@@ -469,56 +538,27 @@ def compile_and_validate(
                             raise ValidationError(
                                 f"processed action frame is not a non-empty file: {frame}"
                             )
-        if family in {"compact-prop-pack", "scene-prop-set"}:
-            for slot in request["spec"]["slots"]:
-                slot_file = (root / slot["source"]).resolve()
-                if (
-                    not slot_file.is_relative_to(root.resolve())
-                    or not slot_file.is_file()
-                    or slot_file.stat().st_size <= 0
-                ):
-                    raise ValidationError(
-                        f"atlas slot source is not a non-empty project file: {slot['source']}"
-                    )
+        for path in auxiliary_paths:
+            file = _project_file(root, path, "reference output or preview")
+            if not file.is_file() or file.stat().st_size <= 0:
+                raise ValidationError(
+                    f"reference output or preview is not a non-empty file: {path}"
+                )
     except (OSError, StableEntryError, ValidationError) as exc:
-        return _failure(result, passed, "L1", exc)
+        return (
+            _reference_failure(result, exc)
+            if reference_path is not None
+            else _failure(result, passed, "L1", exc)
+        )
     passed.append("L1")
     try:
         registry = build_default_registry()
         compiled: dict[str, CompileRequest] = {}
-        if family in {"compact-prop-pack", "scene-prop-set"}:
-            atlas_path = (
-                Path("assets/generated") / family / asset_id / f"{asset_id}.png"
-            )
-            metadata_path = atlas_path.with_suffix(".json")
-            with tempfile.NamedTemporaryFile(
-                mode="w", encoding="utf-8", suffix=".json", dir=root, delete=False
-            ) as handle:
-                declaration_path = Path(handle.name)
-                json.dump(request["spec"], handle)
-            try:
-                assemble_atlas(
-                    declaration_path,
-                    atlas_path,
-                    metadata_path,
-                    production_family=family,
-                    asset_id=asset_id,
-                    project_root=root,
-                )
-            finally:
-                declaration_path.unlink(missing_ok=True)
         for output, declaration in declarations:
             actual = CompileRequest(**{**declaration.__dict__, "project_root": root})
-            compiled_result = registry.compile(actual)
-            if compiled_result.godot_artifact.to_dict() != {
-                "type": output["godot_type"],
-                "path": output["path"],
-            }:
-                raise ValidationError(
-                    f"compiler output does not match runtime output {output['name']!r}"
-                )
+            registry.compile(actual)
             compiled[output["path"]] = actual
-    except (AtlasAssemblyError, CompilerError, OSError, ValidationError) as exc:
+    except (CompilerError, OSError, ValidationError) as exc:
         return _failure(result, passed, "L2", exc)
     passed.append("L2")
     structures = build_default_structures()

--- a/skills/assets/_shared/samples/result/screen-reference.json
+++ b/skills/assets/_shared/samples/result/screen-reference.json
@@ -4,7 +4,7 @@
     {
       "role": "reference",
       "name": "main_menu",
-      "path": "references/scene_main_menu.png"
+      "path": "references/main_menu.png"
     }
   ],
   "sources": [],

--- a/skills/assets/background-map/SKILL.md
+++ b/skills/assets/background-map/SKILL.md
@@ -14,8 +14,12 @@ geometry.
 
 Accept one asset request matching the shared Asset Skill request schema in
 `.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
-`asset_type` to be `background-map`. Validate the returned document against the
-shared result schema and checker before returning it.
+`asset_type` to be `background-map`. Run
+`standalone_validation.compile_and_validate()` before returning it. The runner
+checks the family binding and stable path at L0, the PNG at L1, the registered
+`single -> Texture2D` route at L2, and real headless Godot load plus Texture2D
+structure at L3/L4; it overwrites rather than trusts caller-supplied validation.
+It begins from the shared result schema and checker, then proves the result.
 
 This skill can be invoked directly or by an orchestrator; its request and
 result are identical in both cases. Do not read or write `ASSETS.md`, tags,

--- a/skills/assets/background-map/standalone_validation.py
+++ b/skills/assets/background-map/standalone_validation.py
@@ -1,0 +1,49 @@
+"""Published standalone entry for the background-map Asset Skill."""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+
+def _runtime() -> None:
+    runner = Path(__file__).resolve()
+    root = runner.parents[3]
+    source = runner.parents[1] / "_shared"
+    candidates = (root / ".godotmaker" / "asset-runtime", source)
+    path = next(
+        (
+            item
+            for item in candidates
+            if item.is_dir()
+            and (
+                item != source
+                or (
+                    runner.parents[1].name == "assets"
+                    and runner.parents[2].name == "skills"
+                )
+            )
+        ),
+        None,
+    )
+    tools = root / "tools"
+    if path is None:
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone validation: checked "
+            + ", ".join(str(item) for item in candidates)
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            f"GodotMaker tools directory is missing for standalone validation: expected {tools}"
+        )
+    for item in (str(path), str(tools)):
+        if item not in sys.path:
+            sys.path.append(item)
+
+
+_runtime()
+from missing_family_standalone_validation import (  # noqa: E402
+    MissingFamilySkillError,
+    compile_and_validate,
+)
+
+__all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/character-bundle/SKILL.md
+++ b/skills/assets/character-bundle/SKILL.md
@@ -76,9 +76,6 @@ the `fx-bundle` skill.
    Godot; L4 must confirm the action names, order, frame bindings, FPS, loop
    values, and relative durations.
 
-Optional portraits are separate `Texture2D` runtime outputs. They must not
-replace the actor's primary `SpriteFrames` output.
-
 ## Result
 
 Return a shared result with at least one runtime output:

--- a/skills/assets/character-bundle/SKILL.md
+++ b/skills/assets/character-bundle/SKILL.md
@@ -78,7 +78,7 @@ the `fx-bundle` skill.
 
 ## Result
 
-Return a shared result with at least one runtime output:
+Return a shared result with exactly one runtime output:
 
 ```json
 {

--- a/skills/assets/character-bundle/SKILL.md
+++ b/skills/assets/character-bundle/SKILL.md
@@ -68,7 +68,11 @@ the `fx-bundle` skill.
    `name`, `fps`, `loop`, `frame_paths`, and `frame_durations`.
    Do not publish a per-action SpriteFrames resource or a source sheet as the
    runtime result.
-5. Run L0-L4 validation. L3 must load the compiled resource with headless
+5. Run `standalone_validation.compile_and_validate()` for L0-L4 validation.
+   It derives each processed frame path as
+   `res://assets/generated/character-bundle/<asset_id>/<asset_id>_<action>_<frame>.png`,
+   compiles with a fresh registry, and overwrites rather than trusting result
+   validation. L3 must load the compiled resource with headless
    Godot; L4 must confirm the action names, order, frame bindings, FPS, loop
    values, and relative durations.
 
@@ -98,5 +102,6 @@ Return a shared result with at least one runtime output:
 }
 ```
 
-Set `validation.passed` only after all required actions and L0-L4 checks pass.
+Set `validation.passed` only from the runner result after all required actions
+and L0-L4 checks pass.
 When any action is incomplete, do not return a runtime `SpriteFrames` result.

--- a/skills/assets/character-bundle/standalone_validation.py
+++ b/skills/assets/character-bundle/standalone_validation.py
@@ -1,0 +1,49 @@
+"""Published standalone entry for the character-bundle Asset Skill."""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+
+def _runtime() -> None:
+    runner = Path(__file__).resolve()
+    root = runner.parents[3]
+    source = runner.parents[1] / "_shared"
+    candidates = (root / ".godotmaker" / "asset-runtime", source)
+    path = next(
+        (
+            p
+            for p in candidates
+            if p.is_dir()
+            and (
+                p != source
+                or (
+                    runner.parents[1].name == "assets"
+                    and runner.parents[2].name == "skills"
+                )
+            )
+        ),
+        None,
+    )
+    tools = root / "tools"
+    if path is None:
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone validation: checked "
+            + ", ".join(str(item) for item in candidates)
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            f"GodotMaker tools directory is missing for standalone validation: expected {tools}"
+        )
+    for p in (str(path), str(tools)):
+        if p not in sys.path:
+            sys.path.append(p)
+
+
+_runtime()
+from missing_family_standalone_validation import (  # noqa: E402
+    MissingFamilySkillError,
+    compile_and_validate,
+)
+
+__all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/compact-prop-pack/SKILL.md
+++ b/skills/assets/compact-prop-pack/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: compact-prop-pack
+description: Produce standalone fixed-slot AtlasTexture resources for compact reusable props.
+---
+
 # Compact Prop Pack
 
 Produce a standalone atlas-backed set of small, independently usable props:
@@ -70,7 +75,10 @@ names exactly match the corresponding metadata region names.
    `.godotmaker/asset-runtime/asset_compiler/atlas_texture.py`, passing only
    `metadata_path` and that region's `logical_asset_id` in the compiler spec.
    The artifact filename must equal the logical id.
-5. Run the shared L0-L4 validation ladder for every runtime output. L4 must
+5. Run `standalone_validation.compile_and_validate()` for L0-L4 on every runtime output.
+   It validates the declaration/result binding, assembles the atlas, compiles
+   each declared AtlasTexture, then runs real headless Godot L3/L4; it never
+   trusts result validation supplied by a caller. L4 must
    confirm the exact declared region, the shared atlas path, and zero margin.
 6. Return the shared result object only after every requested logical output
    passes. A failed or absent slot fails the invocation; do not substitute a

--- a/skills/assets/compact-prop-pack/standalone_validation.py
+++ b/skills/assets/compact-prop-pack/standalone_validation.py
@@ -1,0 +1,49 @@
+"""Published standalone entry for the compact-prop-pack Asset Skill."""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+
+def _runtime() -> None:
+    runner = Path(__file__).resolve()
+    root = runner.parents[3]
+    source = runner.parents[1] / "_shared"
+    candidates = (root / ".godotmaker" / "asset-runtime", source)
+    path = next(
+        (
+            p
+            for p in candidates
+            if p.is_dir()
+            and (
+                p != source
+                or (
+                    runner.parents[1].name == "assets"
+                    and runner.parents[2].name == "skills"
+                )
+            )
+        ),
+        None,
+    )
+    tools = root / "tools"
+    if path is None:
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone validation: checked "
+            + ", ".join(str(item) for item in candidates)
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            f"GodotMaker tools directory is missing for standalone validation: expected {tools}"
+        )
+    for p in (str(path), str(tools)):
+        if p not in sys.path:
+            sys.path.append(p)
+
+
+_runtime()
+from missing_family_standalone_validation import (  # noqa: E402
+    MissingFamilySkillError,
+    compile_and_validate,
+)
+
+__all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/fx-bundle/SKILL.md
+++ b/skills/assets/fx-bundle/SKILL.md
@@ -61,7 +61,10 @@ hard-code loop state.
    through the shared `grid_sheet` to `SpriteFrames` route. Its compiler input
    has `required_actions` plus the action `name`, `fps`, `loop`, `frame_paths`,
    and `frame_durations`. Validate L0-L4, including headless Godot load and L4
-   frame order, texture bindings, FPS, loop, and durations.
+   frame order, texture bindings, FPS, loop, and durations. Use
+   `standalone_validation.compile_and_validate()` to perform that work; it
+   derives stable processed frame paths using `<asset_id>_<action>_<frame>.png`
+   and overwrites any supplied validation assertion.
 4. For a static effect, process/select exactly one transparent foreground PNG
    and publish it through the shared `single` to `Texture2D` route. Validate
    its L0-L4 texture evidence.
@@ -87,4 +90,4 @@ An animated result has one `SpriteFrames` runtime output:
 
 A static result has one `Texture2D` runtime output whose path is the selected
 single image and whose source layout is `single`. Set `validation.passed` only
-after the applicable L0-L4 checks pass.
+from the standalone runner after the applicable L0-L4 checks pass.

--- a/skills/assets/fx-bundle/standalone_validation.py
+++ b/skills/assets/fx-bundle/standalone_validation.py
@@ -1,0 +1,49 @@
+"""Published standalone entry for the fx-bundle Asset Skill."""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+
+def _runtime() -> None:
+    runner = Path(__file__).resolve()
+    root = runner.parents[3]
+    source = runner.parents[1] / "_shared"
+    candidates = (root / ".godotmaker" / "asset-runtime", source)
+    path = next(
+        (
+            p
+            for p in candidates
+            if p.is_dir()
+            and (
+                p != source
+                or (
+                    runner.parents[1].name == "assets"
+                    and runner.parents[2].name == "skills"
+                )
+            )
+        ),
+        None,
+    )
+    tools = root / "tools"
+    if path is None:
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone validation: checked "
+            + ", ".join(str(item) for item in candidates)
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            f"GodotMaker tools directory is missing for standalone validation: expected {tools}"
+        )
+    for p in (str(path), str(tools)):
+        if p not in sys.path:
+            sys.path.append(p)
+
+
+_runtime()
+from missing_family_standalone_validation import (  # noqa: E402
+    MissingFamilySkillError,
+    compile_and_validate,
+)
+
+__all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/platform-strip/SKILL.md
+++ b/skills/assets/platform-strip/SKILL.md
@@ -13,8 +13,12 @@ for characters, enemies, UI, compact props, or full scenic backgrounds.
 
 Accept one asset request matching the shared Asset Skill request schema in
 `.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
-`asset_type` to be `platform-strip`. Validate the returned document against the
-shared result schema and checker before returning it.
+`asset_type` to be `platform-strip`. `spec` is `{ "kind": "single" | "atlas",
+"segments": [{"name": "..."}] }`; it declares the complete logical segment
+set. Run `standalone_validation.compile_and_validate()` before returning it.
+The runner binds every segment to its stable Texture2D or AtlasTexture path,
+executes the applicable compiler route, then runs real headless Godot L3/L4.
+It begins from the shared result schema and checker, then proves the result.
 
 This skill can be invoked directly or by an orchestrator with the same contract.
 Do not read or write `ASSETS.md`, tags, stage state, generated manifests, or
@@ -36,6 +40,8 @@ worker dispatch state.
    `.tres` `AtlasTexture` with zero margin. Do not use automatic packing,
    trimming, heuristic region discovery, or an undeclared region.
 5. Load the declared result in Godot and validate its reported resource type.
+   The public runner, rather than a self-reported validation object, owns this
+   L0-L4 verdict.
 
 ## Result
 

--- a/skills/assets/platform-strip/standalone_validation.py
+++ b/skills/assets/platform-strip/standalone_validation.py
@@ -1,0 +1,49 @@
+"""Published standalone entry for the platform-strip Asset Skill."""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+
+def _runtime() -> None:
+    runner = Path(__file__).resolve()
+    root = runner.parents[3]
+    source = runner.parents[1] / "_shared"
+    candidates = (root / ".godotmaker" / "asset-runtime", source)
+    path = next(
+        (
+            p
+            for p in candidates
+            if p.is_dir()
+            and (
+                p != source
+                or (
+                    runner.parents[1].name == "assets"
+                    and runner.parents[2].name == "skills"
+                )
+            )
+        ),
+        None,
+    )
+    tools = root / "tools"
+    if path is None:
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone validation: checked "
+            + ", ".join(str(item) for item in candidates)
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            f"GodotMaker tools directory is missing for standalone validation: expected {tools}"
+        )
+    for p in (str(path), str(tools)):
+        if p not in sys.path:
+            sys.path.append(p)
+
+
+_runtime()
+from missing_family_standalone_validation import (  # noqa: E402
+    MissingFamilySkillError,
+    compile_and_validate,
+)
+
+__all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/scene-prop-set/SKILL.md
+++ b/skills/assets/scene-prop-set/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: scene-prop-set
+description: Produce standalone fixed-slot AtlasTexture resources for scene-derived foreground props.
+---
+
 # Scene Prop Set
 
 Produce a standalone atlas-backed set of foreground props derived from a
@@ -67,7 +72,10 @@ objects, or worker-dispatch details.
 4. Use `.godotmaker/asset-runtime/asset_compiler/atlas_texture.py` once per region
    to compile an independent `AtlasTexture`. Pass its `metadata_path` and the
    exact logical region name; the `.tres` filename must match that name.
-5. Run shared L0-L4 validation per output. L4 must prove the loaded resource
+5. Run `standalone_validation.compile_and_validate()` for L0-L4 per output. It binds the
+   declared slot set, assembles the physical atlas, compiles every AtlasTexture,
+   and performs real headless Godot L3/L4 without trusting a result validation
+   claim. L4 must prove the loaded resource
    refers to the shared atlas, retains its exact declared region, and has a
    zero margin.
 6. Return every requested logical output only when it validates. Fail closed

--- a/skills/assets/scene-prop-set/standalone_validation.py
+++ b/skills/assets/scene-prop-set/standalone_validation.py
@@ -1,0 +1,49 @@
+"""Published standalone entry for the scene-prop-set Asset Skill."""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+
+def _runtime() -> None:
+    runner = Path(__file__).resolve()
+    root = runner.parents[3]
+    source = runner.parents[1] / "_shared"
+    candidates = (root / ".godotmaker" / "asset-runtime", source)
+    path = next(
+        (
+            p
+            for p in candidates
+            if p.is_dir()
+            and (
+                p != source
+                or (
+                    runner.parents[1].name == "assets"
+                    and runner.parents[2].name == "skills"
+                )
+            )
+        ),
+        None,
+    )
+    tools = root / "tools"
+    if path is None:
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone validation: checked "
+            + ", ".join(str(item) for item in candidates)
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            f"GodotMaker tools directory is missing for standalone validation: expected {tools}"
+        )
+    for p in (str(path), str(tools)):
+        if p not in sys.path:
+            sys.path.append(p)
+
+
+_runtime()
+from missing_family_standalone_validation import (  # noqa: E402
+    MissingFamilySkillError,
+    compile_and_validate,
+)
+
+__all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/screen-reference/SKILL.md
+++ b/skills/assets/screen-reference/SKILL.md
@@ -13,8 +13,12 @@ It is reference-only: it does not create a runtime Godot resource, has no
 
 Accept one asset request matching the shared Asset Skill request schema in
 `.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
-`asset_type` to be `screen-reference`. Validate the returned document against
-the shared result schema and checker before returning it.
+`asset_type` to be `screen-reference`. Run
+`standalone_validation.compile_and_validate()` before returning it. This
+reference-only runner binds the fixed reference path at L0 and verifies the
+image file at L1; it never enters the runtime L2-L4 ladder and overwrites any
+caller-supplied validation claim.
+It begins from the shared result schema and checker, then proves the result.
 
 This skill can be invoked directly or by an orchestrator with the same contract.
 Do not read or write `ASSETS.md`, tags, stage state, generated manifests, or

--- a/skills/assets/screen-reference/standalone_validation.py
+++ b/skills/assets/screen-reference/standalone_validation.py
@@ -1,0 +1,49 @@
+"""Published standalone entry for the screen-reference Asset Skill."""
+
+from __future__ import annotations
+import sys
+from pathlib import Path
+
+
+def _runtime() -> None:
+    runner = Path(__file__).resolve()
+    root = runner.parents[3]
+    source = runner.parents[1] / "_shared"
+    candidates = (root / ".godotmaker" / "asset-runtime", source)
+    path = next(
+        (
+            p
+            for p in candidates
+            if p.is_dir()
+            and (
+                p != source
+                or (
+                    runner.parents[1].name == "assets"
+                    and runner.parents[2].name == "skills"
+                )
+            )
+        ),
+        None,
+    )
+    tools = root / "tools"
+    if path is None:
+        raise ImportError(
+            "GodotMaker asset runtime is missing for standalone validation: checked "
+            + ", ".join(str(item) for item in candidates)
+        )
+    if not tools.is_dir():
+        raise ImportError(
+            f"GodotMaker tools directory is missing for standalone validation: expected {tools}"
+        )
+    for p in (str(path), str(tools)):
+        if p not in sys.path:
+            sys.path.append(p)
+
+
+_runtime()
+from missing_family_standalone_validation import (  # noqa: E402
+    MissingFamilySkillError,
+    compile_and_validate,
+)
+
+__all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-import sys
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -258,7 +258,7 @@ def test_prop_runner_never_rebuilds_or_overwrites_the_delivered_atlas(tmp_path):
     actual = compile_and_validate(
         request, result, project_root=tmp_path, godot_path="fake"
     )
-    assert actual["validation"]["levels"]["L2"] is False
+    assert actual["validation"]["levels"]["L1"] is False
     assert (atlas.read_bytes(), metadata.read_bytes()) == before
 
 
@@ -290,3 +290,321 @@ def test_animated_bundle_checks_each_declared_sheet_at_l1(tmp_path):
         request, result, project_root=tmp_path, godot_path="fake"
     )
     assert actual["validation"]["levels"]["L1"] is False
+
+
+def _set_good_probe(monkeypatch, structures):
+    class Probe:
+        def __init__(self, _path):
+            pass
+
+        def probe(self, _root, requests):
+            return ProbeReport(
+                "fake",
+                tuple(
+                    ProbeResult(
+                        item.res_path,
+                        item.expected_type,
+                        True,
+                        item.expected_type,
+                        True,
+                        structure=structures[item.res_path],
+                    )
+                    for item in requests
+                ),
+            )
+
+    monkeypatch.setattr(runner, "GodotProbe", Probe)
+
+
+def _prop_handoff(family: str, asset_id: str = "market") -> tuple[dict, dict]:
+    root = f"res://assets/generated/{family}/{asset_id}"
+    slots = [
+        {"name": "coin", "rect": [0, 0, 16, 16], "source": "sources/coin.png"},
+        {"name": "chest", "rect": [16, 0, 16, 16], "source": "sources/chest.png"},
+    ]
+    request = {
+        "asset_type": family,
+        "asset_id": asset_id,
+        "brief": "Two compact props.",
+        "spec": {"version": 1, "atlas": {"width": 32, "height": 16}, "slots": slots},
+    }
+    result = {
+        "asset_type": family,
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": slot["name"],
+                "path": f"{root}/{slot['name']}.tres",
+                "godot_type": "AtlasTexture",
+            }
+            for slot in slots
+        ],
+        "sources": [{"path": f"{root}/{asset_id}.png", "layout": "region_atlas"}],
+        "previews": [],
+        "validation": {"passed": False},
+    }
+    return request, result
+
+
+def _write_prop_delivery(
+    root: Path, request: dict, *, extra_region: bool = False
+) -> None:
+    family, asset_id = request["asset_type"], request["asset_id"]
+    output = root / "assets" / "generated" / family / asset_id
+    output.mkdir(parents=True)
+    atlas = request["spec"]["atlas"]
+    Image.new("RGBA", (atlas["width"], atlas["height"]), (1, 2, 3, 255)).save(
+        output / f"{asset_id}.png"
+    )
+    regions = [
+        {
+            "name": slot["name"],
+            "rect": slot["rect"],
+            "pivot": [0.5, 0.5],
+            "nine_slice": None,
+        }
+        for slot in request["spec"]["slots"]
+    ]
+    if extra_region:
+        regions.append(
+            {
+                "name": "ghost",
+                "rect": [0, 0, 1, 1],
+                "pivot": [0.5, 0.5],
+                "nine_slice": None,
+            }
+        )
+    (output / f"{asset_id}.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "atlas_path": f"res://assets/generated/{family}/{asset_id}/{asset_id}.png",
+                "regions": regions,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.parametrize("family", ["compact-prop-pack", "scene-prop-set"])
+def test_prop_families_run_multi_slot_delivery_through_l4(
+    monkeypatch, tmp_path, family
+):
+    request, result = _prop_handoff(family)
+    _write_prop_delivery(tmp_path, request)
+    root = f"res://assets/generated/{family}/market"
+    _set_good_probe(
+        monkeypatch,
+        {
+            f"{root}/coin.tres": {
+                "atlas_texture": {
+                    "has_atlas": True,
+                    "atlas_path": f"{root}/market.png",
+                    "region": [0, 0, 16, 16],
+                    "margin": [0, 0, 0, 0],
+                }
+            },
+            f"{root}/chest.tres": {
+                "atlas_texture": {
+                    "has_atlas": True,
+                    "atlas_path": f"{root}/market.png",
+                    "region": [16, 0, 16, 16],
+                    "margin": [0, 0, 0, 0],
+                }
+            },
+        },
+    )
+
+    actual = compile_and_validate(
+        request, result, project_root=tmp_path, godot_path="fake"
+    )
+
+    assert actual["validation"]["levels"] == {
+        level: True for level in ("L0", "L1", "L2", "L3", "L4")
+    }
+
+
+@pytest.mark.parametrize("mutation", ["rect", "extra-region", "dimensions"])
+def test_prop_delivery_must_exactly_bind_declared_geometry(tmp_path, mutation):
+    request, result = _prop_handoff("compact-prop-pack")
+    _write_prop_delivery(tmp_path, request, extra_region=mutation == "extra-region")
+    output = tmp_path / "assets/generated/compact-prop-pack/market"
+    metadata = output / "market.json"
+    if mutation == "rect":
+        delivered = json.loads(metadata.read_text(encoding="utf-8"))
+        delivered["regions"][0]["rect"] = [0, 0, 1, 1]
+        metadata.write_text(json.dumps(delivered), encoding="utf-8")
+    elif mutation == "dimensions":
+        Image.new("RGBA", (64, 64), (1, 2, 3, 255)).save(output / "market.png")
+
+    actual = compile_and_validate(
+        request, result, project_root=tmp_path, godot_path="fake"
+    )
+
+    assert actual["validation"]["levels"] == {
+        "L0": True,
+        "L1": False,
+        "L2": False,
+        "L3": False,
+        "L4": False,
+    }
+
+
+@pytest.mark.parametrize("kind", ["single", "atlas"])
+def test_platform_strip_runs_each_supported_source_type_to_l4(
+    monkeypatch, tmp_path, kind
+):
+    asset_id = "bridge"
+    root = f"res://assets/generated/platform-strip/{asset_id}"
+    request = {
+        "asset_type": "platform-strip",
+        "asset_id": asset_id,
+        "brief": "A bridge.",
+        "spec": {"kind": kind, "segments": [{"name": "left"}, {"name": "right"}]},
+    }
+    if kind == "single":
+        result = {
+            "asset_type": "platform-strip",
+            "outputs": [
+                {
+                    "role": "runtime",
+                    "name": name,
+                    "path": f"{root}/{name}.png",
+                    "godot_type": "Texture2D",
+                }
+                for name in ("left", "right")
+            ],
+            "sources": [
+                {"path": f"{root}/{name}.png", "layout": "single"}
+                for name in ("left", "right")
+            ],
+            "previews": [],
+            "validation": {"passed": False},
+        }
+        directory = tmp_path / "assets/generated/platform-strip/bridge"
+        directory.mkdir(parents=True)
+        for name in ("left", "right"):
+            Image.new("RGBA", (8, 8), (1, 2, 3, 255)).save(directory / f"{name}.png")
+        structures = {
+            f"{root}/{name}.png": {"texture2d": {"width": 8, "height": 8}}
+            for name in ("left", "right")
+        }
+    else:
+        result = {
+            "asset_type": "platform-strip",
+            "outputs": [
+                {
+                    "role": "runtime",
+                    "name": name,
+                    "path": f"{root}/{name}.tres",
+                    "godot_type": "AtlasTexture",
+                }
+                for name in ("left", "right")
+            ],
+            "sources": [{"path": f"{root}/bridge.png", "layout": "region_atlas"}],
+            "previews": [],
+            "validation": {"passed": False},
+        }
+        directory = tmp_path / "assets/generated/platform-strip/bridge"
+        directory.mkdir(parents=True)
+        Image.new("RGBA", (16, 8), (1, 2, 3, 255)).save(directory / "bridge.png")
+        (directory / "bridge.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "atlas_path": f"{root}/bridge.png",
+                    "regions": [
+                        {
+                            "name": "left",
+                            "rect": [0, 0, 8, 8],
+                            "pivot": [0.5, 0.5],
+                            "nine_slice": None,
+                        },
+                        {
+                            "name": "right",
+                            "rect": [8, 0, 8, 8],
+                            "pivot": [0.5, 0.5],
+                            "nine_slice": None,
+                        },
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        structures = {
+            f"{root}/{name}.tres": {
+                "atlas_texture": {
+                    "has_atlas": True,
+                    "atlas_path": f"{root}/bridge.png",
+                    "region": rect,
+                    "margin": [0, 0, 0, 0],
+                }
+            }
+            for name, rect in (("left", [0, 0, 8, 8]), ("right", [8, 0, 8, 8]))
+        }
+    _set_good_probe(monkeypatch, structures)
+
+    actual = compile_and_validate(
+        request, result, project_root=tmp_path, godot_path="fake"
+    )
+
+    assert actual["validation"]["passed"] is True, actual["validation"]
+
+
+@pytest.mark.parametrize(
+    ("family", "request_name", "result_name"),
+    [
+        ("character-bundle", "valid-request.json", "valid-result.json"),
+        ("fx-bundle", "animated-request.json", "animated-result.json"),
+        ("fx-bundle", "static-request.json", "static-result.json"),
+    ],
+)
+def test_bundles_run_declared_static_and_multi_action_outputs_to_l4(
+    monkeypatch, tmp_path, family, request_name, result_name
+):
+    fixtures = REPO_ROOT / "skills/assets" / family / "fixtures"
+    request = json.loads((fixtures / request_name).read_text(encoding="utf-8"))
+    result = json.loads((fixtures / result_name).read_text(encoding="utf-8"))
+    asset_id = request["asset_id"]
+    output = tmp_path / "assets" / "generated" / family / asset_id
+    output.mkdir(parents=True)
+    for preview in result["previews"]:
+        preview_file = tmp_path / preview["path"].removeprefix("res://")
+        preview_file.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGBA", (8, 8), (1, 2, 3, 255)).save(preview_file)
+    runtime = result["outputs"][0]
+    if runtime["godot_type"] == "Texture2D":
+        Image.new("RGBA", (8, 8), (1, 2, 3, 255)).save(output / f"{asset_id}.png")
+        structures = {runtime["path"]: {"texture2d": {"width": 8, "height": 8}}}
+    else:
+        for source in result["sources"]:
+            Image.new("RGBA", (8, 8), (1, 2, 3, 255)).save(
+                output / Path(source["path"]).name
+            )
+        for action in request["spec"]["actions"]:
+            for frame in action["frame_names"]:
+                Image.new("RGBA", (1, 1), (1, 2, 3, 255)).save(
+                    output / f"{asset_id}_{action['name']}_{frame}.png"
+                )
+        animations = [
+            {
+                "name": action["name"],
+                "loop": action["loop"],
+                "fps": action["fps"],
+                "frame_paths": [
+                    f"res://assets/generated/{family}/{asset_id}/{asset_id}_{action['name']}_{frame}.png"
+                    for frame in action["frame_names"]
+                ],
+                "frame_count": len(action["frame_names"]),
+                "frame_durations": action["frame_durations"],
+            }
+            for action in request["spec"]["actions"]
+        ]
+        structures = {runtime["path"]: {"spriteframes": {"animations": animations}}}
+    _set_good_probe(monkeypatch, structures)
+
+    actual = compile_and_validate(
+        request, result, project_root=tmp_path, godot_path="fake"
+    )
+
+    assert actual["validation"]["passed"] is True, actual["validation"]

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -1,0 +1,142 @@
+"""Fail-closed standalone execution tests for the formerly prose-only families."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path[:0] = [
+    str(REPO_ROOT / "skills" / "assets" / "_shared"),
+    str(REPO_ROOT / "tools"),
+]
+
+from missing_family_standalone_validation import (  # noqa: E402
+    MissingFamilySkillError,
+    compile_and_validate,
+)
+
+
+def _background_result(
+    *, asset_type: str = "background-map", godot_type: str = "Texture2D"
+) -> dict:
+    return {
+        "asset_type": asset_type,
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": "sky",
+                "path": "res://assets/generated/background-map/sky/sky.png",
+                "godot_type": godot_type,
+            }
+        ],
+        "sources": [
+            {
+                "path": "res://assets/generated/background-map/sky/sky.png",
+                "layout": "single",
+            }
+        ],
+        "previews": [],
+        "validation": {
+            "passed": True,
+            "levels": {"L0": True, "L1": True, "L2": True, "L3": True, "L4": True},
+        },
+    }
+
+
+def test_background_runner_does_not_trust_a_forged_successful_validation(tmp_path):
+    actual = compile_and_validate(
+        {"asset_type": "background-map", "asset_id": "sky", "brief": "A blue sky."},
+        _background_result(),
+        project_root=tmp_path,
+        godot_path="godot",
+    )
+    assert actual["validation"]["passed"] is False
+    assert actual["validation"]["levels"] == {
+        "L0": True,
+        "L1": False,
+        "L2": False,
+        "L3": False,
+        "L4": False,
+    }
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        pytest.param(
+            _background_result(asset_type="platform-strip"), id="wrong-family"
+        ),
+        pytest.param(
+            _background_result(godot_type="AtlasTexture"), id="wrong-godot-type"
+        ),
+    ],
+)
+def test_background_runner_fails_closed_before_l1_for_wrong_public_binding(
+    tmp_path, result
+):
+    with pytest.raises(MissingFamilySkillError, match="L0 standalone contract failed"):
+        compile_and_validate(
+            {"asset_type": "background-map", "asset_id": "sky", "brief": "A blue sky."},
+            result,
+            project_root=tmp_path,
+            godot_path="godot",
+        )
+
+
+def test_platform_atlas_requires_every_declared_logical_output(tmp_path):
+    request = {
+        "asset_type": "platform-strip",
+        "asset_id": "bridge",
+        "brief": "A bridge.",
+        "spec": {"kind": "atlas", "segments": [{"name": "left"}, {"name": "middle"}]},
+    }
+    result = {
+        "asset_type": "platform-strip",
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": "left",
+                "path": "res://assets/generated/platform-strip/bridge/left.tres",
+                "godot_type": "AtlasTexture",
+            }
+        ],
+        "sources": [
+            {
+                "path": "res://assets/generated/platform-strip/bridge/bridge.png",
+                "layout": "region_atlas",
+            }
+        ],
+        "previews": [],
+        "validation": {"passed": True},
+    }
+    with pytest.raises(MissingFamilySkillError, match="every declared segment"):
+        compile_and_validate(request, result, project_root=tmp_path, godot_path="godot")
+
+
+def test_screen_reference_completes_at_l1_without_invoking_runtime_ladder(tmp_path):
+    reference = tmp_path / "references" / "title.png"
+    reference.parent.mkdir()
+    reference.write_bytes(b"image")
+    result = compile_and_validate(
+        {
+            "asset_type": "screen-reference",
+            "asset_id": "title",
+            "brief": "A title scene.",
+        },
+        {
+            "asset_type": "screen-reference",
+            "outputs": [
+                {"role": "reference", "name": "title", "path": "references/title.png"}
+            ],
+            "sources": [],
+            "previews": [],
+            "validation": {"passed": False},
+        },
+        project_root=tmp_path,
+        godot_path="not-used",
+    )
+    assert result["validation"] == {"passed": True, "levels": {"L0": True, "L1": True}}

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import sys
+import json
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -18,6 +20,8 @@ from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
     compile_and_validate,
 )
+from asset_validation import ProbeReport, ProbeResult  # noqa: E402
+import missing_family_standalone_validation as runner  # noqa: E402
 
 
 def _background_result(
@@ -120,7 +124,7 @@ def test_platform_atlas_requires_every_declared_logical_output(tmp_path):
 def test_screen_reference_completes_at_l1_without_invoking_runtime_ladder(tmp_path):
     reference = tmp_path / "references" / "title.png"
     reference.parent.mkdir()
-    reference.write_bytes(b"image")
+    Image.new("RGBA", (2, 2), (1, 2, 3, 255)).save(reference)
     result = compile_and_validate(
         {
             "asset_type": "screen-reference",
@@ -140,3 +144,149 @@ def test_screen_reference_completes_at_l1_without_invoking_runtime_ladder(tmp_pa
         godot_path="not-used",
     )
     assert result["validation"] == {"passed": True, "levels": {"L0": True, "L1": True}}
+
+
+def test_background_executes_l2_to_l4_with_a_real_png_and_probe(monkeypatch, tmp_path):
+    source = tmp_path / "assets/generated/background-map/sky/sky.png"
+    source.parent.mkdir(parents=True)
+    Image.new("RGBA", (2, 3), (1, 2, 3, 255)).save(source)
+
+    class Probe:
+        def __init__(self, _path):
+            pass
+
+        def probe(self, _root, requests):
+            return ProbeReport(
+                "fake",
+                (
+                    ProbeResult(
+                        requests[0].res_path,
+                        "Texture2D",
+                        True,
+                        "CompressedTexture2D",
+                        True,
+                        structure={"texture2d": {"width": 2, "height": 3}},
+                    ),
+                ),
+            )
+
+    monkeypatch.setattr(runner, "GodotProbe", Probe)
+    actual = compile_and_validate(
+        {"asset_type": "background-map", "asset_id": "sky", "brief": "A blue sky."},
+        _background_result(),
+        project_root=tmp_path,
+        godot_path="fake",
+    )
+    assert actual["validation"]["levels"] == {
+        level: True for level in ("L0", "L1", "L2", "L3", "L4")
+    }
+
+
+@pytest.mark.parametrize("source", [None, 5], ids=["missing", "wrong-type"])
+def test_prop_slot_errors_fail_closed_at_l0(tmp_path, source):
+    slot = {"name": "coin", "rect": [0, 0, 1, 1]}
+    if source is not None:
+        slot["source"] = source
+    request = {
+        "asset_type": "compact-prop-pack",
+        "asset_id": "props",
+        "brief": "props",
+        "spec": {"version": 1, "atlas": {"width": 1, "height": 1}, "slots": [slot]},
+    }
+    result = {
+        "asset_type": "compact-prop-pack",
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": "coin",
+                "path": "res://assets/generated/compact-prop-pack/props/coin.tres",
+                "godot_type": "AtlasTexture",
+            }
+        ],
+        "sources": [
+            {
+                "path": "res://assets/generated/compact-prop-pack/props/props.png",
+                "layout": "region_atlas",
+            }
+        ],
+        "previews": [],
+        "validation": {"passed": False},
+    }
+    with pytest.raises(MissingFamilySkillError, match="L0 standalone contract failed"):
+        compile_and_validate(request, result, project_root=tmp_path, godot_path="fake")
+
+
+def test_prop_runner_never_rebuilds_or_overwrites_the_delivered_atlas(tmp_path):
+    output = tmp_path / "assets/generated/compact-prop-pack/props"
+    output.mkdir(parents=True)
+    atlas = output / "props.png"
+    Image.new("RGBA", (1, 1), (0, 0, 255, 255)).save(atlas)
+    metadata = output / "props.json"
+    metadata.write_text("not metadata", encoding="utf-8")
+    before = (atlas.read_bytes(), metadata.read_bytes())
+    request = {
+        "asset_type": "compact-prop-pack",
+        "asset_id": "props",
+        "brief": "props",
+        "spec": {
+            "version": 1,
+            "atlas": {"width": 1, "height": 1},
+            "slots": [
+                {"name": "coin", "rect": [0, 0, 1, 1], "source": "sources/coin.png"}
+            ],
+        },
+    }
+    result = {
+        "asset_type": "compact-prop-pack",
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": "coin",
+                "path": "res://assets/generated/compact-prop-pack/props/coin.tres",
+                "godot_type": "AtlasTexture",
+            }
+        ],
+        "sources": [
+            {
+                "path": "res://assets/generated/compact-prop-pack/props/props.png",
+                "layout": "region_atlas",
+            }
+        ],
+        "previews": [],
+        "validation": {"passed": True},
+    }
+    actual = compile_and_validate(
+        request, result, project_root=tmp_path, godot_path="fake"
+    )
+    assert actual["validation"]["levels"]["L2"] is False
+    assert (atlas.read_bytes(), metadata.read_bytes()) == before
+
+
+def test_animated_bundle_checks_each_declared_sheet_at_l1(tmp_path):
+    request = json.loads(
+        (
+            REPO_ROOT / "skills/assets/character-bundle/fixtures/valid-request.json"
+        ).read_text(encoding="utf-8")
+    )
+    result = json.loads(
+        (
+            REPO_ROOT / "skills/assets/character-bundle/fixtures/valid-result.json"
+        ).read_text(encoding="utf-8")
+    )
+    result["sources"].append(
+        {
+            "path": "res://assets/generated/character-bundle/player/never_written.png",
+            "layout": "grid_sheet",
+        }
+    )
+    output = tmp_path / "assets/generated/character-bundle/player"
+    output.mkdir(parents=True)
+    for path in ("player_idle_sheet.png", "preview_idle.png"):
+        (output / path).write_bytes(b"x")
+    for action in request["spec"]["actions"]:
+        for frame in action["frame_names"]:
+            (output / f"player_{action['name']}_{frame}.png").write_bytes(b"x")
+    actual = compile_and_validate(
+        request, result, project_root=tmp_path, godot_path="fake"
+    )
+    assert actual["validation"]["levels"]["L1"] is False

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -1082,9 +1082,20 @@ def load_runner(name, family):
 tileset = load_runner("published_tileset_validation", "tileset")
 ui_kit = load_runner("published_ui_kit_validation", "ui-kit")
 card_kit = load_runner("published_card_kit_validation", "card-kit")
+background_map = load_runner("published_background_map_validation", "background-map")
+platform_strip = load_runner("published_platform_strip_validation", "platform-strip")
+screen_reference = load_runner("published_screen_reference_validation", "screen-reference")
+character_bundle = load_runner("published_character_bundle_validation", "character-bundle")
+fx_bundle = load_runner("published_fx_bundle_validation", "fx-bundle")
+compact_prop_pack = load_runner("published_compact_prop_pack_validation", "compact-prop-pack")
+scene_prop_set = load_runner("published_scene_prop_set_validation", "scene-prop-set")
 assert callable(tileset.compile_and_validate)
 assert callable(ui_kit.compile_and_validate)
 assert callable(card_kit.compile_and_validate)
+assert all(callable(module.compile_and_validate) for module in (
+    background_map, platform_strip, screen_reference, character_bundle,
+    fx_bundle, compact_prop_pack, scene_prop_set,
+))
 
 import asset_compiler
 import asset_skill_contract_check
@@ -1165,7 +1176,11 @@ from pathlib import Path
 
 skills = Path({str(skills_target)!r})
 missing = Path({str(missing)!r})
-for family in ("tileset", "ui-kit", "card-kit"):
+for family in (
+    "tileset", "ui-kit", "card-kit", "background-map", "platform-strip",
+    "screen-reference", "character-bundle", "fx-bundle", "compact-prop-pack",
+    "scene-prop-set",
+):
     runner = skills / family / "standalone_validation.py"
     spec = importlib.util.spec_from_file_location(
         f"missing_{{family}}_runner", runner


### PR DESCRIPTION
## Summary

Adds executable standalone L0-L4 validation paths for the remaining asset families.

## Motivation

Standalone asset validation must derive results from delivered files, compiler output, and Godot probes rather than caller-supplied validation.

## Changes

- [x] Add published and source-tree standalone validation runners for seven asset families.
- [x] Bind delivered files, paths, types, animation actions, and atlas geometry fail-closed.

## Testing

- [x] New or updated tests pass (`python -m pytest -q`; 1961 passed, 31 skipped)
- [x] Gitleaks passes or no secret-bearing files were touched (Secret Scan CI passed)
- [x] Manual testing completed, if applicable (not applicable)

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

Not applicable: this PR adds no migration.

## Checklist

- [x] Code follows project conventions
- [ ] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
