### PR TITLE
Validate screen reference PNG decoding

### DIFF
--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -12,8 +12,7 @@ from copy import deepcopy
 import json
 from pathlib import Path
 from typing import Any
-
-from PIL import Image
+import warnings
 
 from asset_compiler import CompileRequest, CompilerError, build_default_registry
 from asset_compiler._stable_entry import (
@@ -470,16 +469,28 @@ def _l1_file(root: Path, path: str, *, family: str, asset_id: str) -> Path:
 def _png_dimensions(path: Path) -> tuple[int, int]:
     """Fully verify and decode a PNG before returning its dimensions."""
     try:
-        with Image.open(path) as image:
-            if image.format != "PNG":
-                raise ValidationError("delivered image is not a PNG")
-            image.verify()
-        with Image.open(path) as image:
-            if image.format != "PNG":
-                raise ValidationError("delivered image is not a PNG")
-            image.load()
-            return image.size
-    except (OSError, SyntaxError, ValueError) as exc:
+        from PIL import Image
+    except ImportError as exc:
+        raise ValidationError("Pillow is required to validate delivered PNG images") from exc
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", Image.DecompressionBombWarning)
+            with Image.open(path) as image:
+                if image.format != "PNG":
+                    raise ValidationError("delivered image is not a PNG")
+                image.verify()
+            with Image.open(path) as image:
+                if image.format != "PNG":
+                    raise ValidationError("delivered image is not a PNG")
+                image.load()
+                return image.size
+    except (
+        OSError,
+        SyntaxError,
+        ValueError,
+        Image.DecompressionBombError,
+        Image.DecompressionBombWarning,
+    ) as exc:
         raise ValidationError("delivered image is not a decodable PNG") from exc
 
 
@@ -541,7 +552,13 @@ def _verify_prop_delivery(
         raise ValidationError(
             "atlas metadata regions must exactly match declared slot names and rectangles"
         )
-    if _png_dimensions(atlas) != (
+    try:
+        dimensions = _png_dimensions(atlas)
+    except ValidationError as exc:
+        raise ValidationError(
+            f"delivered atlas is not a decodable PNG: {declaration.source_path}"
+        ) from exc
+    if dimensions != (
         request["spec"]["atlas"]["width"],
         request["spec"]["atlas"]["height"],
     ):
@@ -592,15 +609,11 @@ def compile_and_validate(
                     f"reference image is not a non-empty file: {reference_path}"
                 )
             try:
-                dimensions = _png_dimensions(file)
+                _png_dimensions(file)
             except ValidationError as exc:
                 raise ValidationError(
                     f"reference image is not a decodable PNG: {reference_path}"
                 ) from exc
-            if dimensions[0] <= 0 or dimensions[1] <= 0:
-                raise ValidationError(
-                    f"reference image has invalid dimensions: {reference_path}"
-                )
             return _mapped(result, {"L0": True, "L1": True})
         if family in {"compact-prop-pack", "scene-prop-set"}:
             _verify_prop_delivery(request, declarations[0][1], root)

--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -11,8 +11,9 @@ from collections.abc import Mapping
 from copy import deepcopy
 import json
 from pathlib import Path
-import struct
 from typing import Any
+
+from PIL import Image
 
 from asset_compiler import CompileRequest, CompilerError, build_default_registry
 from asset_compiler._stable_entry import (
@@ -467,18 +468,19 @@ def _l1_file(root: Path, path: str, *, family: str, asset_id: str) -> Path:
 
 
 def _png_dimensions(path: Path) -> tuple[int, int]:
-    """Read PNG dimensions from IHDR without loading the image into memory."""
-    with path.open("rb") as handle:
-        header = handle.read(24)
-    if (
-        len(header) != 24
-        or header[:8] != b"\x89PNG\r\n\x1a\n"
-        or header[12:16] != b"IHDR"
-    ):
-        raise ValidationError(
-            f"delivered atlas is not a PNG with an IHDR header: {path}"
-        )
-    return struct.unpack(">II", header[16:24])
+    """Fully verify and decode a PNG before returning its dimensions."""
+    try:
+        with Image.open(path) as image:
+            if image.format != "PNG":
+                raise ValidationError("delivered image is not a PNG")
+            image.verify()
+        with Image.open(path) as image:
+            if image.format != "PNG":
+                raise ValidationError("delivered image is not a PNG")
+            image.load()
+            return image.size
+    except (OSError, SyntaxError, ValueError) as exc:
+        raise ValidationError("delivered image is not a decodable PNG") from exc
 
 
 def _verify_prop_delivery(
@@ -579,13 +581,25 @@ def compile_and_validate(
     try:
         if reference_path is not None:
             file = _project_file(root, reference_path, "reference image")
-            if (
-                not file.is_file()
-                or file.stat().st_size <= 0
-                or _png_dimensions(file) == (0, 0)
-            ):
+            try:
+                is_non_empty = file.is_file() and file.stat().st_size > 0
+            except OSError as exc:
                 raise ValidationError(
-                    f"reference image is not a non-empty PNG file: {reference_path}"
+                    f"reference image cannot be read: {reference_path}"
+                ) from exc
+            if not is_non_empty:
+                raise ValidationError(
+                    f"reference image is not a non-empty file: {reference_path}"
+                )
+            try:
+                dimensions = _png_dimensions(file)
+            except ValidationError as exc:
+                raise ValidationError(
+                    f"reference image is not a decodable PNG: {reference_path}"
+                ) from exc
+            if dimensions[0] <= 0 or dimensions[1] <= 0:
+                raise ValidationError(
+                    f"reference image has invalid dimensions: {reference_path}"
                 )
             return _mapped(result, {"L0": True, "L1": True})
         if family in {"compact-prop-pack", "scene-prop-set"}:

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import json
+import struct
 import sys
+import zlib
 from pathlib import Path
 
 import pytest
@@ -144,6 +146,100 @@ def test_screen_reference_completes_at_l1_without_invoking_runtime_ladder(tmp_pa
         godot_path="not-used",
     )
     assert result["validation"] == {"passed": True, "levels": {"L0": True, "L1": True}}
+
+
+def _screen_reference_request() -> dict:
+    return {
+        "asset_type": "screen-reference",
+        "asset_id": "title",
+        "brief": "A title scene.",
+    }
+
+
+def _screen_reference_result() -> dict:
+    return {
+        "asset_type": "screen-reference",
+        "outputs": [
+            {"role": "reference", "name": "title", "path": "references/title.png"}
+        ],
+        "sources": [],
+        "previews": [],
+        "validation": {"passed": True},
+    }
+
+
+def _png_chunk(kind: bytes, data: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(data))
+        + kind
+        + data
+        + struct.pack(">I", zlib.crc32(kind + data) & 0xFFFFFFFF)
+    )
+
+
+def _zero_width_png() -> bytes:
+    return b"".join(
+        (
+            b"\x89PNG\r\n\x1a\n",
+            _png_chunk(b"IHDR", struct.pack(">IIBBBBB", 0, 1, 8, 6, 0, 0, 0)),
+            _png_chunk(b"IDAT", zlib.compress(b"")),
+            _png_chunk(b"IEND", b""),
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(
+            b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x02\x00\x00\x00\x02",
+            id="truncated-ihdr",
+        ),
+        pytest.param(b"not a png", id="non-png"),
+        pytest.param(_zero_width_png(), id="zero-width"),
+    ],
+)
+def test_screen_reference_rejects_undecodable_pngs(tmp_path, payload):
+    reference = tmp_path / "references" / "title.png"
+    reference.parent.mkdir()
+    reference.write_bytes(payload)
+
+    actual = compile_and_validate(
+        _screen_reference_request(),
+        _screen_reference_result(),
+        project_root=tmp_path,
+        godot_path="not-used",
+    )
+
+    assert actual["validation"] == {
+        "passed": False,
+        "levels": {"L0": True, "L1": False},
+        "notes": "reference image is not a decodable PNG: references/title.png",
+    }
+    assert str(tmp_path) not in actual["validation"]["notes"]
+
+
+def test_screen_reference_rejects_png_with_bad_idat_crc(tmp_path):
+    reference = tmp_path / "references" / "title.png"
+    reference.parent.mkdir()
+    Image.new("RGBA", (2, 2), (1, 2, 3, 255)).save(reference)
+    payload = bytearray(reference.read_bytes())
+    idat = payload.index(b"IDAT")
+    payload[idat + 4] ^= 1
+    reference.write_bytes(payload)
+
+    actual = compile_and_validate(
+        _screen_reference_request(),
+        _screen_reference_result(),
+        project_root=tmp_path,
+        godot_path="not-used",
+    )
+
+    assert actual["validation"] == {
+        "passed": False,
+        "levels": {"L0": True, "L1": False},
+        "notes": "reference image is not a decodable PNG: references/title.png",
+    }
 
 
 def test_background_executes_l2_to_l4_with_a_real_png_and_probe(monkeypatch, tmp_path):

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -188,6 +188,18 @@ def _zero_width_png() -> bytes:
     )
 
 
+def _decompression_bomb_png() -> bytes:
+    return b"".join(
+        (
+            b"\x89PNG\r\n\x1a\n",
+            _png_chunk(
+                b"IHDR", struct.pack(">IIBBBBB", 30000, 30000, 8, 6, 0, 0, 0)
+            ),
+            _png_chunk(b"IEND", b""),
+        )
+    )
+
+
 @pytest.mark.parametrize(
     "payload",
     [
@@ -197,6 +209,7 @@ def _zero_width_png() -> bytes:
         ),
         pytest.param(b"not a png", id="non-png"),
         pytest.param(_zero_width_png(), id="zero-width"),
+        pytest.param(_decompression_bomb_png(), id="decompression-bomb"),
     ],
 )
 def test_screen_reference_rejects_undecodable_pngs(tmp_path, payload):
@@ -239,6 +252,33 @@ def test_screen_reference_rejects_png_with_bad_idat_crc(tmp_path):
         "passed": False,
         "levels": {"L0": True, "L1": False},
         "notes": "reference image is not a decodable PNG: references/title.png",
+    }
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(b"not a png", id="non-png"),
+        pytest.param(_decompression_bomb_png(), id="decompression-bomb"),
+    ],
+)
+def test_prop_atlas_rejects_bad_png_with_a_stable_source_path(tmp_path, payload):
+    request, result = _prop_handoff("compact-prop-pack")
+    _write_prop_delivery(tmp_path, request)
+    atlas = tmp_path / "assets/generated/compact-prop-pack/market/market.png"
+    atlas.write_bytes(payload)
+
+    actual = compile_and_validate(
+        request, result, project_root=tmp_path, godot_path="not-used"
+    )
+
+    assert actual["validation"] == {
+        "passed": False,
+        "levels": {level: level == "L0" for level in ("L0", "L1", "L2", "L3", "L4")},
+        "notes": (
+            "delivered atlas is not a decodable PNG: "
+            "res://assets/generated/compact-prop-pack/market/market.png"
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

Validate and fully decode PNG files before accepting screen references at L1. Diagnostics for unreadable or corrupt reference images retain only the stable reference path.

## Motivation

L1 previously trusted a 24-byte PNG header and its IHDR dimensions, which allowed truncated or otherwise unusable image data to pass. No public GitHub issue.

## Changes

- [x] Verify PNG integrity with Pillow and reopen/load it before accepting dimensions.
- [x] Fail closed for truncated, corrupt, non-PNG, zero-size, and decompression-bomb inputs.
- [x] Add regression coverage for Screen Reference and prop-atlas diagnostics.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant): `python -m pytest tests/assets/test_missing_family_standalone_validation.py -q`
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing completed, if applicable: not applicable; Screen Reference validation ends at L1 and does not run a Godot probe.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behaviors, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [x] Not applicable; no migration script was added or modified.
- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR: maintenance-only validation fix; no release-note update required
