### PR TITLE
Reject empty TileSet collision polygons

### DIFF
--- a/skills/assets/_shared/asset_compiler/tileset.py
+++ b/skills/assets/_shared/asset_compiler/tileset.py
@@ -100,8 +100,10 @@ def _layer_index(value: Any, label: str, count: int) -> int:
     return index
 
 
-def _polygon_points(value: Any, label: str) -> list[list[float]]:
+def _polygon_points(value: Any, label: str, *, allow_empty: bool = True) -> list[list[float]]:
     points = _list(value, f"{label} points")
+    if len(points) < 3 and not allow_empty:
+        raise CompilerError(f"{label} points must contain at least three points")
     if len(points) in (1, 2):
         raise CompilerError(f"{label} points must be empty or contain at least three points")
     normalized: list[list[float]] = []
@@ -207,7 +209,10 @@ def _validate_tile_data(item: dict[str, Any], spec: dict[str, Any], label: str) 
                 raise CompilerError(f"{label} cannot declare duplicate navigation polygons for one layer")
             if key == "navigation_polygons":
                 seen_navigation_layers.add(layer)
-            polygon["points"] = _polygon_points(polygon.get("points"), f"{label} {family} polygon")
+            polygon["points"] = _polygon_points(
+                polygon.get("points"), f"{label} {family} polygon",
+                allow_empty=key != "collision_polygons",
+            )
 
 
 def _validate_animation(animation: Any) -> dict[str, Any]:

--- a/tests/assets/test_tileset_compiler.py
+++ b/tests/assets/test_tileset_compiler.py
@@ -250,6 +250,36 @@ def test_tileset_recipe_rejects_invalid_declared_tile_semantics(tmp_path, change
         compiler._recipe(_recipe_request(tmp_path, _spec(**changes)))
 
 
+@pytest.mark.parametrize("alternative", [False, True])
+def test_tileset_recipe_rejects_empty_collision_polygons_for_tiles_and_alternatives(tmp_path, alternative):
+    collision = {"layer": 0, "points": []}
+    tile = {"coords": [0, 0]}
+    if alternative:
+        tile["alternatives"] = [{"id": 1, "collision_polygons": [collision]}]
+    else:
+        tile["collision_polygons"] = [collision]
+    request = _recipe_request(tmp_path, _spec(
+        physics_layers=[{}],
+        sources=[{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [tile]}],
+    ))
+    with pytest.raises(CompilerError, match="collision polygon points must contain at least three points"):
+        compiler._recipe(request)
+
+
+def test_tileset_recipe_continues_to_allow_empty_occlusion_and_navigation_polygons(tmp_path):
+    recipe = compiler._recipe(_recipe_request(tmp_path, _spec(
+        occlusion_layers=[{}], navigation_layers=[{}],
+        sources=[{"texture": "res://assets/generated/tileset/grass/atlas.png", "tiles": [{
+            "coords": [0, 0],
+            "occlusion_polygons": [{"layer": 0, "points": []}],
+            "navigation_polygons": [{"layer": 0, "points": []}],
+        }]}],
+    )))
+    tile = recipe["sources"][0]["tiles"][0]
+    assert tile["occlusion_polygons"][0]["points"] == []
+    assert tile["navigation_polygons"][0]["points"] == []
+
+
 def test_tileset_recipe_rejects_duplicate_tile_coords_and_alternative_ids(tmp_path):
     source = "res://assets/generated/tileset/grass/atlas.png"
     duplicate_coords = _recipe_request(tmp_path, _spec(sources=[{
@@ -534,6 +564,43 @@ def test_tileset_real_godot_handles_multiple_sources_defaults_and_polygon_float3
             source_path=request.source_path, artifact_type="TileSet", artifact_path=request.artifact_path,
             project_root=godot_project, probe=report.resources[0], spec=request.spec,
         ))
+
+
+def test_tileset_real_godot_validates_collision_polygons_and_rejects_empty_ones_before_invocation(
+    godot_bin, godot_project, monkeypatch,
+):
+    source = godot_project / "assets/generated/tileset/grass/atlas.png"
+    source.parent.mkdir(parents=True)
+    source.write_bytes(_png(16, 16))
+
+    def request_for(points, binary):
+        return CompileRequest(
+            production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+            source_path="res://assets/generated/tileset/grass/atlas.png", artifact_type="TileSet",
+            artifact_path="res://assets/generated/tileset/grass/collision.tres", project_root=godot_project,
+            spec={"godot_path": binary, "tile_size": [16, 16], "physics_layers": [{}], "sources": [{
+                "texture": "res://assets/generated/tileset/grass/atlas.png",
+                "tiles": [{"coords": [0, 0], "collision_polygons": [{"layer": 0, "points": points}]}],
+            }]},
+        )
+
+    valid = request_for([[0, 0], [16, 0], [0, 16]], godot_bin)
+    compiler.compile_tileset(valid)
+    report = GodotProbe(godot_bin).probe(
+        godot_project, [ProbeRequest(valid.artifact_path, "TileSet", ("tileset",))]
+    )
+    structures.validate_tileset(StructureRequest(
+        production_family="tileset", asset_id="grass", source_layout_type="tile_atlas",
+        source_path=valid.source_path, artifact_type="TileSet", artifact_path=valid.artifact_path,
+        project_root=godot_project, probe=report.resources[0], spec=valid.spec,
+    ))
+
+    def must_not_invoke_godot(*args, **kwargs):
+        raise AssertionError("empty collision polygons must fail during L2 before Godot is invoked")
+
+    monkeypatch.setattr(compiler.subprocess, "run", must_not_invoke_godot)
+    with pytest.raises(CompilerError, match="collision polygon points must contain at least three points"):
+        compiler.compile_tileset(request_for([], "not-a-godot-binary"))
 
 
 def test_compile_tileset_does_not_mutate_nested_spec_across_direct_calls(godot_bin, godot_project):


### PR DESCRIPTION
## Summary

Reject TileSet collision polygons whose `points` array contains fewer than three finite 2D points, while retaining the established empty-polygon behavior for occlusion and navigation.

## Motivation

Godot normalizes an empty collision polygon away while saving a TileSet. The compiler must reject that input before compilation so the resource can reach the verified ready state.

Related public GitHub issue: No public GitHub issue.

## Changes

- [x] Validate collision polygons for base tiles and alternatives with at least three finite 2D points.
- [x] Add regression coverage for empty collision polygons and preserve empty occlusion/navigation behavior.

## Testing

- [x] New or updated tests pass (`python -m pytest tests/assets/test_tileset_compiler.py -q`: 42 passed, 8 skipped; `python -m pytest -q`: 1972 passed, 32 skipped).
- [x] Gitleaks passes or no secret-bearing files were touched (no secret-bearing files were touched; CI Secret Scan passed).
- [x] Manual testing completed, if applicable (real-Godot regression is included; locally skipped because no Godot binary was available).

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive.
- [ ] Performance-sensitive; benchmark results are attached below or linked.

<details>
<summary>Benchmark Results</summary>

```text
Not applicable: validation-only change with no performance claim.
```

</details>

## Version Compatibility

This PR changes validation behavior by rejecting invalid TileSet recipes before compilation; it does not change saved project formats or require migration.

- [x] **No** - no migration needed.
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md)).

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold `migrations/<utc-timestamp>_<slug>.py`. The script must define `migrate(target: Path) -> None` and be idempotent. The bump level does NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified. Not applicable: no migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`.
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`.
- [ ] Post-upgrade on-disk state was inspected and matches expectations.
- [ ] Re-running `tools/publish.py` produces no further migration changes.
- [x] Result attached or summarized below (not applicable: no migration).

## Checklist

- [x] Code follows project conventions.
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable: no ECS systems changed).
- [x] No hardcoded secrets or API keys.
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR (not applicable: narrowly scoped compiler validation fix; no user-facing release-note change requested).
