### PR TITLE
Validate prop atlas slot geometry

### DIFF
--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -34,6 +34,7 @@ from asset_animated_bundle_contract_check import (
     check_bundle_request,
     check_bundle_result,
 )
+from asset_atlas_assemble import validate_fixed_slot_rectangles
 
 
 class MissingFamilySkillError(Exception):
@@ -369,6 +370,7 @@ def _check_props(
         )
     slots = spec["slots"]
     names: list[str] = []
+    rectangles: list[tuple[int, int, int, int]] = []
     for index, raw_slot in enumerate(slots):
         if not isinstance(raw_slot, Mapping):
             raise MissingFamilySkillError(f"{family} slots[{index}] must be an object")
@@ -396,6 +398,11 @@ def _check_props(
             raise MissingFamilySkillError(
                 f"{family} slots[{index}] must be a valid fixed-slot declaration"
             )
+        rectangles.append(tuple(rect))
+        try:
+            validate_fixed_slot_rectangles(rectangles, atlas["width"], atlas["height"])
+        except ValueError as exc:
+            raise MissingFamilySkillError(f"{family} {exc}") from exc
         names.append(name)
     if len(set(names)) != len(names):
         raise MissingFamilySkillError(

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -216,6 +216,92 @@ def test_prop_slot_errors_fail_closed_at_l0(tmp_path, source):
         compile_and_validate(request, result, project_root=tmp_path, godot_path="fake")
 
 
+@pytest.mark.parametrize("family", ["compact-prop-pack", "scene-prop-set"])
+@pytest.mark.parametrize(
+    ("slots", "message"),
+    [
+        pytest.param(
+            [
+                {"name": "left", "rect": [0, 0, 4, 4], "source": "left.png"},
+                {"name": "right", "rect": [4, 0, 4, 4], "source": "right.png"},
+            ],
+            None,
+            id="edge-touching-is-valid",
+        ),
+        pytest.param(
+            [
+                {"name": "left", "rect": [0, 0, 6, 6], "source": "left.png"},
+                {"name": "right", "rect": [4, 4, 4, 4], "source": "right.png"},
+            ],
+            "overlaps another declared slot",
+            id="partial-overlap",
+        ),
+        pytest.param(
+            [
+                {"name": "outer", "rect": [0, 0, 8, 8], "source": "outer.png"},
+                {"name": "inner", "rect": [2, 2, 2, 2], "source": "inner.png"},
+            ],
+            "overlaps another declared slot",
+            id="complete-containment",
+        ),
+        pytest.param(
+            [
+                {"name": "first", "rect": [0, 0, 4, 4], "source": "first.png"},
+                {"name": "second", "rect": [0, 0, 4, 4], "source": "second.png"},
+            ],
+            "overlaps another declared slot",
+            id="identical-rectangles",
+        ),
+        pytest.param(
+            [
+                {"name": "top_left", "rect": [0, 0, 4, 4], "source": "top_left.png"},
+                {"name": "top_right", "rect": [4, 0, 4, 4], "source": "top_right.png"},
+                {"name": "bottom", "rect": [0, 4, 8, 4], "source": "bottom.png"},
+            ],
+            None,
+            id="valid-multi-slot-layout",
+        ),
+        pytest.param(
+            [{"name": "outside", "rect": [6, 0, 3, 2], "source": "outside.png"}],
+            "outside the declared atlas bounds",
+            id="outside-atlas-bounds",
+        ),
+    ],
+)
+def test_prop_fixed_slot_geometry_fails_closed_at_l0(tmp_path, family, slots, message):
+    root = f"res://assets/generated/{family}/props"
+    request = {
+        "asset_type": family,
+        "asset_id": "props",
+        "brief": "props",
+        "spec": {"version": 1, "atlas": {"width": 8, "height": 8}, "slots": slots},
+    }
+    result = {
+        "asset_type": family,
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": slot["name"],
+                "path": f"{root}/{slot['name']}.tres",
+                "godot_type": "AtlasTexture",
+            }
+            for slot in slots
+        ],
+        "sources": [{"path": f"{root}/props.png", "layout": "region_atlas"}],
+        "previews": [],
+        "validation": {"passed": False},
+    }
+
+    if message is None:
+        actual = compile_and_validate(
+            request, result, project_root=tmp_path, godot_path="fake"
+        )
+        assert actual["validation"]["levels"]["L0"] is True
+    else:
+        with pytest.raises(MissingFamilySkillError, match=message):
+            compile_and_validate(request, result, project_root=tmp_path, godot_path="fake")
+
+
 def test_prop_runner_never_rebuilds_or_overwrites_the_delivered_atlas(tmp_path):
     output = tmp_path / "assets/generated/compact-prop-pack/props"
     output.mkdir(parents=True)
@@ -417,6 +503,21 @@ def test_prop_families_run_multi_slot_delivery_through_l4(
 
     actual = compile_and_validate(
         request, result, project_root=tmp_path, godot_path="fake"
+    )
+
+    assert actual["validation"]["levels"] == {
+        level: True for level in ("L0", "L1", "L2", "L3", "L4")
+    }
+
+
+def test_compact_prop_multi_slot_delivery_runs_through_real_godot_l4(
+    godot_project, godot_bin
+):
+    request, result = _prop_handoff("compact-prop-pack")
+    _write_prop_delivery(godot_project, request)
+
+    actual = compile_and_validate(
+        request, result, project_root=godot_project, godot_path=godot_bin
     )
 
     assert actual["validation"]["levels"] == {

--- a/tools/asset_atlas_assemble.py
+++ b/tools/asset_atlas_assemble.py
@@ -78,9 +78,10 @@ def _pivot(value: Any, label: str) -> list[float]:
     return pivot
 
 
-def _rectangles_overlap(
+def rectangles_overlap(
     left: tuple[int, int, int, int], right: tuple[int, int, int, int]
 ) -> bool:
+    """Return whether two positive [x, y, width, height] rectangles overlap."""
     left_x, left_y, left_width, left_height = left
     right_x, right_y, right_width, right_height = right
     return not (
@@ -89,6 +90,18 @@ def _rectangles_overlap(
         or left_y + left_height <= right_y
         or right_y + right_height <= left_y
     )
+
+
+def validate_fixed_slot_rectangles(
+    rectangles: list[tuple[int, int, int, int]], atlas_width: int, atlas_height: int
+) -> None:
+    """Reject fixed slot rectangles outside an atlas or overlapping a prior slot."""
+    for index, rect in enumerate(rectangles):
+        x, y, width, height = rect
+        if x + width > atlas_width or y + height > atlas_height:
+            raise ValueError(f"slots[{index}].rect is outside the declared atlas bounds")
+        if any(rectangles_overlap(rect, existing) for existing in rectangles[:index]):
+            raise ValueError(f"slots[{index}].rect overlaps another declared slot")
 
 
 def _load_png(path: Path):
@@ -300,11 +313,12 @@ def assemble_atlas(
             raise AtlasAssemblyError(f"Slot name is duplicated: {name}")
         names.add(name)
         rect = _rect(slot.get("rect"), f"{label}.rect")
-        x, y, width, height = rect
-        if x + width > atlas_width or y + height > atlas_height:
-            raise AtlasAssemblyError(f"{label}.rect is outside the declared atlas bounds")
-        if any(_rectangles_overlap(rect, existing) for existing in rectangles):
-            raise AtlasAssemblyError(f"{label}.rect overlaps another declared slot")
+        try:
+            validate_fixed_slot_rectangles(
+                [*rectangles, rect], atlas_width, atlas_height
+            )
+        except ValueError as exc:
+            raise AtlasAssemblyError(f"declaration.{exc}") from exc
         rectangles.append(rect)
         source = slot.get("source")
         if not isinstance(source, str) or not source.strip():


### PR DESCRIPTION
## Summary

Validate fixed atlas slot bounds and non-overlap during standalone L0 validation for compact and scene prop packs.

## Motivation

Standalone validation previously accepted deliveries that faithfully reproduced invalid fixed-slot declarations. No public GitHub issue is associated with this change.

## Changes

- [x] Share the assembler fixed-slot geometry validator with standalone validation.
- [x] Add coverage for edge touching, overlap variants, legal multi-slot layouts, bounds validation, and a real-Godot multi-slot regression.

## Testing

- [x] New or updated tests pass (`python -m pytest tests/ -x -q`)
- [x] No secret-bearing files were touched; the Secret Scan check passes
- [x] Manual testing completed where applicable; the real-Godot regression is configured to run when a Godot binary is available

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Not applicable: no migration script is added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
