### PR TITLE
Bind standalone validators to skill contracts

### DIFF
--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -580,11 +580,19 @@ def compile_and_validate(
     *,
     project_root: Path,
     godot_path: str,
+    expected_family: str | None = None,
 ) -> dict[str, Any]:
     """Execute the real applicable ladder for one of the seven missing families."""
     try:
         check_request(request)
         check_result(result)
+        if expected_family is not None and (
+            request["asset_type"] != expected_family
+            or result["asset_type"] != expected_family
+        ):
+            raise MissingFamilySkillError(
+                f"standalone adapter requires asset_type {expected_family!r}"
+            )
         if (
             request["asset_type"] not in _FAMILIES
             or result["asset_type"] != request["asset_type"]

--- a/skills/assets/_shared/ui_card_standalone_validation.py
+++ b/skills/assets/_shared/ui_card_standalone_validation.py
@@ -74,7 +74,8 @@ def _l1_paths(spec: Mapping[str, Any]) -> list[str]:
 
 
 def compile_and_validate(
-    request: Mapping[str, Any], result: Mapping[str, Any], *, project_root: Path, godot_path: str
+    request: Mapping[str, Any], result: Mapping[str, Any], *, project_root: Path, godot_path: str,
+    expected_family: str | None = None,
 ) -> dict[str, Any]:
     """Compile and validate every declared standalone UI/card resource.
 
@@ -83,6 +84,13 @@ def compile_and_validate(
     own registry and probes every runtime output returned to the caller.
     """
     try:
+        if expected_family is not None and (
+            request.get("asset_type") != expected_family
+            or result.get("asset_type") != expected_family
+        ):
+            raise UICardSkillError(
+                f"standalone adapter requires asset_type {expected_family!r}"
+            )
         handoff = check_ui_card_handoff(request, result)
         spec = handoff["request"]["spec"]
         if not isinstance(spec, Mapping):

--- a/skills/assets/_shared/ui_card_standalone_validation.py
+++ b/skills/assets/_shared/ui_card_standalone_validation.py
@@ -84,14 +84,14 @@ def compile_and_validate(
     own registry and probes every runtime output returned to the caller.
     """
     try:
+        handoff = check_ui_card_handoff(request, result)
         if expected_family is not None and (
-            request.get("asset_type") != expected_family
-            or result.get("asset_type") != expected_family
+            request["asset_type"] != expected_family
+            or result["asset_type"] != expected_family
         ):
             raise UICardSkillError(
                 f"standalone adapter requires asset_type {expected_family!r}"
             )
-        handoff = check_ui_card_handoff(request, result)
         spec = handoff["request"]["spec"]
         if not isinstance(spec, Mapping):
             raise UICardSkillError("family contract returned no normalized spec")

--- a/skills/assets/background-map/standalone_validation.py
+++ b/skills/assets/background-map/standalone_validation.py
@@ -43,7 +43,11 @@ def _runtime() -> None:
 _runtime()
 from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
-    compile_and_validate,
+    compile_and_validate as _compile_and_validate,
 )
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="background-map")
 
 __all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/card-kit/standalone_validation.py
+++ b/skills/assets/card-kit/standalone_validation.py
@@ -45,6 +45,10 @@ def _configure_runtime_imports() -> None:
 
 _configure_runtime_imports()
 
-from ui_card_standalone_validation import UICardSkillError, compile_and_validate  # noqa: E402
+from ui_card_standalone_validation import UICardSkillError, compile_and_validate as _compile_and_validate  # noqa: E402
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="card-kit")
 
 __all__ = ["UICardSkillError", "compile_and_validate"]

--- a/skills/assets/character-bundle/standalone_validation.py
+++ b/skills/assets/character-bundle/standalone_validation.py
@@ -43,7 +43,11 @@ def _runtime() -> None:
 _runtime()
 from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
-    compile_and_validate,
+    compile_and_validate as _compile_and_validate,
 )
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="character-bundle")
 
 __all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/compact-prop-pack/standalone_validation.py
+++ b/skills/assets/compact-prop-pack/standalone_validation.py
@@ -43,7 +43,11 @@ def _runtime() -> None:
 _runtime()
 from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
-    compile_and_validate,
+    compile_and_validate as _compile_and_validate,
 )
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="compact-prop-pack")
 
 __all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/fx-bundle/standalone_validation.py
+++ b/skills/assets/fx-bundle/standalone_validation.py
@@ -43,7 +43,11 @@ def _runtime() -> None:
 _runtime()
 from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
-    compile_and_validate,
+    compile_and_validate as _compile_and_validate,
 )
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="fx-bundle")
 
 __all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/platform-strip/standalone_validation.py
+++ b/skills/assets/platform-strip/standalone_validation.py
@@ -43,7 +43,11 @@ def _runtime() -> None:
 _runtime()
 from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
-    compile_and_validate,
+    compile_and_validate as _compile_and_validate,
 )
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="platform-strip")
 
 __all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/scene-prop-set/standalone_validation.py
+++ b/skills/assets/scene-prop-set/standalone_validation.py
@@ -43,7 +43,11 @@ def _runtime() -> None:
 _runtime()
 from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
-    compile_and_validate,
+    compile_and_validate as _compile_and_validate,
 )
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="scene-prop-set")
 
 __all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/screen-reference/standalone_validation.py
+++ b/skills/assets/screen-reference/standalone_validation.py
@@ -43,7 +43,11 @@ def _runtime() -> None:
 _runtime()
 from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
-    compile_and_validate,
+    compile_and_validate as _compile_and_validate,
 )
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="screen-reference")
 
 __all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/assets/tileset/standalone_validation.py
+++ b/skills/assets/tileset/standalone_validation.py
@@ -87,35 +87,38 @@ class TileSetSkillError(Exception):
 _LEVELS = ("L0", "L1", "L2", "L3", "L4")
 
 
-def _runtime_output(result: Mapping[str, Any]) -> Mapping[str, Any]:
+def _runtime_output(result: Mapping[str, Any], asset_id: str) -> Mapping[str, Any]:
     outputs = [output for output in result["outputs"] if output["role"] == "runtime"]
-    if len(outputs) != 1 or outputs[0].get("godot_type") != "TileSet":
+    expected_path = f"res://assets/generated/tileset/{asset_id}/{asset_id}.tres"
+    if (
+        len(outputs) != 1
+        or outputs[0].get("godot_type") != "TileSet"
+        or outputs[0].get("path") != expected_path
+    ):
         raise TileSetSkillError(
-            "v1 standalone tileset supports exactly one runtime output, and it must be TileSet"
+            "v1 standalone tileset requires exactly one stable TileSet runtime output"
         )
     return outputs[0]
 
 
 def _atlas_sources(request: Mapping[str, Any], result: Mapping[str, Any]) -> list[str]:
     recipe_sources = request.get("spec", {}).get("sources")
-    if not isinstance(recipe_sources, list) or not recipe_sources:
-        raise TileSetSkillError("tileset spec requires a non-empty sources list")
-    declared = {
-        source["path"]
-        for source in result["sources"]
-        if source.get("layout") == "tile_atlas"
-    }
-    paths: list[str] = []
-    for source in recipe_sources:
-        if not isinstance(source, Mapping) or not isinstance(source.get("texture"), str):
-            raise TileSetSkillError("every tileset recipe source requires a texture path")
-        texture = source["texture"]
-        if texture not in declared:
-            raise TileSetSkillError(
-                "every tileset recipe texture must be declared as a tile_atlas result source"
-            )
-        paths.append(texture)
-    return paths
+    asset_id = request["asset_id"]
+    expected_path = f"res://assets/generated/tileset/{asset_id}/{asset_id}_atlas.png"
+    if (
+        not isinstance(recipe_sources, list)
+        or len(recipe_sources) != 1
+        or not isinstance(recipe_sources[0], Mapping)
+        or recipe_sources[0].get("texture") != expected_path
+    ):
+        raise TileSetSkillError(
+            "tileset spec requires exactly one stable atlas texture source"
+        )
+    if result["sources"] != [{"path": expected_path, "layout": "tile_atlas"}]:
+        raise TileSetSkillError(
+            "tileset result requires exactly its one stable tile_atlas source"
+        )
+    return [expected_path]
 
 
 def _mapped_result(
@@ -165,7 +168,7 @@ def compile_and_validate(
         check_result(result)
         if request["asset_type"] != "tileset" or result["asset_type"] != "tileset":
             raise TileSetSkillError("standalone TileSet validation requires asset_type 'tileset'")
-        output = _runtime_output(result)
+        output = _runtime_output(result, request["asset_id"])
         atlas_paths = _atlas_sources(request, result)
     except (AssetContractError, TileSetSkillError) as exc:
         raise TileSetSkillError(f"L0 standalone contract failed: {exc}") from exc

--- a/skills/assets/ui-kit/standalone_validation.py
+++ b/skills/assets/ui-kit/standalone_validation.py
@@ -45,6 +45,10 @@ def _configure_runtime_imports() -> None:
 
 _configure_runtime_imports()
 
-from ui_card_standalone_validation import UICardSkillError, compile_and_validate  # noqa: E402
+from ui_card_standalone_validation import UICardSkillError, compile_and_validate as _compile_and_validate  # noqa: E402
+
+
+def compile_and_validate(request, result, *, project_root, godot_path):
+    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="ui-kit")
 
 __all__ = ["UICardSkillError", "compile_and_validate"]

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import importlib.util
 import struct
 import sys
 import zlib
@@ -51,6 +52,42 @@ def _background_result(
             "levels": {"L0": True, "L1": True, "L2": True, "L3": True, "L4": True},
         },
     }
+
+
+def _source_adapter(family: str):
+    path = REPO_ROOT / "skills" / "assets" / family / "standalone_validation.py"
+    spec = importlib.util.spec_from_file_location(f"{family}_adapter", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skill_local_adapters_reject_a_legal_request_for_another_family(tmp_path):
+    request = {"asset_type": "background-map", "asset_id": "sky", "brief": "A blue sky."}
+    for family in (
+        "platform-strip", "screen-reference", "character-bundle", "fx-bundle",
+        "compact-prop-pack", "scene-prop-set",
+    ):
+        with pytest.raises(MissingFamilySkillError, match="L0 standalone contract failed"):
+            _source_adapter(family).compile_and_validate(
+                request, _background_result(), project_root=tmp_path, godot_path="fake"
+            )
+
+    platform_request = {
+        "asset_type": "platform-strip", "asset_id": "bridge", "brief": "A bridge.",
+        "spec": {"kind": "single", "segments": [{"name": "center"}]},
+    }
+    platform_result = {
+        "asset_type": "platform-strip",
+        "outputs": [{"role": "runtime", "name": "center", "path": "res://assets/generated/platform-strip/bridge/center.png", "godot_type": "Texture2D"}],
+        "sources": [{"path": "res://assets/generated/platform-strip/bridge/center.png", "layout": "single"}],
+        "previews": [], "validation": {"passed": False},
+    }
+    with pytest.raises(MissingFamilySkillError, match="L0 standalone contract failed"):
+        _source_adapter("background-map").compile_and_validate(
+            platform_request, platform_result, project_root=tmp_path, godot_path="fake"
+        )
 
 
 def test_background_runner_does_not_trust_a_forged_successful_validation(tmp_path):

--- a/tests/assets/test_tileset_skill_contract.py
+++ b/tests/assets/test_tileset_skill_contract.py
@@ -256,5 +256,29 @@ def test_standalone_runner_rejects_an_unvalidated_extra_runtime_output(tmp_path)
         "validation": {"passed": False},
     }
 
-    with pytest.raises(TileSetSkillError, match="exactly one runtime output"):
+    with pytest.raises(TileSetSkillError, match="exactly one stable TileSet runtime output"):
+        compile_and_validate(request, result, project_root=tmp_path, godot_path="godot")
+
+
+@pytest.mark.parametrize("mutation", ["runtime", "result-source", "recipe-source", "multiple-sources"])
+def test_standalone_runner_rejects_noncanonical_stable_tileset_paths(tmp_path, mutation):
+    request = {
+        "asset_type": "tileset", "asset_id": "grassland", "brief": "A grassland tile atlas.",
+        "spec": _fixture(),
+    }
+    result = {
+        "asset_type": "tileset",
+        "outputs": [{"role": "runtime", "path": "res://assets/generated/tileset/grassland/grassland.tres", "godot_type": "TileSet"}],
+        "sources": [{"path": "res://assets/generated/tileset/grassland/grassland_atlas.png", "layout": "tile_atlas"}],
+        "previews": [], "validation": {"passed": False},
+    }
+    if mutation == "runtime":
+        result["outputs"][0]["path"] = "res://assets/generated/tileset/grassland/not-the-asset-id.tres"
+    elif mutation == "result-source":
+        result["sources"][0]["path"] = "res://assets/generated/tileset/grassland/not-the-asset-id.png"
+    elif mutation == "recipe-source":
+        request["spec"]["sources"][0]["texture"] = "res://assets/generated/tileset/grassland/not-the-asset-id.png"
+    else:
+        request["spec"]["sources"].append(dict(request["spec"]["sources"][0]))
+    with pytest.raises(TileSetSkillError, match="L0 standalone contract failed"):
         compile_and_validate(request, result, project_root=tmp_path, godot_path="godot")

--- a/tests/assets/test_ui_card_skill_contract.py
+++ b/tests/assets/test_ui_card_skill_contract.py
@@ -219,6 +219,21 @@ def test_skill_local_ui_card_adapter_rejects_the_other_legal_family(tmp_path, ad
         )
 
 
+@pytest.mark.parametrize("adapter", ["ui-kit", "card-kit"])
+@pytest.mark.parametrize("invalid_input", ["request", "result"])
+def test_skill_local_ui_card_adapter_maps_non_objects_to_l0(tmp_path, adapter, invalid_input):
+    request = _request(adapter)
+    result = _result(request)
+    if invalid_input == "request":
+        request = []
+    else:
+        result = []
+    with pytest.raises(UICardSkillError, match="L0 standalone contract failed"):
+        _source_adapter(adapter).compile_and_validate(
+            request, result, project_root=tmp_path, godot_path="godot"
+        )
+
+
 @pytest.mark.parametrize("family", ["ui-kit", "card-kit"])
 def test_theme_runtime_output_requires_the_declared_stable_path(family):
     request = _request(family)

--- a/tests/assets/test_ui_card_skill_contract.py
+++ b/tests/assets/test_ui_card_skill_contract.py
@@ -1,5 +1,6 @@
 """Executable standalone contracts for ui-kit and card-kit Asset Skills."""
 import json
+import importlib.util
 import struct
 import sys
 import zlib
@@ -20,7 +21,7 @@ from asset_ui_card_contract_check import (  # noqa: E402
 )
 from asset_validation import ProbeReport, ProbeResult  # noqa: E402
 from asset_validation.godot_probe import GodotProbe  # noqa: E402
-from ui_card_standalone_validation import compile_and_validate  # noqa: E402
+from ui_card_standalone_validation import UICardSkillError, compile_and_validate  # noqa: E402
 
 
 def _png(width: int, height: int) -> bytes:
@@ -73,7 +74,7 @@ def _result(request: dict) -> dict:
     return {
         "asset_type": request["asset_type"],
         "outputs": [
-            {"role": "runtime", "name": "theme", "path": f"{root}/theme.tres", "godot_type": "Theme"},
+            {"role": "runtime", "name": "theme", "path": f"{root}/{request['asset_id']}_theme.tres", "godot_type": "Theme"},
             {"role": "runtime", "name": box["output_name"], "path": f"{root}/{box['output_name']}.tres", "godot_type": "StyleBoxTexture"},
             {"role": "runtime", "name": "icon", "path": f"{root}/icon.tres", "godot_type": "AtlasTexture"},
         ],
@@ -84,6 +85,15 @@ def _result(request: dict) -> dict:
         "previews": [],
         "validation": {"passed": False},
     }
+
+
+def _source_adapter(family: str):
+    path = REPO_ROOT / "skills" / "assets" / family / "standalone_validation.py"
+    spec = importlib.util.spec_from_file_location(f"{family}_adapter", path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
 
 
 def _write_sources(root: Path, request: dict, *, recipe_variation: str | None = None) -> None:
@@ -199,6 +209,23 @@ def test_standalone_runner_maps_missing_source_to_l1(tmp_path):
     validated = compile_and_validate(request, result, project_root=tmp_path, godot_path="godot")
 
     assert validated["validation"]["levels"] == {"L0": True, "L1": False, "L2": False, "L3": False, "L4": False}
+
+
+@pytest.mark.parametrize(("adapter", "other"), [("ui-kit", "card-kit"), ("card-kit", "ui-kit")])
+def test_skill_local_ui_card_adapter_rejects_the_other_legal_family(tmp_path, adapter, other):
+    with pytest.raises(UICardSkillError, match="L0 standalone contract failed"):
+        _source_adapter(adapter).compile_and_validate(
+            _request(other), _result(_request(other)), project_root=tmp_path, godot_path="godot"
+        )
+
+
+@pytest.mark.parametrize("family", ["ui-kit", "card-kit"])
+def test_theme_runtime_output_requires_the_declared_stable_path(family):
+    request = _request(family)
+    result = _result(request)
+    result["outputs"][0]["path"] = result["outputs"][0]["path"].replace("_theme.tres", ".tres")
+    with pytest.raises(UICardContractError, match="theme.output_name"):
+        check_ui_card_handoff(request, result)
 
 
 def test_standalone_runner_maps_invalid_nine_slice_to_l2(tmp_path):

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -1134,6 +1134,59 @@ validated = tileset.compile_and_validate(
 assert validated["validation"]["levels"] == {{
     "L0": True, "L1": False, "L2": False, "L3": False, "L4": False,
 }}
+
+wrong_path_result = {{
+    "asset_type": "tileset",
+    "outputs": [{{
+        "role": "runtime",
+        "path": "res://assets/generated/tileset/grassland/not-the-asset-id.tres",
+        "godot_type": "TileSet",
+    }}],
+    "sources": [{{"path": source_path, "layout": "tile_atlas"}}],
+    "previews": [], "validation": {{"passed": False}},
+}}
+try:
+    tileset.compile_and_validate(
+        {{"asset_type": "tileset", "asset_id": "grassland", "brief": "A grassland tile atlas.", "spec": recipe}},
+        wrong_path_result, project_root=target, godot_path="godot",
+    )
+except tileset.TileSetSkillError as exc:
+    assert "L0 standalone contract failed" in str(exc)
+else:
+    raise AssertionError("published tileset adapter accepted a noncanonical runtime path")
+
+background_request = {{"asset_type": "background-map", "asset_id": "sky", "brief": "A blue sky."}}
+background_result = {{
+    "asset_type": "background-map",
+    "outputs": [{{"role": "runtime", "name": "sky", "path": "res://assets/generated/background-map/sky/sky.png", "godot_type": "Texture2D"}}],
+    "sources": [{{"path": "res://assets/generated/background-map/sky/sky.png", "layout": "single"}}],
+    "previews": [], "validation": {{"passed": False}},
+}}
+for adapter in (platform_strip, screen_reference, character_bundle, fx_bundle, compact_prop_pack, scene_prop_set):
+    try:
+        adapter.compile_and_validate(background_request, background_result, project_root=target, godot_path="godot")
+    except adapter.MissingFamilySkillError as exc:
+        assert "L0 standalone contract failed" in str(exc)
+    else:
+        raise AssertionError("published family adapter accepted another family")
+platform_request = {{"asset_type": "platform-strip", "asset_id": "bridge", "brief": "A bridge.", "spec": {{"kind": "single", "segments": [{{"name": "center"}}]}}}}
+platform_result = {{"asset_type": "platform-strip", "outputs": [{{"role": "runtime", "name": "center", "path": "res://assets/generated/platform-strip/bridge/center.png", "godot_type": "Texture2D"}}], "sources": [{{"path": "res://assets/generated/platform-strip/bridge/center.png", "layout": "single"}}], "previews": [], "validation": {{"passed": False}}}}
+try:
+    background_map.compile_and_validate(platform_request, platform_result, project_root=target, godot_path="godot")
+except background_map.MissingFamilySkillError as exc:
+    assert "L0 standalone contract failed" in str(exc)
+else:
+    raise AssertionError("published background-map adapter accepted another family")
+
+for adapter, other in ((ui_kit, "card-kit"), (card_kit, "ui-kit")):
+    request = json.loads((skills / other / "fixtures" / "representative-request.json").read_text(encoding="utf-8"))
+    result = json.loads((skills / other / "fixtures" / "representative-result.json").read_text(encoding="utf-8"))
+    try:
+        adapter.compile_and_validate(request, result, project_root=target, godot_path="godot")
+    except adapter.UICardSkillError as exc:
+        assert "L0 standalone contract failed" in str(exc)
+    else:
+        raise AssertionError("published UI/Card adapter accepted another family")
 '''
         environment = os.environ.copy()
         environment.pop("PYTHONPATH", None)

--- a/tools/asset_ui_card_contract_check.py
+++ b/tools/asset_ui_card_contract_check.py
@@ -254,7 +254,15 @@ def check_ui_card_handoff(request: Any, result: Any) -> dict[str, Any]:
 
     theme = spec["theme"]
     theme_output = runtime.get(theme["output_name"])
-    if theme_output is None or theme_output.get("godot_type") != "Theme":
+    expected_theme_path = (
+        f"res://assets/generated/{request['asset_type']}/{request['asset_id']}/"
+        f"{request['asset_id']}_theme.tres"
+    )
+    if (
+        theme_output is None
+        or theme_output.get("godot_type") != "Theme"
+        or theme_output.get("path") != expected_theme_path
+    ):
         raise UICardContractError("theme.output_name must bind to one Theme runtime output")
     if (theme["recipe_path"], "theme_recipe") not in sources:
         raise UICardContractError("theme.recipe_path must be a theme_recipe result source")


### PR DESCRIPTION
## Summary

Bind standalone validation adapters to their owning asset families and enforce the documented canonical TileSet and Theme paths at L0.

## Motivation

Prevents a valid request for one asset family from succeeding through a different Skill-local adapter, and rejects non-canonical stable output paths before later validation levels.

Related public GitHub issue: N/A

## Changes

- [x] Bind generic, UI, and card adapters to their expected family.
- [x] Enforce canonical TileSet atlas/runtime and UI/Card Theme paths; add negative regression coverage for source and published adapters.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant): `pytest -q` (2004 passed, 33 skipped).
- [x] Gitleaks passes or no secret-bearing files were touched: no secret-bearing files were touched.
- [x] Manual testing completed, if applicable: targeted standalone adapter checks completed; real Godot L3/L4 was previously exercised for canonical paths.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
N/A — not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [x] N/A — no migration script was added or modified.
- [x] N/A — no migration script was added or modified.
- [x] N/A — no migration script was added or modified.
- [x] N/A — no migration script was added or modified.
- [x] N/A — no migration script was added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable: N/A.
- [x] No hardcoded secrets or API keys
- [ ] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR: not updated; this is maintenance-only validation-contract work.
