### PR TITLE
fix: restore screen reference production contract

### DIFF
--- a/skills/assets/_shared/asset-skill-contract.md
+++ b/skills/assets/_shared/asset-skill-contract.md
@@ -63,7 +63,7 @@ not independently triggerable.
 {
   "asset_type": "character-bundle",
   "asset_id": "player",
-  "brief": "A small pixel-art knight with idle and run actions, side view.",
+  "brief": "A small hand-painted knight with idle and run actions, side view; do not use pixel art.",
   "references": [
     { "role": "canonical", "path": "res://references/player_canonical.png" }
   ],
@@ -141,7 +141,9 @@ each `runtime` output into its own stable entry with one primary
 Raw generated or claimed source images the outputs were compiled from. Each
 entry is `{ path, layout? }`. `layout` describes pixel organization and is one of
 `single`, `grid_sheet`, `region_atlas`, `action_frames`, `theme_recipe`,
-`tile_atlas`. `sources` may be empty (for example a reference-only result).
+`tile_atlas`. `sources` may be empty only when the family contract has no raw
+source to preserve; a generated screen reference records its deterministic raw
+provider source.
 
 ### previews
 

--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -156,14 +156,18 @@ def _check_screen_reference(
 ) -> str:
     asset_id = request["asset_id"]
     expected = f"references/{asset_id}.png"
+    expected_source = f".godotmaker/asset-generation/sources/{asset_id}_source.png"
     if (
         _runtime(result)
-        or result["sources"]
         or result["previews"]
         or len(result["outputs"]) != 1
     ):
         raise MissingFamilySkillError(
             "screen-reference must have one reference output and no runtime source"
+        )
+    if result["sources"] != [{"path": expected_source, "layout": "single"}]:
+        raise MissingFamilySkillError(
+            "screen-reference must declare its deterministic raw single source"
         )
     output = result["outputs"][0]
     if (
@@ -628,6 +632,23 @@ def compile_and_validate(
             except ValidationError as exc:
                 raise ValidationError(
                     f"reference image is not a decodable PNG: {reference_path}"
+                ) from exc
+            raw_source = _project_file(
+                root,
+                f".godotmaker/asset-generation/sources/{asset_id}_source.png",
+                "raw screen-reference source",
+            )
+            if not raw_source.is_file() or raw_source.stat().st_size <= 0:
+                raise ValidationError(
+                    "raw screen-reference source is not a non-empty file: "
+                    f".godotmaker/asset-generation/sources/{asset_id}_source.png"
+                )
+            try:
+                _png_dimensions(raw_source)
+            except ValidationError as exc:
+                raise ValidationError(
+                    "raw screen-reference source is not a decodable PNG: "
+                    f".godotmaker/asset-generation/sources/{asset_id}_source.png"
                 ) from exc
             return _mapped(result, {"L0": True, "L1": True})
         if family in {"compact-prop-pack", "scene-prop-set"}:

--- a/skills/assets/_shared/samples/request/character-bundle.json
+++ b/skills/assets/_shared/samples/request/character-bundle.json
@@ -1,7 +1,7 @@
 {
   "asset_type": "character-bundle",
   "asset_id": "player",
-  "brief": "A small pixel-art knight with idle and run actions, side view, transparent background.",
+  "brief": "A small hand-painted knight with idle and run actions, side view, transparent background; do not use pixel art.",
   "references": [
     { "role": "canonical", "path": "res://references/player_canonical.png" },
     { "role": "style", "path": "res://references/style_seed.png" }

--- a/skills/assets/_shared/samples/result/screen-reference.json
+++ b/skills/assets/_shared/samples/result/screen-reference.json
@@ -7,7 +7,12 @@
       "path": "references/main_menu.png"
     }
   ],
-  "sources": [],
+  "sources": [
+    {
+      "path": ".godotmaker/asset-generation/sources/main_menu_source.png",
+      "layout": "single"
+    }
+  ],
   "previews": [],
   "validation": {
     "passed": true,

--- a/skills/assets/screen-reference/SKILL.md
+++ b/skills/assets/screen-reference/SKILL.md
@@ -69,8 +69,14 @@ python tools/asset_source_generate.py --spec <spec.json>
 The successful source report must identify the selected provider and model,
 actual reference attachment count, each reference role/path/hash, raw source,
 and prompt path. For `native` and `codex`, use their provider documents and
-write an equivalent report before finalization. A missing report, provider
-failure, or absent attachment evidence is a STOP.
+write an equivalent JSON report before finalization. It must contain `ok: true`,
+`raw_source`, `raw_source_sha256`, `reference_attachment_count`, and a
+`generation` object with `tool: "image_gen"`. When references are supplied,
+that object must also record `reference_attachment_argument:
+"referenced_image_paths"` and the matching attachment count, and each
+`reference_inputs` item must preserve `role`, `path`, `sha256`, and
+`attached: true`. A missing report, provider failure, or absent attachment
+evidence is a STOP.
 
 Finalize only the provider/user source with the existing controlled tool:
 

--- a/skills/assets/screen-reference/SKILL.md
+++ b/skills/assets/screen-reference/SKILL.md
@@ -70,7 +70,7 @@ The successful source report must identify the selected provider and model,
 actual reference attachment count, each reference role/path/hash, raw source,
 and prompt path. For `native` and `codex`, use their provider documents and
 write an equivalent JSON report before finalization. It must contain `ok: true`,
-`raw_source`, `raw_source_sha256`, `reference_attachment_count`, and a
+`asset_id`, `raw_source`, `raw_source_sha256`, `reference_attachment_count`, and a
 `generation` object with `tool: "image_gen"`. When references are supplied,
 that object must also record `reference_attachment_argument:
 "referenced_image_paths"` and the matching attachment count, and each

--- a/skills/assets/screen-reference/SKILL.md
+++ b/skills/assets/screen-reference/SKILL.md
@@ -1,45 +1,102 @@
 ---
 name: screen-reference
-description: Generate and validate a full-screen visual reference for scene direction and evaluation, without producing a runtime asset.
+description: Generate, finalize, and validate a non-pixel-art full-screen visual reference for scene direction and evaluation, without producing a runtime asset.
 ---
 
 # Screen Reference Asset
 
-Use this skill for full-screen scene references and visual evaluation targets.
-It is reference-only: it does not create a runtime Godot resource, has no
-`godot_artifact`, and must not enter worker runtime handoff.
+Use this Skill for a full-screen visual anchor for scene direction and visual
+evaluation. It is reference-only: it does not create a runtime Godot resource,
+has no `godot_artifact`, and must not enter worker runtime handoff.
+Do not compile it to `Texture2D`, `AtlasTexture`, or any other native runtime
+resource.
+
+Do not request or produce pixel art. Do not use nearest-neighbor scaling to
+imitate pixel art. Raw visual material may come only from the selected image
+provider or an explicitly supplied user source/reference. Do not create art,
+placeholder images, colour blocks, SVGs, canvases, Godot drawings, or image
+assets with ad-hoc scripts.
 
 ## Invocation
 
-Accept one asset request matching the shared Asset Skill request schema in
+Accept one request matching the shared Asset Skill request schema in
 `.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
-`asset_type` to be `screen-reference`. Run
-`standalone_validation.compile_and_validate()` before returning it. This
-reference-only runner binds the fixed reference path at L0 and verifies the
-image file at L1; it never enters the runtime L2-L4 ladder and overwrites any
-caller-supplied validation claim.
-It begins from the shared result schema and checker, then proves the result.
+`asset_type` to be `screen-reference`. `references` is optional. When it is
+present and non-empty, every `{ role, path }` is a required visual input:
 
-This skill can be invoked directly or by an orchestrator with the same contract.
+1. resolve the path inside the project and require a readable image before
+   calling a provider;
+2. preserve its `canonical`, `style`, or `screen` role in the prompt and
+   source-generation provenance;
+3. attach the actual image bytes to the selected provider request. A path
+   mentioned only in text is not an attachment;
+4. STOP before writing a raw source or final output when an input is unreadable
+   or the selected provider cannot attach it.
+
+Use the configured provider named by the request or production brief. `native`,
+`codex`, `gemini`, and `openai` are binding selections: execute that documented
+path or STOP. Never silently switch providers. For `codex`, non-empty
+references require the `image_gen` call's `referenced_image_paths` argument.
+
+This Skill can be invoked directly or by an orchestrator with the same contract.
 Do not read or write `ASSETS.md`, tags, stage state, generated manifests, or
-worker dispatch state.
+worker dispatch state. The `/gm-asset` manager later registers the approved
+finalize report through `asset_finalize_entry_draft.py`.
 
-## Produce
+## Production contract
 
-1. Use the brief and visible references to describe the game genre, scene
-   purpose, camera or viewpoint, gameplay-visible objects, approximate layout,
-   requested HUD or UI elements, style language, target aspect, and orientation.
-2. Generate one source image per requested scene. Do not add labels, callouts,
-   debug overlays, or unrequested objects.
-3. Finalize the accepted image at `references/<asset_id>.png` after checking
-   the requested aspect and dimensions.
-4. Preserve it as a visual reference only. Do not compile it to `Texture2D`,
-   `AtlasTexture`, or any other native runtime resource.
+`spec` must declare the target `size` (`WIDTHxHEIGHT`) and `aspect_ratio`
+(`WIDTH:HEIGHT`). Build a prompt that names the game and screen purpose,
+camera/viewpoint, visible gameplay objects, approximate layout, HUD or UI safe
+regions, style language, target aspect/orientation, and each supplied reference
+role. Do not add labels, callouts, debug overlays, or unrequested objects.
+
+For every accepted image, retain these deterministic paths:
+
+1. prompt: `.godotmaker/asset-generation/prompts/<asset_id>.txt`;
+2. raw provider source: `.godotmaker/asset-generation/sources/<asset_id>_source.png`;
+3. source/provider report: `.godotmaker/asset-generation/reports/<asset_id>_source.json`;
+4. final reference: `references/<asset_id>.png`;
+5. finalize report: `.godotmaker/asset-generation/reports/<asset_id>_finalize.json`.
+
+For `openai` and `gemini`, write a source-generation spec using
+`reference_inputs` for role-preserving references, then run:
+
+```bash
+python tools/asset_source_generate.py --spec <spec.json>
+```
+
+The successful source report must identify the selected provider and model,
+actual reference attachment count, each reference role/path/hash, raw source,
+and prompt path. For `native` and `codex`, use their provider documents and
+write an equivalent report before finalization. A missing report, provider
+failure, or absent attachment evidence is a STOP.
+
+Finalize only the provider/user source with the existing controlled tool:
+
+```bash
+python tools/asset_image_finalize.py \
+  --source .godotmaker/asset-generation/sources/<asset_id>_source.png \
+  --out references/<asset_id>.png \
+  --label <asset_id> \
+  --require-aspect <WIDTH:HEIGHT> \
+  --resize <WIDTHxHEIGHT> \
+  > .godotmaker/asset-generation/reports/<asset_id>_finalize.json
+```
+
+If aspect validation or finalization fails, STOP. The manager must use the
+captured finalize report to create the stable entry draft with
+`source_layout.type: reference`, `processing_status: source_ready`, and no
+`godot_artifact`; never hand-write that entry.
 
 ## Result
 
-Return the shared generic result with one `reference` output, no `godot_type`,
-and no runtime outputs:
+Return the shared generic result with one reference output, its deterministic
+raw source, no `godot_type`, and no runtime outputs. Run
+`standalone_validation.compile_and_validate()` before returning it; it replaces
+any caller-supplied validation claim and proves the stable final reference and
+raw source are readable PNG files.
+It begins from the shared result schema and checker, then proves the result.
 
 ```json
 {
@@ -49,7 +106,10 @@ and no runtime outputs:
     "name": "<asset_id>",
     "path": "references/<asset_id>.png"
   }],
-  "sources": [],
+  "sources": [{
+    "path": ".godotmaker/asset-generation/sources/<asset_id>_source.png",
+    "layout": "single"
+  }],
   "previews": [],
   "validation": {
     "passed": true,
@@ -58,5 +118,7 @@ and no runtime outputs:
 }
 ```
 
-If generation or aspect validation fails, report `validation.passed: false`
-with notes. Never present a screen reference as a worker-consumable asset.
+L2-L4 are not applicable because a screen reference has no Godot artifact and
+is never handed to a worker. Preserve the provider and finalize reports so the
+manager and private Eval can audit the production gates separately; L5 is not
+applicable and L6 is visual/semantic review.

--- a/skills/assets/screen-reference/fixtures/representative-result.json
+++ b/skills/assets/screen-reference/fixtures/representative-result.json
@@ -7,7 +7,12 @@
       "path": "references/main_menu.png"
     }
   ],
-  "sources": [],
+  "sources": [
+    {
+      "path": ".godotmaker/asset-generation/sources/main_menu_source.png",
+      "layout": "single"
+    }
+  ],
   "previews": [],
   "validation": {
     "passed": true,

--- a/skills/core/gm-asset/references/providers/codex.md
+++ b/skills/core/gm-asset/references/providers/codex.md
@@ -21,6 +21,19 @@ For each generated image:
 8. Do not report a project `source_path` as `generated_path`.
 9. Do not create placeholder or procedural images when generation fails.
 
+## Reference Images
+
+References are optional. When a production unit supplies one or more required
+references, each is binding input rather than prompt-only context:
+
+1. verify every path is a readable image before calling `image_gen`;
+2. preserve its production role in the generation prompt and provider report;
+3. call `image_gen` with `referenced_image_paths` containing every required
+   local reference path; do not replace this with text that names a path;
+4. record the exact attached paths, roles, and `referenced_image_paths` count
+   in the provider report;
+5. STOP when the active Codex image path cannot accept those attachments.
+
 Generated-path report shape:
 
 ```json
@@ -105,7 +118,9 @@ For each asset:
 5. Do not inspect unrelated Codex threads.
 6. Do not choose files by modified time.
 7. Do not copy files.
-8. Do not create placeholder or procedural images.
+8. When an asset has references, pass every source_path reference to `image_gen`
+   through `referenced_image_paths` and report the attached paths and roles.
+9. Do not create placeholder or procedural images.
 
 Assets:
 - id: <asset_id>

--- a/skills/core/gm-asset/references/providers/gemini.md
+++ b/skills/core/gm-asset/references/providers/gemini.md
@@ -17,7 +17,7 @@ Write one spec per generated source under
   "source_path": ".godotmaker/asset-generation/sources/<asset_id>_source.png",
   "size": "1K",
   "aspect_ratio": "1:1",
-  "reference_images": [],
+  "reference_inputs": [],
   "report_path": ".godotmaker/asset-generation/reports/<asset_id>_source.json"
 }
 ```
@@ -30,8 +30,11 @@ python tools/asset_source_generate.py --spec <spec.json>
 
 ## Reference Images
 
-Put every required local reference path in `reference_images`. Use only images
-listed by the production-unit brief or selected by the manager.
+Put every required local reference in `reference_inputs` as
+`{ "role": "canonical|style|screen", "path": "<local image path>" }`. Use
+only images listed by the production-unit brief or selected by the manager. The
+tool validates that every input is readable, sends its actual bytes as a Gemini
+image part, and records role/path/hash provenance in its report.
 
 ## Handoff
 

--- a/skills/core/gm-asset/references/providers/native.md
+++ b/skills/core/gm-asset/references/providers/native.md
@@ -16,10 +16,15 @@ Use this file only when `.godotmaker/config.yaml` sets
 
 When the production unit uses image references:
 
-1. Make each reference visible to the active runtime before generation.
-2. State the reference role in the prompt.
-3. Preserve the invariants listed by the production-unit doc.
-4. Use the planned `source_path` for the generated result.
+1. Verify that each path is a readable image and attach the actual image to the
+   active runtime's native image-generation request.
+2. State and preserve the reference role in the prompt and provider report.
+3. Record attached path, role, attachment mechanism, and attachment count in
+   the provider report.
+4. STOP when the active native path cannot attach the supplied image; a textual
+   path or a visual inspection by the agent is not an attachment.
+5. Preserve the invariants listed by the production-unit doc.
+6. Use the planned `source_path` for the generated result.
 
 ## Handoff
 

--- a/skills/core/gm-asset/references/providers/openai.md
+++ b/skills/core/gm-asset/references/providers/openai.md
@@ -17,7 +17,7 @@ Write one spec per generated source under
   "source_path": ".godotmaker/asset-generation/sources/<asset_id>_source.png",
   "size": "1K",
   "aspect_ratio": "1:1",
-  "reference_images": [],
+  "reference_inputs": [],
   "report_path": ".godotmaker/asset-generation/reports/<asset_id>_source.json"
 }
 ```
@@ -37,10 +37,13 @@ python tools/asset_source_generate.py --spec <spec.json>
 
 ## Reference Images
 
-Put every required local reference path in `reference_images`. Use only images
-listed by the production-unit brief or selected by the manager.
+Put every required local reference in `reference_inputs` as
+`{ "role": "canonical|style|screen", "path": "<local image path>" }`. Use
+only images listed by the production-unit brief or selected by the manager. The
+tool validates that every input is readable, sends its actual file bytes through
+the image-edit endpoint, and records role/path/hash provenance in its report.
 
-When `reference_images` is non-empty, the source generator uses the OpenAI image
+When `reference_inputs` is non-empty, the source generator uses the OpenAI image
 edit endpoint and sends every listed reference image. One reference is sent as a
 single image file; multiple references are sent as an image-file list.
 

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -164,6 +164,9 @@ def test_screen_reference_completes_at_l1_without_invoking_runtime_ladder(tmp_pa
     reference = tmp_path / "references" / "title.png"
     reference.parent.mkdir()
     Image.new("RGBA", (2, 2), (1, 2, 3, 255)).save(reference)
+    raw_source = tmp_path / ".godotmaker/asset-generation/sources/title_source.png"
+    raw_source.parent.mkdir(parents=True)
+    Image.new("RGBA", (2, 2), (1, 2, 3, 255)).save(raw_source)
     result = compile_and_validate(
         {
             "asset_type": "screen-reference",
@@ -175,7 +178,12 @@ def test_screen_reference_completes_at_l1_without_invoking_runtime_ladder(tmp_pa
             "outputs": [
                 {"role": "reference", "name": "title", "path": "references/title.png"}
             ],
-            "sources": [],
+            "sources": [
+                {
+                    "path": ".godotmaker/asset-generation/sources/title_source.png",
+                    "layout": "single",
+                }
+            ],
             "previews": [],
             "validation": {"passed": False},
         },
@@ -199,9 +207,36 @@ def _screen_reference_result() -> dict:
         "outputs": [
             {"role": "reference", "name": "title", "path": "references/title.png"}
         ],
-        "sources": [],
+        "sources": [
+            {
+                "path": ".godotmaker/asset-generation/sources/title_source.png",
+                "layout": "single",
+            }
+        ],
         "previews": [],
         "validation": {"passed": True},
+    }
+
+
+def test_screen_reference_rejects_a_missing_deterministic_raw_source(tmp_path):
+    reference = tmp_path / "references" / "title.png"
+    reference.parent.mkdir()
+    Image.new("RGBA", (2, 2), (1, 2, 3, 255)).save(reference)
+
+    actual = compile_and_validate(
+        _screen_reference_request(),
+        _screen_reference_result(),
+        project_root=tmp_path,
+        godot_path="not-used",
+    )
+
+    assert actual["validation"] == {
+        "passed": False,
+        "levels": {"L0": True, "L1": False},
+        "notes": (
+            "raw screen-reference source is not a non-empty file: "
+            ".godotmaker/asset-generation/sources/title_source.png"
+        ),
     }
 
 

--- a/tests/test_asset_family_skills.py
+++ b/tests/test_asset_family_skills.py
@@ -62,7 +62,12 @@ def test_representative_fixture_matches_the_public_family_contract(family, expec
     assert output.get("godot_type") == expected["godot_type"]
 
     if expected["source_layout"] is None:
-        assert result["sources"] == []
+        assert result["sources"] == [
+            {
+                "path": ".godotmaker/asset-generation/sources/main_menu_source.png",
+                "layout": "single",
+            }
+        ]
         assert not any(item["role"] == "runtime" for item in result["outputs"])
     else:
         assert result["sources"][0]["layout"] == expected["source_layout"]
@@ -84,10 +89,13 @@ def test_screen_reference_cannot_be_misrepresented_as_a_runtime_asset():
     screen = (ASSETS_DIR / "screen-reference" / "SKILL.md").read_text(encoding="utf-8")
 
     assert "reference-only" in screen
-    assert "has no\n`godot_artifact`" in screen
+    assert "has no `godot_artifact`" in screen
     assert "must not enter worker runtime handoff" in screen
     assert "no `godot_type`" in screen
     assert "Do not compile it to `Texture2D`" in screen
+    assert "Do not request or produce pixel art" in screen
+    assert "reference_inputs" in screen
+    assert "asset_image_finalize.py" in screen
 
 
 def test_gm_asset_keeps_no_second_authoritative_copy_of_extracted_families():

--- a/tests/tools/test_asset_source_generate.py
+++ b/tests/tools/test_asset_source_generate.py
@@ -22,7 +22,6 @@ def make_spec(tmp_path: Path, **overrides):
         "source_path": ".godotmaker/asset-generation/sources/coin_source.png",
         "size": "1K",
         "aspect_ratio": "1:1",
-        "reference_images": [],
     }
     spec.update(overrides)
     path = tmp_path / "spec.json"
@@ -48,6 +47,14 @@ def write_refs(tmp_path: Path, count: int) -> list[str]:
         write_png(path)
         refs.append(str(path))
     return refs
+
+
+def write_reference_inputs(tmp_path: Path, count: int) -> list[dict[str, str]]:
+    roles = ("canonical", "style", "screen")
+    return [
+        {"role": roles[index % len(roles)], "path": path}
+        for index, path in enumerate(write_refs(tmp_path, count))
+    ]
 
 
 def test_load_spec_requires_explicit_model(tmp_path, monkeypatch):
@@ -158,6 +165,54 @@ def test_openai_uses_all_reference_images_for_edit(tmp_path, monkeypatch):
     assert seen["prompt"] == spec["prompt"]
     assert seen["size"] == "1024x1024"
     assert (tmp_path / spec["source_path"]).exists()
+
+
+def test_role_preserving_reference_inputs_are_attached_and_reported(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    inputs = write_reference_inputs(tmp_path, 2)
+    spec = source_generate.load_spec(
+        make_spec(
+            tmp_path,
+            model="openai:gpt-image-2",
+            reference_inputs=inputs,
+            report_path=".godotmaker/asset-generation/reports/coin_source.json",
+        )
+    )
+
+    def fake_openai(spec_data, output, model_name):
+        assert model_name == "gpt-image-2"
+        assert [str(path) for path in spec_data["reference_images"]] == [
+            item["path"] for item in inputs
+        ]
+        write_png(output)
+
+    monkeypatch.setattr(source_generate, "_generate_openai", fake_openai)
+    result = source_generate.generate_source(spec)
+
+    assert [item["role"] for item in result["reference_inputs"]] == [
+        "canonical", "style"
+    ]
+    assert result["provider_payload"] == {
+        "operation": "images.edit",
+        "reference_input_count": 2,
+        "references_attached": True,
+    }
+    assert all(len(item["sha256"]) == 64 for item in result["reference_inputs"])
+    report = json.loads((tmp_path / result["report_path"]).read_text(encoding="utf-8"))
+    assert report["reference_inputs"] == result["reference_inputs"]
+
+
+def test_role_preserving_reference_input_must_be_readable(tmp_path):
+    unreadable = tmp_path / "broken.png"
+    unreadable.write_text("not an image", encoding="utf-8")
+
+    with pytest.raises(source_generate.SourceGenerateError, match="not readable"):
+        source_generate.load_spec(
+            make_spec(
+                tmp_path,
+                reference_inputs=[{"role": "style", "path": str(unreadable)}],
+            )
+        )
 
 
 @pytest.mark.parametrize(

--- a/tools/asset_source_generate.py
+++ b/tools/asset_source_generate.py
@@ -3,6 +3,7 @@
 
 import argparse
 import base64
+import hashlib
 import io
 import json
 import sys
@@ -61,6 +62,7 @@ ALL_ASPECT_RATIOS = sorted(set(GEMINI_ASPECT_RATIOS + GROK_ASPECT_RATIOS))
 OPENAI_MODEL = "gpt-image-2"
 OPENAI_MAX_REFERENCE_IMAGES = 16
 OPENAI_COSTS = {"1:1": 5, "portrait": 7, "landscape": 7}
+REFERENCE_ROLES = {"canonical", "style", "screen"}
 
 
 def _split_model_selector(selector: str, *, default_provider: str,
@@ -124,21 +126,86 @@ def _optional_string(data: dict, field: str, default: str) -> str:
     return value
 
 
-def _reference_images(data: dict) -> list[Path]:
+def _readable_reference(path: Path) -> None:
+    """Reject a missing or unreadable reference before any provider call."""
+    try:
+        from PIL import Image
+
+        with Image.open(path) as image:
+            image.verify()
+        with Image.open(path) as image:
+            image.load()
+    except Exception as exc:
+        raise SourceGenerateError(f"Reference image is not readable: {path}") from exc
+
+
+def _reference_inputs(data: dict) -> list[dict[str, object]]:
+    """Read visible references while preserving their production role.
+
+    ``reference_images`` is retained for existing production units. New callers
+    should use ``reference_inputs`` so provider provenance can prove both the
+    attached file and the role the prompt/production contract assigned to it.
+    """
+    if "reference_inputs" in data and "reference_images" in data:
+        raise SourceGenerateError(
+            "Spec must use either 'reference_inputs' or legacy 'reference_images', not both"
+        )
+    if "reference_inputs" in data:
+        raw = data["reference_inputs"]
+        if raw is None:
+            return []
+        if not isinstance(raw, list):
+            raise SourceGenerateError("Spec field 'reference_inputs' must be a list")
+        inputs: list[dict[str, object]] = []
+        for index, item in enumerate(raw):
+            if not isinstance(item, dict) or set(item) != {"role", "path"}:
+                raise SourceGenerateError(
+                    f"reference_inputs[{index}] must contain exactly role and path"
+                )
+            role, raw_path = item["role"], item["path"]
+            if not isinstance(role, str) or role not in REFERENCE_ROLES:
+                raise SourceGenerateError(
+                    f"reference_inputs[{index}].role is not allowed: {role!r}"
+                )
+            if not isinstance(raw_path, str) or not raw_path.strip():
+                raise SourceGenerateError(
+                    f"reference_inputs[{index}].path must be a non-empty string"
+                )
+            path = Path(raw_path)
+            if not path.is_file():
+                raise SourceGenerateError(f"Reference image not found: {path}")
+            _readable_reference(path)
+            inputs.append({"role": role, "path": path})
+        return inputs
+
     raw = data.get("reference_images", [])
     if raw is None:
         return []
     if not isinstance(raw, list):
         raise SourceGenerateError("Spec field 'reference_images' must be a list")
-    paths: list[Path] = []
+    inputs = []
     for index, item in enumerate(raw):
         if not isinstance(item, str) or not item.strip():
             raise SourceGenerateError(f"reference_images[{index}] must be a non-empty string")
         path = Path(item)
-        if not path.exists():
+        if not path.is_file():
             raise SourceGenerateError(f"Reference image not found: {path}")
-        paths.append(path)
-    return paths
+        _readable_reference(path)
+        inputs.append({"role": None, "path": path})
+    return inputs
+
+
+def _reference_provenance(inputs: list[dict[str, object]]) -> list[dict[str, object]]:
+    return [
+        {
+            "role": item["role"],
+            "path": _json_path(item["path"]),
+            "mime_type": _mime_for_image(item["path"]),
+            "bytes": item["path"].stat().st_size,
+            "sha256": hashlib.sha256(item["path"].read_bytes()).hexdigest(),
+        }
+        for item in inputs
+    ]
 
 
 def _generate_gemini(spec, output: Path, model_name: str):
@@ -292,7 +359,8 @@ def load_spec(path: Path) -> dict:
     selector = _required_string(data, "model")
     size = _optional_string(data, "size", "1K")
     aspect_ratio = _optional_string(data, "aspect_ratio", "1:1")
-    reference_images = _reference_images(data)
+    reference_inputs = _reference_inputs(data)
+    reference_images = [item["path"] for item in reference_inputs]
     report_path = data.get("report_path")
     if report_path is not None and (not isinstance(report_path, str) or not report_path.strip()):
         raise SourceGenerateError("Spec field 'report_path' must be a non-empty string")
@@ -306,6 +374,7 @@ def load_spec(path: Path) -> dict:
         "size": size,
         "aspect_ratio": aspect_ratio,
         "reference_images": reference_images,
+        "reference_inputs": reference_inputs,
         "report_path": Path(report_path) if report_path else None,
     }
 
@@ -362,6 +431,16 @@ def generate_source(spec: dict) -> dict[str, object]:
         "source_path": _json_path(output),
         "prompt_path": _json_path(spec["prompt_path"]),
         "reference_images": [_json_path(path) for path in spec["reference_images"]],
+        "reference_inputs": _reference_provenance(spec["reference_inputs"]),
+        "provider_payload": {
+            "operation": (
+                "images.edit" if backend == "openai" and spec["reference_images"]
+                else "images.generate" if backend == "openai"
+                else "models.generate_content"
+            ),
+            "reference_input_count": len(spec["reference_images"]),
+            "references_attached": bool(spec["reference_images"]),
+        },
         "cost_cents": cost,
         "bytes": final["bytes"],
         "width": final["width"],


### PR DESCRIPTION
## Summary

Restore `screen-reference` as a provider-backed visual-anchor production contract while preserving its stable result and manifest handoff.

## Motivation

The standalone Skill split dropped the former raw-image production, deterministic finalization, and provider provenance requirements. A supplied reference therefore could not be proven to have reached the image provider.

No public GitHub issue.

## Changes

- [x] Restore declared provider binding, raw-source reporting, deterministic finalization, and reference-attachment provenance.
- [x] Keep references optional; fail closed for unreadable references and unsupported providers.
- [x] Preserve the reference-only L0/L1 boundary, stable entry, and result handoff; do not add runtime or consumer semantics.
- [x] State and test the non-pixel-art contract.

## Testing

- [x] New and updated Python tests pass: `python -m pytest --tb=short` — 2034 passed, 7 skipped.
- [x] Focused Asset Skill tests pass — 109 passed.
- [x] No secret-bearing files were touched.
- [x] Manual testing is not applicable: this changes Skill contracts and deterministic tooling, not an interactive Godot scene or UI.

> The authorized push used `--no-verify` only after the hook completed ruff and pytest successfully, then failed on 32 pre-existing `gdlint` line-length findings in untouched shared GDScript files.

## Benchmark Verification

- [x] Not performance-sensitive.
- [ ] Performance-sensitive; benchmark results are attached below or linked.

## Version Compatibility

- [x] **No** - no migration needed.
- [ ] **Yes** - migration script added to `migrations/`.

The stable `screen-reference` entry and result handoff remain in place; no existing target-project path or configuration key is moved or renamed.

### Migration Upgrade Gate

- [x] Not applicable: no migration script was added or modified.

## Checklist

- [x] Code follows project conventions.
- [x] ECS metadata is not applicable to this Skill/tooling change.
- [x] No hardcoded secrets or API keys.
- [ ] `docs/update/next.md` updated. This remains intentionally unchecked: no release-note entry was added in this PR.