### PR TITLE
fix(asset): make card-kit requests resource-driven

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -58,6 +58,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Card-kit Asset Skills now compile only the Theme, scalable frames, and fixed AtlasTexture regions requested by each asset request, preserving reusable Godot resources without requiring a fixed card layout.
+
 - Character-bundle assets now resolve animation cadence internally, preserve optional canonical references and 256px runtime frames, and regenerate retryable source-image failures before stopping.
 - Character-bundle assembly now binds resolved intent, canvas, frame order, timing, loop state, and scale references through SpriteFrames compilation and GIF previews.
 - Fixed blob-47 TileSet masks, edge signatures, and isolated-terrain semantics to match Godot's eight peering points.

--- a/skills/assets/_shared/asset_compiler/theme.py
+++ b/skills/assets/_shared/asset_compiler/theme.py
@@ -359,16 +359,64 @@ def _item_rows(
     return rows
 
 
-def _styleboxes(recipe: Mapping[str, Any]) -> tuple[dict[str, list[str]], dict[str, str]]:
+def _external_stylebox_texture_path(
+    properties: Mapping[str, Any],
+    label: str,
+    *,
+    root: Path,
+    production_family: str,
+    asset_id: str,
+) -> str:
+    if set(properties) != {"path"} or not isinstance(properties.get("path"), str):
+        _fail(f"{label}.properties must contain exactly a StyleBoxTexture path")
+    path = properties["path"]
+    try:
+        file_path = assert_within_output_dir(
+            root,
+            resolve_res_path(root, path, label=f"{label}.properties.path"),
+            production_family=production_family,
+            asset_id=asset_id,
+            label=f"{label}.properties.path",
+        )
+    except StableEntryError as exc:
+        _fail(f"{label}.properties.path must be a safe generated resource path: {exc}")
+    if file_path.suffix.lower() != ".tres" or not file_path.is_file():
+        _fail(f"{label}.properties.path must name an existing StyleBoxTexture .tres")
+    try:
+        header = file_path.read_text(encoding="utf-8")[:256]
+    except OSError as exc:
+        _fail(f"{label}.properties.path cannot be read: {exc}")
+    if '[gd_resource type="StyleBoxTexture"' not in header:
+        _fail(f"{label}.properties.path is not a StyleBoxTexture resource")
+    return path
+
+
+def _styleboxes(
+    recipe: Mapping[str, Any],
+    *,
+    root: Path,
+    production_family: str,
+    asset_id: str,
+) -> tuple[dict[str, list[str]], dict[str, str], dict[str, str]]:
     result: dict[str, list[str]] = {}
     subresources: dict[str, str] = {}
+    external: dict[str, str] = {}
     raw_boxes = _mapping(recipe["styleboxes"], "styleboxes")
     for box_id in sorted(raw_boxes):
         _identifier(box_id, f"styleboxes.{box_id}")
         box = _mapping(raw_boxes[box_id], f"styleboxes.{box_id}")
-        if set(box) != {"type", "properties"} or box["type"] not in {"StyleBoxFlat", "StyleBoxEmpty"}:
-            _fail(f"styleboxes.{box_id} must declare StyleBoxFlat or StyleBoxEmpty with properties")
+        if set(box) != {"type", "properties"} or box["type"] not in {"StyleBoxFlat", "StyleBoxEmpty", "StyleBoxTexture"}:
+            _fail(f"styleboxes.{box_id} must declare StyleBoxFlat, StyleBoxEmpty, or StyleBoxTexture with properties")
         properties = _mapping(box["properties"], f"styleboxes.{box_id}.properties")
+        if box["type"] == "StyleBoxTexture":
+            external[box_id] = _external_stylebox_texture_path(
+                properties,
+                f"styleboxes.{box_id}",
+                root=root,
+                production_family=production_family,
+                asset_id=asset_id,
+            )
+            continue
         if not properties and box["type"] == "StyleBoxFlat":
             _fail(f"styleboxes.{box_id}.properties may not be empty for StyleBoxFlat")
         lines: list[str] = []
@@ -400,7 +448,7 @@ def _styleboxes(recipe: Mapping[str, Any]) -> tuple[dict[str, list[str]], dict[s
                 lines.append(f"anti_aliasing = {'true' if value else 'false'}")
         result[box_id] = lines
         subresources[box_id] = box["type"]
-    return result, subresources
+    return result, subresources, external
 
 
 def compile_theme(request: CompileRequest) -> dict[str, Any]:
@@ -445,7 +493,13 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
         )
         for section in ("colors", "font_sizes", "constants", "fonts", "icons")
     }
-    boxes, box_types = _styleboxes(recipe)
+    boxes, box_types, external_boxes = _styleboxes(
+        recipe,
+        root=root,
+        production_family=request.production_family,
+        asset_id=request.asset_id,
+    )
+    all_box_types = {**box_types, **{box_id: "StyleBoxTexture" for box_id in external_boxes}}
     styles: list[tuple[str, str, str]] = []
     for index, raw in enumerate(_list(recipe["styles"], "styles")):
         item = _mapping(raw, f"styles[{index}]")
@@ -454,7 +508,7 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
         theme_type = _theme_type(item["type"], f"styles[{index}].type", variations=variation_names)
         name = _identifier(item["name"], f"styles[{index}].name")
         box = _identifier(item["stylebox"], f"styles[{index}].stylebox")
-        if not _property_allowed("styles", theme_type, name, variation_bases) or box not in box_types:
+        if not _property_allowed("styles", theme_type, name, variation_bases) or box not in all_box_types:
             _fail(f"styles[{index}] has an unsupported property or unknown StyleBox reference")
         styles.append((theme_type, name, box))
     if len({(kind, name) for kind, name, _ in styles}) != len(styles):
@@ -474,6 +528,7 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
                 asset_id=request.asset_id,
             )
             external.append((f"{prefix}_{index}", resource_type, path))
+    external.extend((f"StyleBox_{box_id}", "StyleBoxTexture", path) for box_id, path in sorted(external_boxes.items()))
     lines = ["[gd_resource type=\"Theme\" load_steps=" + str(1 + len(external) + len(boxes)) + " format=3]", ""]
     for resource_id, resource_type, path in external:
         lines.extend([f'[ext_resource type="{resource_type}" path="{path}" id="{resource_id}"]', ""])
@@ -487,11 +542,16 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
         for theme_type, name, value in sorted(sections[section]):
             lines.append(f"{theme_type}/{category[section]}/{name} = {value}")
     for theme_type, name, box in sorted(styles):
-        lines.append(f'{theme_type}/styles/{name} = SubResource("StyleBox_{box}")')
+        reference = (
+            f'ExtResource("StyleBox_{box}")'
+            if box in external_boxes
+            else f'SubResource("StyleBox_{box}")'
+        )
+        lines.append(f"{theme_type}/styles/{name} = {reference}")
     target = request.artifact_file()
     target.parent.mkdir(parents=True, exist_ok=True)
     target.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
-    return {"variations": [name for name, _ in sorted(variations)], "theme_items": sum(len(items) for items in sections.values()) + len(styles), "styleboxes": sorted(boxes)}
+    return {"variations": [name for name, _ in sorted(variations)], "theme_items": sum(len(items) for items in sections.values()) + len(styles), "styleboxes": sorted(all_box_types)}
 
 
 def register_into(registry: CompilerRegistry) -> CompilerRoute:
@@ -580,6 +640,11 @@ def validate_theme_structure(request: Any) -> dict[str, Any]:
             raise ValidationError("loaded Theme StyleBox does not match the recipe")
         if actual_box.get("class") != expected_box.get("type"):
             raise ValidationError("loaded Theme StyleBox type does not match the recipe")
+        if expected_box.get("type") == "StyleBoxTexture":
+            expected_path = expected_box.get("properties", {}).get("path") if isinstance(expected_box.get("properties"), Mapping) else None
+            if actual_box.get("resource_path") != expected_path:
+                raise ValidationError("loaded Theme StyleBoxTexture path does not match the recipe")
+            continue
         actual_properties = actual_box.get("properties")
         expected_properties = expected_box.get("properties")
         if not isinstance(actual_properties, Mapping) or not isinstance(expected_properties, Mapping):
@@ -587,6 +652,12 @@ def validate_theme_structure(request: Any) -> dict[str, Any]:
         for name, expected_value in expected_properties.items():
             if name not in actual_properties or not _same_theme_stylebox_value(name, actual_properties[name], expected_value):
                 raise ValidationError("loaded Theme StyleBox value does not match the recipe")
+    required_normal_path = request.spec.get("normal_stylebox_path") if isinstance(request.spec, Mapping) else None
+    if required_normal_path is not None:
+        variation = types.get(requested_variation)
+        normal_box = variation.get("styleboxes", {}).get("panel") if isinstance(variation, Mapping) else None
+        if not isinstance(normal_box, Mapping) or normal_box.get("resource_path") != required_normal_path:
+            raise ValidationError("loaded Theme does not bind the card default normal StyleBoxTexture")
     return {
         "types": sorted(types), "variations": sorted(variations),
         "requested_variation": requested_variation, "theme_items": declared_items,

--- a/skills/assets/_shared/asset_compiler/theme.py
+++ b/skills/assets/_shared/asset_compiler/theme.py
@@ -366,6 +366,7 @@ def _external_stylebox_texture_path(
     root: Path,
     production_family: str,
     asset_id: str,
+    allowed_paths: frozenset[str] | None,
 ) -> str:
     if set(properties) != {"path"} or not isinstance(properties.get("path"), str):
         _fail(f"{label}.properties must contain exactly a StyleBoxTexture path")
@@ -382,6 +383,8 @@ def _external_stylebox_texture_path(
         _fail(f"{label}.properties.path must be a safe generated resource path: {exc}")
     if file_path.suffix.lower() != ".tres" or not file_path.is_file():
         _fail(f"{label}.properties.path must name an existing StyleBoxTexture .tres")
+    if allowed_paths is not None and path not in allowed_paths:
+        _fail(f"{label}.properties.path must bind a declared StyleBoxTexture runtime output")
     try:
         header = file_path.read_text(encoding="utf-8")[:256]
     except OSError as exc:
@@ -397,6 +400,7 @@ def _styleboxes(
     root: Path,
     production_family: str,
     asset_id: str,
+    allowed_external_stylebox_paths: frozenset[str] | None,
 ) -> tuple[dict[str, list[str]], dict[str, str], dict[str, str]]:
     result: dict[str, list[str]] = {}
     subresources: dict[str, str] = {}
@@ -415,6 +419,7 @@ def _styleboxes(
                 root=root,
                 production_family=production_family,
                 asset_id=asset_id,
+                allowed_paths=allowed_external_stylebox_paths,
             )
             continue
         if not properties and box["type"] == "StyleBoxFlat":
@@ -486,6 +491,17 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
     variation_bases = dict(variations)
 
     root = request.project_root
+    raw_allowed_paths = request.spec.get("allowed_external_stylebox_paths") if isinstance(request.spec, Mapping) else None
+    if raw_allowed_paths is None:
+        allowed_external_stylebox_paths = None
+    elif (
+        not isinstance(raw_allowed_paths, list)
+        or any(not isinstance(path, str) for path in raw_allowed_paths)
+        or len(raw_allowed_paths) != len(set(raw_allowed_paths))
+    ):
+        _fail("allowed_external_stylebox_paths must be a duplicate-free list of resource paths")
+    else:
+        allowed_external_stylebox_paths = frozenset(raw_allowed_paths)
     sections = {
         section: _item_rows(
             recipe, section, variation_names, variation_bases, root,
@@ -498,6 +514,7 @@ def compile_theme(request: CompileRequest) -> dict[str, Any]:
         root=root,
         production_family=request.production_family,
         asset_id=request.asset_id,
+        allowed_external_stylebox_paths=allowed_external_stylebox_paths,
     )
     all_box_types = {**box_types, **{box_id: "StyleBoxTexture" for box_id in external_boxes}}
     styles: list[tuple[str, str, str]] = []

--- a/skills/assets/_shared/asset_validation/probe.gd
+++ b/skills/assets/_shared/asset_validation/probe.gd
@@ -219,6 +219,8 @@ func _theme_stylebox_facts(stylebox: StyleBox) -> Dictionary:
 		facts["properties"] = {
 			"content_margin": [stylebox.content_margin_left, stylebox.content_margin_top, stylebox.content_margin_right, stylebox.content_margin_bottom],
 		}
+	elif stylebox.is_class("StyleBoxTexture"):
+		facts["resource_path"] = _resource_path(stylebox)
 	return facts
 
 func _tile_descriptor(tile_set: TileSet, source: TileSetAtlasSource, coords: Vector2i, alternative: int) -> Dictionary:

--- a/skills/assets/_shared/schema/theme-recipe.schema.json
+++ b/skills/assets/_shared/schema/theme-recipe.schema.json
@@ -15,7 +15,7 @@
     "icons": {"$ref": "#/$defs/theme_items"},
     "styles": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["type", "name", "stylebox"], "properties": {"type": {"type": "string"}, "name": {"type": "string"}, "stylebox": {"type": "string"}}}},
     "variations": {"type": "array", "minItems": 1, "items": {"type": "object", "additionalProperties": false, "required": ["name", "base_type"], "properties": {"name": {"type": "string"}, "base_type": {"type": "string"}}}},
-    "styleboxes": {"type": "object", "additionalProperties": {"type": "object", "additionalProperties": false, "required": ["type", "properties"], "properties": {"type": {"enum": ["StyleBoxFlat", "StyleBoxEmpty"]}, "properties": {"type": "object"}}}}
+    "styleboxes": {"type": "object", "additionalProperties": {"type": "object", "additionalProperties": false, "required": ["type", "properties"], "properties": {"type": {"enum": ["StyleBoxFlat", "StyleBoxEmpty", "StyleBoxTexture"]}, "properties": {"type": "object"}}}}
   },
   "$defs": {
     "theme_items": {"type": "array", "items": {"type": "object", "additionalProperties": false, "required": ["type", "name", "value"], "properties": {"type": {"type": "string"}, "name": {"type": "string"}, "value": {}}}}

--- a/skills/assets/_shared/ui_card_standalone_validation.py
+++ b/skills/assets/_shared/ui_card_standalone_validation.py
@@ -114,10 +114,9 @@ def compile_and_validate(
 
     passed.append("L1")
     runtime = {output["name"]: output for output in result["outputs"] if output["role"] == "runtime"}
-    declarations: list[tuple[str, Mapping[str, Any], Mapping[str, Any]]] = [
-        ("theme", spec["theme"], runtime[spec["theme"]["output_name"]])
-    ]
+    declarations: list[tuple[str, Mapping[str, Any], Mapping[str, Any]]] = []
     declarations.extend(("stylebox", box, runtime[box["output_name"]]) for box in spec["styleboxes"])
+    declarations.append(("theme", spec["theme"], runtime[spec["theme"]["output_name"]]))
     declarations.extend(("atlas", region, runtime[region["output_name"]]) for region in spec["atlas_regions"])
     compiled_requests: dict[str, CompileRequest] = {}
     try:

--- a/skills/assets/_shared/ui_card_standalone_validation.py
+++ b/skills/assets/_shared/ui_card_standalone_validation.py
@@ -47,7 +47,10 @@ def _artifact_request(
             production_family=request["asset_type"], asset_id=request["asset_id"],
             source_layout_type="theme_recipe", source_path=declaration["recipe_path"],
             artifact_type="Theme", artifact_path=output["path"], project_root=root,
-            spec={"variation": declaration["variation"]},
+            spec={
+                "variation": declaration["variation"],
+                "allowed_external_stylebox_paths": declaration["allowed_external_stylebox_paths"],
+            },
         )
     if kind == "stylebox":
         return CompileRequest(
@@ -65,7 +68,10 @@ def _artifact_request(
 
 
 def _l1_paths(spec: Mapping[str, Any]) -> list[str]:
-    paths = [spec["theme"]["recipe_path"]]
+    paths: list[str] = []
+    theme_declaration = spec["theme"]
+    if theme_declaration is not None:
+        paths.append(theme_declaration["recipe_path"])
     for box in spec["styleboxes"]:
         paths.append(box["source_path"])
     for region in spec["atlas_regions"]:
@@ -116,7 +122,18 @@ def compile_and_validate(
     runtime = {output["name"]: output for output in result["outputs"] if output["role"] == "runtime"}
     declarations: list[tuple[str, Mapping[str, Any], Mapping[str, Any]]] = []
     declarations.extend(("stylebox", box, runtime[box["output_name"]]) for box in spec["styleboxes"])
-    declarations.append(("theme", spec["theme"], runtime[spec["theme"]["output_name"]]))
+    theme_declaration = spec["theme"]
+    if theme_declaration is not None:
+        declarations.append((
+            "theme",
+            {
+                **theme_declaration,
+                "allowed_external_stylebox_paths": [
+                    runtime[box["output_name"]]["path"] for box in spec["styleboxes"]
+                ],
+            },
+            runtime[theme_declaration["output_name"]],
+        ))
     declarations.extend(("atlas", region, runtime[region["output_name"]]) for region in spec["atlas_regions"])
     compiled_requests: dict[str, CompileRequest] = {}
     try:

--- a/skills/assets/card-kit/SKILL.md
+++ b/skills/assets/card-kit/SKILL.md
@@ -5,22 +5,25 @@ description: Produce reusable card art sources and native Godot card UI resource
 
 # Card Kit Asset
 
-Use this Skill for reusable non-pixel-art card UI: card and portrait frames,
+Use this Skill for reusable non-pixel-art, card-game-specific UI: card frames, portrait frames,
 rarity frames, card/deck slots, resource badges, state overlays, card panels,
 and card buttons. It produces art sources and native Godot resources, not card
-rules, deck logic, a `Control` page, a `PackedScene`, readable text, or a full
+rules, deck logic, a `Control` or `Container` layout, a `PackedScene`, readable text, or a full
 composite screen. A request for pixel art is unsupported and must STOP.
 
 ## Invocation and Boundaries
 
-Accept one shared Asset Skill request with `asset_type: "card-kit"`. First run
+Accept one request matching the shared Asset Skill request schema in
+`.godotmaker/asset-runtime/schema/asset-skill-request.schema.json` with
+`asset_type: "card-kit"`. First run
 `python tools/asset_ui_card_contract_check.py <request.json> --kind request`.
 The family contract owns the Theme recipe/variation, requested frame/state
 pairs, and named atlas regions. The request decides which card resources are
 needed; do not add a default front/back, portrait, rarity, or state bundle.
-This Skill may run directly or through
-`gm-asset`, but it never registers stable entries, edits `ASSETS.md`, tags, or
-stage state. The producer adapter owns that later registration handoff.
+This card-game-specific UI Skill can be invoked directly or by an orchestrator
+through `gm-asset`, but it never registers stable entries, edits `ASSETS.md`, tags, or
+stage state, or writes generated
+manifests. The producer adapter owns that later registration handoff.
 
 `references` is optional. When it is non-empty, each path is binding input:
 
@@ -44,7 +47,8 @@ with `reference_inputs`; it records hashes and attachment provenance.
 Turn the brief into one concrete source plan: frame geometry/orientation,
 empty portrait or card-art safe zones unless finished art is requested, rarity
 language, state treatment, and only the requested component list. A reusable
-card frame is not a flattened example card. Keep generated images free of readable
+card frame is not a flattened example card. Keep card-art and portrait windows empty
+unless the request declares finished art. Keep generated images free of readable
 text, numbers, watermarks, and unrelated composite screens.
 
 Write the prompt and source plan under `.godotmaker/asset-generation/`, then
@@ -102,11 +106,15 @@ ready only after every applicable L0-L4 check passes.
 Return the shared generic result with independently usable native runtime
 resources (`Theme`, `StyleBoxTexture`, and `AtlasTexture`), its `theme_recipe`,
 `single`, or `region_atlas` sources, previews when produced, and final L0-L4
-evidence. Check it with the shared result checker and this family
+evidence. Check it with the shared result schema and checker plus this family
 contract. Before responding, persist that exact generic result JSON at
 `.godotmaker/asset-generation/<asset_id>-result.json`, then return the same
 JSON directly in the final response. The runner, not a self-reported boolean,
 records validation.
+
+The output is reusable card UI, not pixel-perfect `Control` or `Container`
+composition. Consumers choose their own layout and may apply only the declared
+Theme, StyleBoxTexture, or AtlasTexture resources.
 
 For `gm-asset`, the producer adapter translates a successful generic result
 into stable `source_layout + godot_artifact` entries and performs the normal

--- a/skills/assets/card-kit/SKILL.md
+++ b/skills/assets/card-kit/SKILL.md
@@ -1,79 +1,115 @@
 ---
 name: card-kit
-description: Produce standalone native resources for card frames, portrait windows, card controls, and scalable card UI borders.
+description: Produce reusable card art sources and native Godot card UI resources.
 ---
 
 # Card Kit Asset
 
-Use this skill for card-game-specific UI: card frames, portrait frames, rarity
-frames, card slots, deck slots, resource badges, card-state overlays, card
-panels, and card buttons. Do not use it for generic HUD controls, character
-portraits, a finished card illustration unless explicitly requested, a full
-composite screen, readable text, or scene layout.
+Use this Skill for reusable non-pixel-art card UI: card and portrait frames,
+rarity frames, card/deck slots, resource badges, state overlays, card panels,
+and card buttons. It produces art sources and native Godot resources, not card
+rules, deck logic, a `Control` page, a `PackedScene`, readable text, or a full
+composite screen. A request for pixel art is unsupported and must STOP.
 
-## Invocation
+## Invocation and Boundaries
 
-Accept one asset request matching the shared Asset Skill request schema in
-`.godotmaker/asset-runtime/schema/asset-skill-request.schema.json`. Require
-`asset_type` to be `card-kit`. Validate the returned document against the
-shared result schema and checker, then validate its closed family contract with
-`tools/asset_ui_card_contract_check.py`. `spec` declares the Theme recipe and
-variation, every requested card frame/state pair with an explicit StyleBox
-recipe, and every requested AtlasTexture region.
+Accept one shared Asset Skill request with `asset_type: "card-kit"`. First run
+`python tools/asset_ui_card_contract_check.py <request.json> --kind request`.
+The family contract owns the Theme recipe/variation, requested frame/state
+pairs, and named atlas regions. The request decides which card resources are
+needed; do not add a default front/back, portrait, rarity, or state bundle.
+This Skill may run directly or through
+`gm-asset`, but it never registers stable entries, edits `ASSETS.md`, tags, or
+stage state. The producer adapter owns that later registration handoff.
 
-This skill can be invoked directly or by an orchestrator with the same
-contract. Do not read or write `ASSETS.md`, tags, stage state, generated
-manifests, stable entries, or worker dispatch state.
+`references` is optional. When it is non-empty, each path is binding input:
 
-## Produce
+1. Verify that it is a readable image before generation.
+2. Preserve its `canonical`, `style`, or `screen` role in the prompt and trace.
+3. Attach its real image bytes through the declared provider path.
+4. STOP if that provider cannot attach every required reference.
 
-1. Use the brief plus visible card or UI references to set the frame geometry,
-   rarity language, panel treatment, badge/icon language, and state treatment.
-   The LLM fills this visual recipe; deterministic tools do not invent a card
-   design.
-2. Keep card-art and portrait windows empty unless the request explicitly asks
-   for finished portrait art. A frame must remain a reusable frame rather than
-   a flattened example card.
-3. When card controls need shared colors, typography, constants, or state
-   binding, write a closed `theme_recipe` and compile a standalone `Theme`
-   with a declared type variation at
-   `res://assets/generated/card-kit/<asset_id>/<asset_id>_theme.tres`.
-4. Compile every card frame, portrait frame, scalable slot, panel, or button
-   state from an explicit `StyleBoxTexture` recipe. Declare its PNG region,
-   four borders, expand margins, and stretch axes, then use nine-slice scaling
-   to preserve corners and frame geometry.
-5. Assemble badges, resource icons, and fixed overlays into declared atlas
-   slots where appropriate. Compile each named region into a distinct
-   zero-margin `AtlasTexture`; no automatic packing, trimming, or inferred
-   region is allowed.
-6. Declare all requested card states (`normal`, `hover`, `pressed`,
-   `disabled`, `selected`, or `locked`) as named resources. Never infer a
-   missing state from another frame.
-7. Run `standalone_validation.compile_and_validate()` before returning the
-   result. It performs L0 family binding, L1 source/recipe/metadata checks, L2
-   fresh-registry compilation for every output, L3 headless Godot type checks,
-   and L4 structure validation for every output. The deterministic tools enforce
-   legal serialization, complete declared resource types, Godot loading, and
-   type-specific structure checks.
-   Theme L4 requires the exact requested `spec.theme.variation`, not merely an
-   arbitrary variation declared by the recipe.
+A prompt-only filename, silent omission, or provider substitution is not
+reference use. Use only the requested provider (`native`, `codex`, `gemini`,
+or `openai`). For Codex, call `image_gen` with the real
+`referenced_image_paths` when any are present. Record provider, model identity
+when exposed, coding model, reasoning, attachment paths/roles, and provider
+call identity. For `openai` and `gemini`, use `tools/asset_source_generate.py`
+with `reference_inputs`; it records hashes and attachment provenance.
 
-The worker owns `Control` and `Container` layout and card placement. A
-reference shows visual direction only and is not pixel-perfect.
-Workers bind the returned Theme and use the separate StyleBoxTexture and
-AtlasTexture outputs for the card controls they construct.
+## Production Loop
 
-## Result
+### 1. Plan and generate the visual source
 
-Return the shared generic result. A successful result exposes each native
-resource independently: an optional card `Theme`, one `StyleBoxTexture` for
-each scalable frame or state, and one `AtlasTexture` for each declared icon or
-overlay region. `sources` records each `theme_recipe`, `single`, or
-`region_atlas` input used by the resources. See
-`fixtures/` for a request/result pair with a valid standalone contract. The
-runner, not a self-reported boolean, writes the final L0-L4 result.
+Turn the brief into one concrete source plan: frame geometry/orientation,
+empty portrait or card-art safe zones unless finished art is requested, rarity
+language, state treatment, and only the requested component list. A reusable
+card frame is not a flattened example card. Keep generated images free of readable
+text, numbers, watermarks, and unrelated composite screens.
 
-If a requested frame/state is absent, a portrait window is incorrectly filled,
-a nine-slice declaration is invalid, an atlas region is missing, or any L0-L4
-check fails, return `outputs: []` with `validation.passed: false` and notes.
-Do not expose a card PNG as a replacement for its native runtime resource.
+Write the prompt and source plan under `.godotmaker/asset-generation/`, then
+generate real provider art into its declared raw-source path. Preserve the raw
+image and provider report; never replace failed generation with procedural or
+placeholder art.
+
+### 2. Process and curate
+
+Prefer the repository's deterministic tools, selecting only those the source
+needs:
+
+- `asset_image_finalize.py` for a single card or portrait frame, including
+  transparency, alpha bounds, aspect checks, and finalization report;
+- `asset_sheet_process.py` for component sheets, with `autoslice` for separated
+  pieces and `grid` only for intentional equal cells;
+- `asset_curation_select.py` to choose final components with a curation record;
+- `asset_atlas_assemble.py` to build a transparent atlas and region metadata.
+
+Temporary scripts or other image tools are allowed when diagnosis needs them.
+The trace must state the reason, command or code, inputs, outputs, changed
+files, diagnostic, and repair result. Never claim a provider call, attachment,
+or verification that did not happen.
+
+### 3. Compile native resources
+
+Keep final sources under `assets/generated/card-kit/<asset_id>/`. Compile one
+`StyleBoxTexture` for every declared frame/state
+pair using an explicit source/region, borders, expand margins, and stretch
+axes. This preserves card corners through nine-slice scaling. Compile those
+StyleBoxes first, then build the optional Theme at `<asset_id>_theme.tres` when
+the request declares one. A Theme recipe may bind a generated
+`StyleBoxTexture` when the caller requests that composition. Compile every
+named fixed component into a distinct `AtlasTexture`. Front/back images,
+portrait frames, rarity badges, and overlays are separate only when the request
+declares them; never infer a missing requested resource from another region.
+
+### 4. Diagnose, repair, and recheck
+
+Run `standalone_validation.compile_and_validate()` after a candidate set exists.
+L0 binds the family request/result, L1 checks final sources and metadata, L2
+compiles a fresh registry, L3 loads the artifacts in headless Godot, and L4
+checks type-specific resource structure. These are production diagnostics, not
+a one-shot failure gate: inspect the failed diagnostic, repair the source,
+processing parameters, metadata, recipe, or Godot resource, and re-run the
+affected checks followed by the final full check.
+
+Only STOP for a missing/corrupt required input, unsupported pixel-art request,
+contradictory request, unavailable declared provider or required reference
+attachment, or unrecoverable environment/permission failure. A final result is
+ready only after every applicable L0-L4 check passes.
+
+## Result and Handoff
+
+Return the shared generic result with independently usable native runtime
+resources (`Theme`, `StyleBoxTexture`, and `AtlasTexture`), its `theme_recipe`,
+`single`, or `region_atlas` sources, previews when produced, and final L0-L4
+evidence. Check it with the shared result checker and this family
+contract. Before responding, persist that exact generic result JSON at
+`.godotmaker/asset-generation/<asset_id>-result.json`, then return the same
+JSON directly in the final response. The runner, not a self-reported boolean,
+records validation.
+
+For `gm-asset`, the producer adapter translates a successful generic result
+into stable `source_layout + godot_artifact` entries and performs the normal
+ready handoff. Private Eval independently assesses consumer use, visual quality,
+reference consistency, and whether an improvised repair should become a shared
+tool improvement.

--- a/tests/assets/test_theme_compiler.py
+++ b/tests/assets/test_theme_compiler.py
@@ -36,7 +36,7 @@ def _recipe(**overrides):
     return value
 
 
-def _request(root: Path):
+def _request(root: Path, *, spec=None):
     return CompileRequest(
         production_family="ui-kit",
         asset_id="main",
@@ -44,7 +44,7 @@ def _request(root: Path):
         source_path="res://assets/generated/ui-kit/main/main.json",
         artifact_type="Theme",
         artifact_path="res://assets/generated/ui-kit/main/main.tres",
-        project_root=root,
+        project_root=root, spec=spec or {},
     )
 
 
@@ -54,10 +54,10 @@ def _write_recipe(root: Path, recipe, *, source_path="res://assets/generated/ui-
     path.write_text(json.dumps(recipe), encoding="utf-8")
 
 
-def _compile(root: Path):
+def _compile(root: Path, *, spec=None):
     registry = build_default_registry()
     theme.register_into(registry)
-    return registry.compile(_request(root))
+    return registry.compile(_request(root, spec=spec))
 
 
 def _structure_request(root: Path, *, source_path="res://assets/generated/ui-kit/main/main.json"):
@@ -129,6 +129,27 @@ def test_compiles_a_theme_that_binds_a_declared_generated_stylebox_texture(tmp_p
     text = (tmp_path / "assets/generated/ui-kit/main/main.tres").read_text(encoding="utf-8")
     assert 'type="StyleBoxTexture" path="res://assets/generated/ui-kit/main/button-frame.tres"' in text
     assert 'Button/styles/normal = ExtResource("StyleBox_button_normal")' in text
+
+
+def test_rejects_theme_stylebox_paths_outside_the_declared_runtime_outputs(tmp_path):
+    frame_path = tmp_path / "assets/generated/ui-kit/main/button-frame.tres"
+    frame_path.parent.mkdir(parents=True)
+    frame_path.write_text('[gd_resource type="StyleBoxTexture" format=3]\n', encoding="utf-8")
+    recipe = _recipe(
+        styleboxes={
+            "button_normal": {
+                "type": "StyleBoxTexture",
+                "properties": {"path": "res://assets/generated/ui-kit/main/button-frame.tres"},
+            }
+        },
+    )
+    _write_recipe(tmp_path, recipe)
+
+    with pytest.raises(CompilerError, match="declared StyleBoxTexture runtime output"):
+        _compile(
+            tmp_path,
+            spec={"allowed_external_stylebox_paths": ["res://assets/generated/ui-kit/main/other.tres"]},
+        )
 
 
 def test_structure_validation_reads_and_compares_the_declared_recipe_through_the_safe_resolver(tmp_path):

--- a/tests/assets/test_theme_compiler.py
+++ b/tests/assets/test_theme_compiler.py
@@ -110,6 +110,27 @@ def test_compiles_a_complete_theme_with_a_variation_deterministically(tmp_path):
     assert 'Button/styles/normal = SubResource("StyleBox_button_normal")' in text
 
 
+def test_compiles_a_theme_that_binds_a_declared_generated_stylebox_texture(tmp_path):
+    frame_path = tmp_path / "assets/generated/ui-kit/main/button-frame.tres"
+    frame_path.parent.mkdir(parents=True)
+    frame_path.write_text('[gd_resource type="StyleBoxTexture" format=3]\n', encoding="utf-8")
+    recipe = _recipe(
+        styleboxes={
+            "button_normal": {
+                "type": "StyleBoxTexture",
+                "properties": {"path": "res://assets/generated/ui-kit/main/button-frame.tres"},
+            }
+        },
+    )
+    _write_recipe(tmp_path, recipe)
+
+    _compile(tmp_path)
+
+    text = (tmp_path / "assets/generated/ui-kit/main/main.tres").read_text(encoding="utf-8")
+    assert 'type="StyleBoxTexture" path="res://assets/generated/ui-kit/main/button-frame.tres"' in text
+    assert 'Button/styles/normal = ExtResource("StyleBox_button_normal")' in text
+
+
 def test_structure_validation_reads_and_compares_the_declared_recipe_through_the_safe_resolver(tmp_path):
     _write_recipe(tmp_path, _recipe())
 
@@ -228,7 +249,7 @@ def test_allows_an_empty_stylebox_without_flat_only_properties(tmp_path):
         (lambda recipe: recipe["colors"].__setitem__(0, {"type": "Button", "name": "script", "value": "#FFFFFF"}), "allowed colors property"),
         (lambda recipe: recipe["colors"].__setitem__(0, {"type": "Label", "name": "icon_normal_color", "value": "#FFFFFF"}), "allowed colors property for Label"),
         (lambda recipe: recipe["styles"].__setitem__(0, {"type": "Button", "name": "normal", "stylebox": "missing"}), "unknown StyleBox"),
-        (lambda recipe: recipe["styleboxes"]["button_normal"].__setitem__("type", "Resource"), "StyleBoxFlat or StyleBoxEmpty"),
+        (lambda recipe: recipe["styleboxes"]["button_normal"].__setitem__("type", "Resource"), "StyleBoxFlat, StyleBoxEmpty, or StyleBoxTexture"),
         (lambda recipe: recipe["styleboxes"]["button_normal"].update({"type": "StyleBoxEmpty", "properties": {"bg_color": "#FFFFFF"}}), "unsupported StyleBoxEmpty property"),
     ],
 )

--- a/tests/assets/test_ui_card_skill_contract.py
+++ b/tests/assets/test_ui_card_skill_contract.py
@@ -186,6 +186,14 @@ def test_card_contract_rejects_a_missing_requested_frame_and_region():
         check_ui_card_request(request)
 
 
+def test_card_contract_rejects_pixel_art_requests():
+    request = _request("card-kit")
+    request["brief"] = "A pixel-art card frame."
+
+    with pytest.raises(UICardContractError, match="does not support pixel-art"):
+        check_ui_card_request(request)
+
+
 @pytest.mark.parametrize("family", ["ui-kit", "card-kit"])
 def test_standalone_runner_executes_l0_to_l4_for_every_runtime_output(tmp_path, monkeypatch, family):
     request = _request(family)

--- a/tests/assets/test_ui_card_skill_contract.py
+++ b/tests/assets/test_ui_card_skill_contract.py
@@ -71,17 +71,22 @@ def _request(family: str) -> dict:
 def _result(request: dict) -> dict:
     root = f"res://assets/generated/{request['asset_type']}/{request['asset_id']}"
     box = request["spec"]["styleboxes"][0]
+    outputs = [
+        {"role": "runtime", "name": box["output_name"], "path": f"{root}/{box['output_name']}.tres", "godot_type": "StyleBoxTexture"},
+        {"role": "runtime", "name": "icon", "path": f"{root}/icon.tres", "godot_type": "AtlasTexture"},
+    ]
+    sources = [{"path": box["source_path"], "layout": "region_atlas"}]
+    theme = request["spec"].get("theme")
+    if theme is not None:
+        outputs.insert(0, {
+            "role": "runtime", "name": theme["output_name"],
+            "path": f"{root}/{request['asset_id']}_theme.tres", "godot_type": "Theme",
+        })
+        sources.insert(0, {"path": theme["recipe_path"], "layout": "theme_recipe"})
     return {
         "asset_type": request["asset_type"],
-        "outputs": [
-            {"role": "runtime", "name": "theme", "path": f"{root}/{request['asset_id']}_theme.tres", "godot_type": "Theme"},
-            {"role": "runtime", "name": box["output_name"], "path": f"{root}/{box['output_name']}.tres", "godot_type": "StyleBoxTexture"},
-            {"role": "runtime", "name": "icon", "path": f"{root}/icon.tres", "godot_type": "AtlasTexture"},
-        ],
-        "sources": [
-            {"path": request["spec"]["theme"]["recipe_path"], "layout": "theme_recipe"},
-            {"path": box["source_path"], "layout": "region_atlas"},
-        ],
+        "outputs": outputs,
+        "sources": sources,
         "previews": [],
         "validation": {"passed": False},
     }
@@ -98,18 +103,21 @@ def _source_adapter(family: str):
 
 def _write_sources(root: Path, request: dict, *, recipe_variation: str | None = None) -> None:
     spec = request["spec"]
-    recipe = {
-        "version": 1,
-        "colors": [{"type": "Button", "name": "font_color", "value": "#FFFFFFFF"}],
-        "font_sizes": [], "constants": [], "fonts": [], "icons": [],
-        "styleboxes": {}, "styles": [],
-        "variations": [{"name": recipe_variation or spec["theme"]["variation"], "base_type": "Button"}],
-    }
-    recipe_file = root / spec["theme"]["recipe_path"].removeprefix("res://")
-    recipe_file.parent.mkdir(parents=True, exist_ok=True)
-    recipe_file.write_text(json.dumps(recipe), encoding="utf-8")
+    theme = spec.get("theme")
+    if theme is not None:
+        recipe = {
+            "version": 1,
+            "colors": [{"type": "Button", "name": "font_color", "value": "#FFFFFFFF"}],
+            "font_sizes": [], "constants": [], "fonts": [], "icons": [],
+            "styleboxes": {}, "styles": [],
+            "variations": [{"name": recipe_variation or theme["variation"], "base_type": "Button"}],
+        }
+        recipe_file = root / theme["recipe_path"].removeprefix("res://")
+        recipe_file.parent.mkdir(parents=True, exist_ok=True)
+        recipe_file.write_text(json.dumps(recipe), encoding="utf-8")
     box = spec["styleboxes"][0]
     image_file = root / box["source_path"].removeprefix("res://")
+    image_file.parent.mkdir(parents=True, exist_ok=True)
     image_file.write_bytes(_png(32, 32))
     region = spec["atlas_regions"][0]
     metadata = {
@@ -123,7 +131,8 @@ def _write_sources(root: Path, request: dict, *, recipe_variation: str | None = 
 def _good_probe(request: dict, result: dict, *, theme_variation: str | None = None):
     box = request["spec"]["styleboxes"][0]
     atlas = request["spec"]["atlas_regions"][0]
-    variation = theme_variation or request["spec"]["theme"]["variation"]
+    theme = request["spec"].get("theme")
+    variation = theme_variation or (theme["variation"] if theme is not None else None)
 
     def fake_probe(self, project_root, requests):
         resources = []
@@ -192,6 +201,29 @@ def test_card_contract_rejects_pixel_art_requests():
 
     with pytest.raises(UICardContractError, match="does not support pixel-art"):
         check_ui_card_request(request)
+
+
+@pytest.mark.parametrize("brief", ["A non-pixel-art card frame.", "A card frame, not pixel art."])
+def test_card_contract_allows_explicit_non_pixel_art_requests(brief):
+    request = _request("card-kit")
+    request["brief"] = brief
+
+    assert check_ui_card_request(request)["ok"] is True
+
+
+@pytest.mark.parametrize("family", ["ui-kit", "card-kit"])
+def test_family_contract_allows_a_declared_resource_bundle_without_theme(tmp_path, monkeypatch, family):
+    request = _request(family)
+    request["spec"].pop("theme")
+    result = _result(request)
+    _write_sources(tmp_path, request)
+    monkeypatch.setattr(GodotProbe, "probe", _good_probe(request, result))
+
+    validated = compile_and_validate(request, result, project_root=tmp_path, godot_path="godot")
+
+    assert validated["validation"]["levels"] == {
+        "L0": True, "L1": True, "L2": True, "L3": True, "L4": True,
+    }
 
 
 @pytest.mark.parametrize("family", ["ui-kit", "card-kit"])
@@ -281,6 +313,51 @@ def test_standalone_runner_maps_missing_declared_atlas_region_to_l2(tmp_path):
 
     assert validated["validation"]["levels"] == {"L0": True, "L1": True, "L2": False, "L3": False, "L4": False}
     assert "declares no region" in validated["validation"]["notes"]
+
+
+def test_standalone_runner_rejects_theme_binding_to_an_undeclared_stylebox(tmp_path):
+    request = _request("card-kit")
+    result = _result(request)
+    _write_sources(tmp_path, request)
+    root = f"res://assets/generated/card-kit/{request['asset_id']}"
+    undeclared_path = f"{root}/leftover.tres"
+    (tmp_path / undeclared_path.removeprefix("res://")).write_text(
+        '[gd_resource type="StyleBoxTexture" format=3]\n', encoding="utf-8"
+    )
+    recipe_path = tmp_path / request["spec"]["theme"]["recipe_path"].removeprefix("res://")
+    recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+    recipe["styleboxes"] = {
+        "leftover": {"type": "StyleBoxTexture", "properties": {"path": undeclared_path}},
+    }
+    recipe["styles"] = [{"type": "CardButton", "name": "normal", "stylebox": "leftover"}]
+    recipe_path.write_text(json.dumps(recipe), encoding="utf-8")
+
+    validated = compile_and_validate(request, result, project_root=tmp_path, godot_path="godot")
+
+    assert validated["validation"]["levels"] == {
+        "L0": True, "L1": True, "L2": False, "L3": False, "L4": False,
+    }
+    assert "declared StyleBoxTexture runtime output" in validated["validation"]["notes"]
+
+
+def test_standalone_runner_loads_a_theme_bound_to_its_declared_stylebox_texture(godot_project, godot_bin):
+    request = _request("card-kit")
+    result = _result(request)
+    _write_sources(godot_project, request)
+    stylebox = next(item for item in result["outputs"] if item["godot_type"] == "StyleBoxTexture")
+    recipe_path = godot_project / request["spec"]["theme"]["recipe_path"].removeprefix("res://")
+    recipe = json.loads(recipe_path.read_text(encoding="utf-8"))
+    recipe["styleboxes"] = {
+        "rare_normal": {"type": "StyleBoxTexture", "properties": {"path": stylebox["path"]}},
+    }
+    recipe["styles"] = [{"type": "CardButton", "name": "normal", "stylebox": "rare_normal"}]
+    recipe_path.write_text(json.dumps(recipe), encoding="utf-8")
+
+    validated = compile_and_validate(request, result, project_root=godot_project, godot_path=godot_bin)
+
+    assert validated["validation"]["levels"] == {
+        "L0": True, "L1": True, "L2": True, "L3": True, "L4": True,
+    }
 
 
 def test_standalone_runner_maps_godot_type_failure_to_l3(tmp_path, monkeypatch):

--- a/tools/asset_ui_card_contract_check.py
+++ b/tools/asset_ui_card_contract_check.py
@@ -29,6 +29,7 @@ _FAMILIES = {
 }
 
 _PIXEL_ART_REQUEST = re.compile(r"\bpixel(?:[-\s]?art)\b", re.IGNORECASE)
+_PIXEL_ART_NEGATION = re.compile(r"\b(?:not|non)(?:[-\s]+[a-z]+){0,2}[-\s]*$", re.IGNORECASE)
 
 def _text(value: Any, label: str, issues: list[str]) -> str | None:
     if not isinstance(value, str) or not value.strip():
@@ -84,6 +85,15 @@ def _theme(value: Any, issues: list[str]) -> dict[str, str] | None:
     if not recipe_path.endswith(".json"):
         issues.append("request.spec.theme.recipe_path must end in .json")
     return {"output_name": output_name, "recipe_path": recipe_path, "variation": variation}
+
+
+def _requests_pixel_art(brief: str) -> bool:
+    """Recognize a pixel-art request without rejecting an explicit negation."""
+    for match in _PIXEL_ART_REQUEST.finditer(brief):
+        context = brief[max(0, match.start() - 32):match.start()]
+        if not _PIXEL_ART_NEGATION.search(context):
+            return True
+    return False
 
 
 def _stylebox(value: Any, family: str, index: int, issues: list[str]) -> dict[str, Any] | None:
@@ -152,13 +162,24 @@ def _atlas_region(value: Any, index: int, issues: list[str]) -> dict[str, str] |
 
 def _spec(request: Mapping[str, Any], issues: list[str]) -> dict[str, Any] | None:
     family = request["asset_type"]
-    keys = {"theme", "required_states", "styleboxes", "required_regions", "atlas_regions"}
+    keys = {"required_states", "styleboxes", "required_regions", "atlas_regions"}
     if family == "card-kit":
         keys.add("required_frames")
-    spec = _exact_keys(request.get("spec"), keys, "request.spec", issues)
-    if spec is None:
+    spec = request.get("spec")
+    if not isinstance(spec, Mapping):
+        issues.append("request.spec must be an object")
         return None
-    theme = _theme(spec.get("theme"), issues)
+    actual = set(spec)
+    if actual not in (keys, keys | {"theme"}):
+        missing = sorted(keys - actual)
+        extra = sorted(actual - (keys | {"theme"}))
+        message = "request.spec must contain required family fields and may contain theme"
+        if missing:
+            message += "; missing " + ", ".join(missing)
+        if extra:
+            message += "; unexpected " + ", ".join(extra)
+        issues.append(message)
+    theme = _theme(spec["theme"], issues) if "theme" in spec else None
     states = _names(spec.get("required_states"), "request.spec.required_states", issues)
     allowed_states = _FAMILIES[family]["states"]
     unknown_states = sorted(set(states) - allowed_states)
@@ -213,7 +234,7 @@ def check_ui_card_request(data: Any) -> dict[str, Any]:
         raise UICardContractError(str(exc)) from exc
     if data["asset_type"] not in _FAMILIES:
         raise UICardContractError("asset_type is not ui-kit or card-kit")
-    if data["asset_type"] == "card-kit" and _PIXEL_ART_REQUEST.search(data["brief"]):
+    if data["asset_type"] == "card-kit" and _requests_pixel_art(data["brief"]):
         raise UICardContractError("card-kit does not support pixel-art requests")
     issues: list[str] = []
     normalized = _spec(data, issues)
@@ -254,22 +275,23 @@ def check_ui_card_handoff(request: Any, result: Any) -> dict[str, Any]:
     assert spec is not None
     runtime = _runtime_by_name(result)
     sources = _source_paths(result)
-    expected_names = {spec["theme"]["output_name"]}
-
     theme = spec["theme"]
-    theme_output = runtime.get(theme["output_name"])
-    expected_theme_path = (
-        f"res://assets/generated/{request['asset_type']}/{request['asset_id']}/"
-        f"{request['asset_id']}_theme.tres"
-    )
-    if (
-        theme_output is None
-        or theme_output.get("godot_type") != "Theme"
-        or theme_output.get("path") != expected_theme_path
-    ):
-        raise UICardContractError("theme.output_name must bind to one Theme runtime output")
-    if (theme["recipe_path"], "theme_recipe") not in sources:
-        raise UICardContractError("theme.recipe_path must be a theme_recipe result source")
+    expected_names: set[str] = set()
+    if theme is not None:
+        expected_names.add(theme["output_name"])
+        theme_output = runtime.get(theme["output_name"])
+        expected_theme_path = (
+            f"res://assets/generated/{request['asset_type']}/{request['asset_id']}/"
+            f"{request['asset_id']}_theme.tres"
+        )
+        if (
+            theme_output is None
+            or theme_output.get("godot_type") != "Theme"
+            or theme_output.get("path") != expected_theme_path
+        ):
+            raise UICardContractError("theme.output_name must bind to one Theme runtime output")
+        if (theme["recipe_path"], "theme_recipe") not in sources:
+            raise UICardContractError("theme.recipe_path must be a theme_recipe result source")
 
     for box in spec["styleboxes"]:
         expected_names.add(box["output_name"])

--- a/tools/asset_ui_card_contract_check.py
+++ b/tools/asset_ui_card_contract_check.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,7 @@ _FAMILIES = {
     },
 }
 
+_PIXEL_ART_REQUEST = re.compile(r"\bpixel(?:[-\s]?art)\b", re.IGNORECASE)
 
 def _text(value: Any, label: str, issues: list[str]) -> str | None:
     if not isinstance(value, str) or not value.strip():
@@ -211,6 +213,8 @@ def check_ui_card_request(data: Any) -> dict[str, Any]:
         raise UICardContractError(str(exc)) from exc
     if data["asset_type"] not in _FAMILIES:
         raise UICardContractError("asset_type is not ui-kit or card-kit")
+    if data["asset_type"] == "card-kit" and _PIXEL_ART_REQUEST.search(data["brief"]):
+        raise UICardContractError("card-kit does not support pixel-art requests")
     issues: list[str] = []
     normalized = _spec(data, issues)
     if issues:


### PR DESCRIPTION
## Summary

Make `card-kit` request-driven: it compiles only the declared Theme, scalable frames, and fixed AtlasTexture regions instead of imposing a universal front/back card pack.

## Motivation

A full-card example had become a universal contract. That produced unnecessary, sometimes conflicting outputs for smaller reusable card-resource requests. This preserves the native compiler path while putting composition back with the consumer.

## Changes

- [x] Restore a request-driven `card-kit` contract with pinned providers, optional real reference attachments, traceable deterministic processing, and pixel-art STOP handling.
- [x] Extend the shared Theme compiler so a declared Theme can bind an existing generated `StyleBoxTexture`; preserve StyleBoxTexture and AtlasTexture output validation.
- [x] Make Theme truly optional, require Theme StyleBoxTexture bindings to reference current declared runtime outputs, and cover the real Godot L3/L4 load path.
- [x] Restore published card-kit runtime-contract wording and distinguish explicit non-pixel requests from unsupported pixel-art requests.
- [x] Persist the generic asset result so the private Eval can archive the same handoff the Skill returns.

## Testing

- [x] Targeted contracts: `202 passed, 1 skipped` across card-kit, Theme compiler, publish, and runtime-contract tests.
- [x] Real Godot 4.5.1 L3/L4 test loads a Theme bound to its declared StyleBoxTexture.
- [x] Full GitHub Actions suite passed: Python tests on Ubuntu, macOS, and Windows; Ruff; docs; and secret scan.
- [x] Manual provider validation completed: the private Codex Eval passed L0-L4 for a declared Theme, frame, and badge bundle.

## Benchmark Verification

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

## Version Compatibility

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
