### PR TITLE
fix(asset): separate autoslice extraction from grid layout

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -80,7 +80,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Asset readiness promotion now requires a compiler receipt bound to the compiled entry, while already-ready assets can explicitly revalidate without retaining that receipt.
 - Theme recipes now accept only fully decoded raster textures and FreeType-loadable TTF/OTF fonts, rejecting truncated or unsupported resource content before a Theme is written.
 - Failed native Godot artifact compilation now retains the previous stable artifact and atomically commits a validated replacement only after success.
-- Added the required `--grid` (and `--names`) argument to every production-unit `asset_sheet_process.py` example so the ui-kit, card-kit, compact-prop-pack, fx-bundle, scene-prop-set, and platform-strip commands run as written instead of failing on a missing required argument, and clarified that `--grid` is required in both autoslice and grid snap modes.
+- Restored `asset_sheet_process.py --snap-mode autoslice` to independent Godot-style region extraction without grid bucketing or cross-region unions; fixed-grid extraction continues to require `--grid`.
 - Point generated-asset runtime handoff (gm-build, gm-fixgap, worker dispatch, worker agent) at `.godotmaker/asset-generation/manifest.json` instead of the analyst's `assets/manifest.json` (#97)
 
 ## Removed

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -71,11 +71,10 @@ non-character source sheets.
 
 Required decisions:
 
-1. `--grid <COLSxROWS>`
-2. `--names <comma-separated names>`
-3. `--snap-mode autoslice` for separated objects
-4. `--snap-mode grid` for strict cell grids
-5. `--component-mode largest` for compact UI/icon/prop cells with stray
+1. `--names <comma-separated names>`
+2. `--snap-mode autoslice` for independent separated regions
+3. `--snap-mode grid --grid <COLSxROWS>` for strict cell grids
+4. `--component-mode largest` for compact UI/icon/prop cells with stray
    fragments
 
 Manual entry point:
@@ -84,11 +83,14 @@ Manual entry point:
 python tools/asset_sheet_process.py \
   --source <source.png> \
   --out-dir <curation_dir> \
-  --grid <COLSxROWS> \
   --names <names> \
   --snap-mode <autoslice|grid> \
   --report <report.json>
 ```
+
+Pass `--grid <COLSxROWS>` only with `--snap-mode grid`. Autoslice orders
+independent regions from top to bottom and left to right, and rejects a
+`--names` count that does not match the detected region count.
 
 ## asset_action_process.py
 

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -57,11 +57,10 @@ guide 用于约束 image generation 的 slot 数量、居中和安全边距。�
 
 必须决定：
 
-1. `--grid <COLSxROWS>`
-2. `--names <comma-separated names>`
-3. 对象已经分离时使用 `--snap-mode autoslice`
-4. 严格 cell 网格使用 `--snap-mode grid`
-5. 紧凑 UI、icon、prop cell 中有零散碎片时使用 `--component-mode largest`
+1. `--names <comma-separated names>`
+2. 独立对象已经分离时使用 `--snap-mode autoslice`
+3. 严格 cell 网格使用 `--snap-mode grid --grid <COLSxROWS>`
+4. 紧凑 UI、icon、prop cell 中有零散碎片时使用 `--component-mode largest`
 
 手动入口：
 
@@ -69,11 +68,13 @@ guide 用于约束 image generation 的 slot 数量、居中和安全边距。�
 python tools/asset_sheet_process.py \
   --source <source.png> \
   --out-dir <curation_dir> \
-  --grid <COLSxROWS> \
   --names <names> \
   --snap-mode <autoslice|grid> \
   --report <report.json>
 ```
+
+只在 `--snap-mode grid` 中传入 `--grid <COLSxROWS>`。Autoslice 按从上到下、
+从左到右输出独立区域；`--names` 数量与检测区域数量不一致时会拒绝语义映射。
 
 ## asset_action_process.py
 

--- a/skills/core/gm-asset/references/production-units/compact-prop-pack.md
+++ b/skills/core/gm-asset/references/production-units/compact-prop-pack.md
@@ -47,16 +47,12 @@ Extract separated props:
 python tools/asset_sheet_process.py \
   --source <prop_source.png> \
   --out-dir <curation_dir> \
-  --grid <COLSxROWS> \
   --names <prop_names> \
   --background magenta \
-  --snap-mode autoslice \
-  --component-mode largest
+  --snap-mode autoslice
 ```
 
-`--grid` is required in both snap modes; in autoslice it sets the cell buckets
-and per-cell names that detected props are assigned to. Match `--grid` and
-`--names` to the prop layout requested in the prompt.
+Match `--names` to the separated props in row-major reading order.
 
 Use `--snap-mode grid` only for deliberate equal-cell prop packs.
 Use the same autoslice path for one-item pickup, collectable, and small-prop

--- a/skills/core/gm-asset/references/production-units/fx-bundle.md
+++ b/skills/core/gm-asset/references/production-units/fx-bundle.md
@@ -66,16 +66,12 @@ Process one-frame foreground effects:
 python tools/asset_sheet_process.py \
   --source <fx_source.png> \
   --out-dir <curation_dir> \
-  --grid <COLSxROWS> \
   --names <effect_names> \
   --background magenta \
-  --snap-mode autoslice \
-  --component-mode largest
+  --snap-mode autoslice
 ```
 
-`--grid` is required in both snap modes; in autoslice it sets the cell buckets
-and per-cell names that detected effects are assigned to. Match `--grid` and
-`--names` to the one-frame effect layout requested in the prompt.
+Match `--names` to the separated effects in row-major reading order.
 
 Select one-frame foreground effects with `tools/asset_curation_select.py`.
 Draft selected one-frame entries with `tools/asset_curation_entry_draft.py`

--- a/skills/core/gm-asset/references/production-units/scene-prop-set.md
+++ b/skills/core/gm-asset/references/production-units/scene-prop-set.md
@@ -51,16 +51,12 @@ Process one-item foreground object sources with autoslice:
 python tools/asset_sheet_process.py \
   --source <object_source.png> \
   --out-dir <curation_dir> \
-  --grid <COLSxROWS> \
   --names <object_names> \
   --background magenta \
-  --snap-mode autoslice \
-  --component-mode largest
+  --snap-mode autoslice
 ```
 
-`--grid` is required in both snap modes; in autoslice it sets the cell buckets
-and per-cell names that detected objects are assigned to. Match `--grid` and
-`--names` to the object layout requested in the prompt.
+Match `--names` to the separated objects in row-major reading order.
 
 Do not use a source image or reference mockup as an independent final prop.
 

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -143,7 +143,7 @@ def test_production_unit_docs_are_first_entry_points():
     assert "## Curation" in runtime
 
 
-def test_production_unit_sheet_process_examples_pass_grid():
+def test_production_unit_autoslice_examples_do_not_pass_grid():
     units = [
         "compact-prop-pack",
         "fx-bundle",
@@ -154,8 +154,9 @@ def test_production_unit_sheet_process_examples_pass_grid():
         for block in doc.split("```"):
             if "python tools/asset_sheet_process.py" not in block:
                 continue
-            assert "--grid" in block, (
-                f"{unit}.md asset_sheet_process example is missing --grid"
+            assert "--snap-mode autoslice" in block
+            assert "--grid" not in block, (
+                f"{unit}.md autoslice example still passes --grid"
             )
 
 

--- a/tests/tools/test_asset_sheet_process.py
+++ b/tests/tools/test_asset_sheet_process.py
@@ -204,14 +204,13 @@ def test_process_sheet_all_component_mode_preserves_stray_fragments(tmp_path):
         candidate.close()
 
 
-def test_process_sheet_autoslice_keeps_cross_cell_object_intact(tmp_path):
+def test_process_sheet_autoslice_extracts_independent_regions_without_grid(tmp_path):
     source = tmp_path / "autoslice_sheet.png"
     make_autoslice_sheet(source)
 
     result = process_sheet(
         source,
         tmp_path / "out",
-        grid="2x1",
         names="wide_button,right_icon",
         asset_id="ui_kit_source",
         snap_mode="autoslice",
@@ -219,6 +218,8 @@ def test_process_sheet_autoslice_keeps_cross_cell_object_intact(tmp_path):
 
     assert result["snap_mode"] == "autoslice"
     assert result["strategy"] == "transparent_autoslice"
+    assert result["grid"] is None
+    assert result["detected_region_count"] == 2
     assert result["accepted_count"] == 2
     wide = result["accepted"][0]
     icon = result["accepted"][1]
@@ -235,6 +236,35 @@ def test_process_sheet_autoslice_keeps_cross_cell_object_intact(tmp_path):
     finally:
         wide_image.close()
         icon_image.close()
+
+
+def test_process_sheet_autoslice_reports_name_count_mismatch_without_outputs(tmp_path):
+    source = tmp_path / "autoslice_sheet.png"
+    make_autoslice_sheet(source)
+    report = tmp_path / "report.json"
+
+    result = process_sheet(
+        source,
+        tmp_path / "out",
+        names="wide_button",
+        asset_id="ui_kit_source",
+        snap_mode="autoslice",
+        report=report,
+    )
+
+    assert result["ok"] is False
+    assert result["status"] == "needs_regeneration"
+    assert result["expected_region_count"] == 1
+    assert result["detected_region_count"] == 2
+    assert result["accepted_count"] == 0
+    assert result["rejected"] == [{
+        "state": "rejected",
+        "reason": "name_count_mismatch",
+        "expected_count": 1,
+        "detected_count": 2,
+    }]
+    assert not list((tmp_path / "out").glob("*.png"))
+    assert json.loads(report.read_text(encoding="utf-8"))["detected_region_count"] == 2
 
 
 def test_process_sheet_removes_edge_connected_magenta_fringe(tmp_path):
@@ -409,8 +439,6 @@ def test_cli_autoslice_outputs_json(tmp_path):
             str(source),
             "--out-dir",
             str(tmp_path / "out"),
-            "--grid",
-            "2x1",
             "--names",
             "wide_button,right_icon",
             "--asset-id",
@@ -431,8 +459,7 @@ def test_cli_autoslice_outputs_json(tmp_path):
     assert data["accepted_count"] == 2
 
 
-@pytest.mark.parametrize("snap_mode", ["autoslice", "grid"])
-def test_cli_requires_grid_in_both_modes(tmp_path, snap_mode):
+def test_cli_requires_grid_in_grid_mode(tmp_path):
     source = tmp_path / "sheet.png"
     make_sheet(source)
 
@@ -447,7 +474,7 @@ def test_cli_requires_grid_in_both_modes(tmp_path, snap_mode):
             "--names",
             "a,b,c,d",
             "--snap-mode",
-            snap_mode,
+            "grid",
         ],
         capture_output=True,
         text=True,
@@ -455,11 +482,10 @@ def test_cli_requires_grid_in_both_modes(tmp_path, snap_mode):
     )
 
     assert result.returncode != 0
-    assert "--grid" in result.stderr
+    assert "--grid" in json.loads(result.stdout)["error"]
 
 
-@pytest.mark.parametrize("snap_mode", ["autoslice", "grid"])
-def test_cli_rejects_malformed_grid_in_both_modes(tmp_path, snap_mode):
+def test_cli_rejects_malformed_grid_in_grid_mode(tmp_path):
     source = tmp_path / "sheet.png"
     make_sheet(source)
 
@@ -474,7 +500,7 @@ def test_cli_rejects_malformed_grid_in_both_modes(tmp_path, snap_mode):
             "--grid",
             "2",
             "--snap-mode",
-            snap_mode,
+            "grid",
         ],
         capture_output=True,
         text=True,
@@ -485,3 +511,31 @@ def test_cli_rejects_malformed_grid_in_both_modes(tmp_path, snap_mode):
     data = json.loads(result.stdout)
     assert data["ok"] is False
     assert "--grid" in data["error"]
+
+
+def test_cli_rejects_grid_in_autoslice_mode(tmp_path):
+    source = tmp_path / "autoslice_sheet.png"
+    make_autoslice_sheet(source)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_sheet_process.py"),
+            "--source",
+            str(source),
+            "--out-dir",
+            str(tmp_path / "out"),
+            "--grid",
+            "2x1",
+            "--snap-mode",
+            "autoslice",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    data = json.loads(result.stdout)
+    assert data["ok"] is False
+    assert "not accepted" in data["error"]

--- a/tools/asset_sheet_process.py
+++ b/tools/asset_sheet_process.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import argparse
-from bisect import bisect_right
 import json
 import math
 import re
@@ -38,17 +37,26 @@ def _parse_grid(value: str) -> tuple[int, int]:
     return cols, rows
 
 
-def _parse_names(value: str | None, total: int) -> list[str]:
+def _parse_name_values(value: str | None) -> list[str] | None:
     if value is None:
-        return [f"{index + 1:02d}" for index in range(total)]
+        return None
     names = [name.strip() for name in value.split(",")]
     if any(not name for name in names):
         raise SheetProcessError("--names cannot contain empty names")
-    if len(names) != total:
-        raise SheetProcessError(f"--names has {len(names)} entries, grid has {total} cells")
     for name in names:
         if not SAFE_NAME_RE.fullmatch(name) or name in {".", ".."}:
             raise SheetProcessError("--names entries must be safe file names")
+    return names
+
+
+def _parse_names(value: str | None, total: int, *, subject: str = "grid cells") -> list[str]:
+    names = _parse_name_values(value)
+    if names is None:
+        return [f"{index + 1:02d}" for index in range(total)]
+    if len(names) != total:
+        raise SheetProcessError(
+            f"--names has {len(names)} entries, detected {subject} has {total} entries"
+        )
     return names
 
 
@@ -258,11 +266,6 @@ def _bbox_touches_margin(
     return left <= margin or top <= margin or right >= width - margin or bottom >= height - margin
 
 
-def _rect_area(rect: tuple[int, int, int, int]) -> int:
-    left, top, right, bottom = rect
-    return max(0, right - left) * max(0, bottom - top)
-
-
 def _rect_has_point(
     rect: tuple[int, int, int, int],
     point: tuple[int, int],
@@ -313,14 +316,6 @@ def _merge_rects(
     )
 
 
-def _union_rects(rects: list[tuple[int, int, int, int]]) -> tuple[int, int, int, int]:
-    left = min(rect[0] for rect in rects)
-    top = min(rect[1] for rect in rects)
-    right = max(rect[2] for rect in rects)
-    bottom = max(rect[3] for rect in rects)
-    return left, top, right, bottom
-
-
 def _autoslice_rects(image) -> list[tuple[int, int, int, int]]:
     alpha = image.getchannel("A")
     pixels = alpha.load()
@@ -360,6 +355,10 @@ def _autoslice_rects(image) -> list[tuple[int, int, int, int]]:
     return rects
 
 
+def _rect_alpha_area(image, rect: tuple[int, int, int, int]) -> int:
+    return sum(image.getchannel("A").crop(rect).histogram()[1:])
+
+
 def _atomic_write_json(path: Path, data: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     with tempfile.NamedTemporaryFile(
@@ -383,7 +382,7 @@ def process_sheet(
     source: Path,
     output_dir: Path,
     *,
-    grid: str,
+    grid: str | None = None,
     snap_mode: str,
     names: str | None = None,
     asset_id: str | None = None,
@@ -402,7 +401,7 @@ def process_sheet(
     preserve_cell_bounds: bool = False,
     report: Path | None = None,
 ) -> dict[str, object]:
-    """Split a production-shaped grid sheet into cropped per-cell PNGs."""
+    """Extract fixed grid cells or independent autoslice regions."""
     try:
         from PIL import Image
     except ImportError as exc:
@@ -417,18 +416,20 @@ def process_sheet(
     if padding < 0:
         raise SheetProcessError("--padding must be zero or positive")
 
-    cols, rows = _parse_grid(grid)
-    total = cols * rows
-    cell_names = _parse_names(names, total)
-
     if background not in {"transparent", "magenta"}:
         raise SheetProcessError("--background must be transparent or magenta")
     if snap_mode not in SNAP_MODES:
         raise SheetProcessError("--snap-mode must be grid or autoslice")
+    if snap_mode == "grid" and grid is None:
+        raise SheetProcessError("--grid is required with --snap-mode grid")
+    if snap_mode == "autoslice" and grid is not None:
+        raise SheetProcessError("--grid is not accepted with --snap-mode autoslice")
     if preserve_cell_bounds and snap_mode != "grid":
         raise SheetProcessError("--preserve-cell-bounds requires --snap-mode grid")
     if component_mode not in COMPONENT_MODES:
         raise SheetProcessError("--component-mode must be all or largest")
+    if snap_mode == "autoslice" and component_mode != "all":
+        raise SheetProcessError("--component-mode is only configurable with --snap-mode grid")
     for name, value in {
         "--component-padding": component_padding,
         "--min-component-area": min_component_area,
@@ -438,6 +439,14 @@ def process_sheet(
     }.items():
         if value is not None and value < 0:
             raise SheetProcessError(f"{name} must be zero or positive")
+
+    cols: int | None = None
+    rows: int | None = None
+    cell_names: list[str] | None = None
+    requested_names = _parse_name_values(names)
+    if snap_mode == "grid":
+        cols, rows = _parse_grid(grid or "")
+        cell_names = _parse_names(names, cols * rows)
 
     image = Image.open(source).convert("RGBA")
     try:
@@ -458,110 +467,98 @@ def process_sheet(
         width, height = image.size
         if not _has_transparent_pixels(image):
             raise SheetProcessError("Source sheet must have transparency after background cleanup")
-        column_edges = [(width * index) // cols for index in range(cols + 1)]
-        row_edges = [(height * index) // rows for index in range(rows + 1)]
-        cell_w = width // cols
-        cell_h = height // rows
+        column_edges: list[int] | None = None
+        row_edges: list[int] | None = None
+        cell_w: int | None = None
+        cell_h: int | None = None
+        if snap_mode == "grid":
+            assert cols is not None and rows is not None
+            column_edges = [(width * index) // cols for index in range(cols + 1)]
+            row_edges = [(height * index) // rows for index in range(rows + 1)]
+            cell_w = width // cols
+            cell_h = height // rows
         output_dir.mkdir(parents=True, exist_ok=True)
 
         accepted: list[dict[str, object]] = []
         rejected: list[dict[str, object]] = []
+        detected_regions: list[dict[str, object]] = []
+        discarded_regions: list[dict[str, object]] = []
+        name_count_mismatch = False
 
         if snap_mode == "autoslice":
-            rects_by_index: dict[int, list[tuple[int, int, int, int]]] = {}
             for rect in _autoslice_rects(image):
-                rect_left, rect_top, rect_right, rect_bottom = rect
-                center_x = (rect_left + rect_right - 1) / 2
-                center_y = (rect_top + rect_bottom - 1) / 2
-                col = min(cols - 1, max(0, bisect_right(column_edges, center_x) - 1))
-                row = min(rows - 1, max(0, bisect_right(row_edges, center_y) - 1))
-                rects_by_index.setdefault(row * cols + col, []).append(rect)
-
-            for index, name in enumerate(cell_names):
-                row, col = divmod(index, cols)
-                left = column_edges[col]
-                top = row_edges[row]
-                right = column_edges[col + 1]
-                bottom = row_edges[row + 1]
-                cell_rects = sorted(
-                    rects_by_index.get(index, []),
-                    key=_rect_area,
-                    reverse=True,
-                )
-                empty_base = {
-                    "name": name,
-                    "candidate_id": f"{asset_id or source.stem}.{name}",
-                    "state": "candidate",
-                    "index": index,
-                    "grid": [col, row],
-                    "source_box": [left, top, right, bottom],
-                    "component_mode": component_mode,
-                    "component_count": 0,
-                    "selected_component_area": None,
-                    "selected_component_bbox": None,
-                }
-                if not cell_rects:
-                    rejected.append({**empty_base, "state": "rejected", "reason": "empty_cell"})
-                    continue
-
-                if component_mode == "largest":
-                    selected_rect = cell_rects[0]
-                    selected_area = _rect_area(selected_rect)
+                alpha_area = _rect_alpha_area(image, rect)
+                region = {"bbox": list(rect), "alpha_area": alpha_area}
+                if alpha_area < min_component_area:
+                    discarded_regions.append({**region, "reason": "below_min_component_area"})
                 else:
-                    selected_rect = _union_rects(cell_rects)
-                    selected_area = sum(_rect_area(rect) for rect in cell_rects)
+                    detected_regions.append(region)
 
-                base = {
-                    "name": name,
-                    "candidate_id": f"{asset_id or source.stem}.{name}",
-                    "state": "candidate",
-                    "index": index,
-                    "grid": [col, row],
-                    "source_box": [left, top, right, bottom],
-                    "component_mode": component_mode,
-                    "component_count": len(cell_rects),
-                    "selected_component_area": selected_area,
-                    "selected_component_bbox": list(selected_rect),
-                }
-                bbox = selected_rect
-                touches_edge = _bbox_touches_margin(
-                    bbox,
-                    width=width,
-                    height=height,
-                    margin=edge_touch_margin,
-                )
-                if touches_edge and reject_edge_touch:
-                    rejected.append({
-                        **base,
-                        "state": "rejected",
-                        "reason": "edge_touch",
-                        "crop_bbox": list(bbox),
-                    })
-                    continue
-
-                crop_bbox = _padded_bbox(
-                    bbox,
-                    width=width,
-                    height=height,
-                    padding=padding if component_padding is None else component_padding,
-                )
-                cropped = image.crop(crop_bbox)
-                path = output_dir / f"{name}.png"
-                cropped.save(path)
-                accepted.append({
-                    **base,
-                    "path": str(path),
-                    "crop_bbox": list(bbox),
-                    "padded_crop_bbox": list(crop_bbox),
-                    "edge_touch": touches_edge,
-                    "trim_border": trim_border,
-                    "edge_clean_depth": edge_clean_depth,
-                    "edge_touch_margin": edge_touch_margin,
-                    "width": cropped.size[0],
-                    "height": cropped.size[1],
+            if requested_names is not None and len(requested_names) != len(detected_regions):
+                name_count_mismatch = True
+                rejected.append({
+                    "state": "rejected",
+                    "reason": "name_count_mismatch",
+                    "expected_count": len(requested_names),
+                    "detected_count": len(detected_regions),
                 })
+            else:
+                region_names = requested_names or [
+                    f"{index + 1:02d}" for index in range(len(detected_regions))
+                ]
+                for index, (name, region) in enumerate(zip(region_names, detected_regions)):
+                    bbox = tuple(region["bbox"])
+                    base = {
+                        "name": name,
+                        "candidate_id": f"{asset_id or source.stem}.{name}",
+                        "state": "candidate",
+                        "index": index,
+                        "grid": None,
+                        "source_box": list(bbox),
+                        "component_mode": "all",
+                        "component_count": 1,
+                        "selected_component_area": region["alpha_area"],
+                        "selected_component_bbox": list(bbox),
+                    }
+                    touches_edge = _bbox_touches_margin(
+                        bbox,
+                        width=width,
+                        height=height,
+                        margin=edge_touch_margin,
+                    )
+                    if touches_edge and reject_edge_touch:
+                        rejected.append({
+                            **base,
+                            "state": "rejected",
+                            "reason": "edge_touch",
+                            "crop_bbox": list(bbox),
+                        })
+                        continue
+
+                    crop_bbox = _padded_bbox(
+                        bbox,
+                        width=width,
+                        height=height,
+                        padding=padding if component_padding is None else component_padding,
+                    )
+                    cropped = image.crop(crop_bbox)
+                    path = output_dir / f"{name}.png"
+                    cropped.save(path)
+                    accepted.append({
+                        **base,
+                        "path": str(path),
+                        "crop_bbox": list(bbox),
+                        "padded_crop_bbox": list(crop_bbox),
+                        "edge_touch": touches_edge,
+                        "trim_border": trim_border,
+                        "edge_clean_depth": edge_clean_depth,
+                        "edge_touch_margin": edge_touch_margin,
+                        "width": cropped.size[0],
+                        "height": cropped.size[1],
+                    })
         else:
-            for index, name in enumerate(cell_names):
+            assert cols is not None and column_edges is not None and row_edges is not None
+            for index, name in enumerate(cell_names or []):
                 row, col = divmod(index, cols)
                 left = column_edges[col]
                 top = row_edges[row]
@@ -644,15 +641,18 @@ def process_sheet(
     else:
         strategy = "solid_background_grid" if background == "magenta" else "transparent_grid"
 
+    autoslice_needs_regeneration = snap_mode == "autoslice" and (
+        name_count_mismatch or bool(rejected) or not accepted
+    )
     result: dict[str, object] = {
         "version": 1,
-        "ok": True,
+        "ok": not autoslice_needs_regeneration,
         "asset_id": asset_id,
         "tag": tag,
         "source": str(source),
         "source_path": str(source),
         "strategy": strategy,
-        "status": "candidate_extracted" if accepted else "needs_regeneration",
+        "status": "needs_regeneration" if autoslice_needs_regeneration or not accepted else "candidate_extracted",
         "background": background,
         "cleanup": cleanup,
         "snap_mode": snap_mode,
@@ -663,9 +663,17 @@ def process_sheet(
         "edge_clean_depth": edge_clean_depth,
         "edge_touch_margin": edge_touch_margin,
         "preserve_cell_bounds": preserve_cell_bounds,
-        "grid": {"cols": cols, "rows": rows},
-        "cell_size": [cell_w, cell_h],
-        "cell_bounds": {"columns": column_edges, "rows": row_edges},
+        "grid": {"cols": cols, "rows": rows} if snap_mode == "grid" else None,
+        "cell_size": [cell_w, cell_h] if snap_mode == "grid" else None,
+        "cell_bounds": (
+            {"columns": column_edges, "rows": row_edges}
+            if snap_mode == "grid"
+            else None
+        ),
+        "expected_region_count": len(requested_names) if requested_names is not None else None,
+        "detected_region_count": len(detected_regions),
+        "detected_regions": detected_regions,
+        "discarded_regions": discarded_regions,
         "candidates": [
             {
                 "candidate_id": f"{asset_id or source.stem}.{item['name']}",
@@ -702,13 +710,8 @@ def _main() -> int:
     parser.add_argument("--out-dir", required=True, help="Output directory")
     parser.add_argument(
         "--grid",
-        required=True,
-        help=(
-            "Grid layout COLSxROWS, e.g. 2x2. Required for both snap modes. "
-            "In grid mode it defines the fixed cells that are cropped. In "
-            "autoslice mode it defines the cell buckets and per-cell naming "
-            "that detected rectangles are assigned to by their center"
-        ),
+        default=None,
+        help="Grid layout COLSxROWS for --snap-mode grid",
     )
     parser.add_argument("--names", default=None, help="Comma-separated output names")
     parser.add_argument("--asset-id", default=None, help="Optional source asset id")
@@ -737,7 +740,7 @@ def _main() -> int:
         "--snap-mode",
         choices=sorted(SNAP_MODES),
         required=True,
-        help="Use fixed grid cells or Godot-style autoslice rectangles",
+        help="Use fixed grid cells or independent Godot-style autoslice regions",
     )
     parser.add_argument(
         "--component-mode",
@@ -811,7 +814,7 @@ def _main() -> int:
         return 1
 
     print(json.dumps(result))
-    return 0
+    return 0 if result.get("ok") else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Separate independent autoslice extraction from fixed-grid sheet processing.

## Motivation

`asset_sheet_process.py --snap-mode autoslice` previously required a grid, bucketed connected regions into those cells, and could union unrelated regions. That made autoslice behave like an unreliable variant of grid processing instead of a true connected-region extractor.

## Changes

- [x] Make autoslice detect and crop independent connected regions without accepting `--grid`.
- [x] Keep `--grid COLSxROWS` required for deterministic fixed-cell extraction.
- [x] Fail closed before writing candidates when supplied names do not match the detected region count.
- [x] Update compact-prop-pack, scene-prop-set, and fx-bundle production-unit guidance and English/Chinese tool documentation.
- [x] Add CLI, extraction, mismatch, and documentation regressions.

The existing fixed-slot atlas assembler remains the separate downstream layout step. This PR intentionally does not include the unfinished ui-kit Theme, compiler, source scheme, recipe, or private Eval work.

## Testing

- [x] New or updated tests pass (`python -m pytest --tb=short`: 2122 passed, 7 skipped)
- [x] Gitleaks passes (`362 commits scanned`, no leaks)
- [x] Pre-push checks pass (`ruff check .` and full pytest)
- [x] Manual CLI behavior is covered by subprocess regression tests

## Benchmark Verification

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

## Version Compatibility

- [x] **No target-project migration needed** - the processing CLI contract changes, but no persisted target-project files or config keys are rewritten.
- [ ] **Yes** - migration script added to `migrations/`

### Migration Upgrade Gate

Not applicable; no migration was added.

## Checklist

- [x] Code follows project conventions
- [x] ECS metadata is not applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
