### PR TITLE
Restore fx-bundle production contract

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -60,6 +60,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - Compact prop packs now generate one provider-authored source sheet, normalize each curated prop into its declared atlas slot, and publish independently addressable AtlasTexture resources with repaired L0-L4 validation.
 
+- FX bundle production now separates static autoslice and animated grid paths, preserves provider reference claims, and promotes runtime entries only after L0-L4 validation.
 - Card-kit Asset Skills now compile only the Theme, scalable frames, and fixed AtlasTexture regions requested by each asset request, preserving reusable Godot resources without requiring a fixed card layout.
 
 - Character-bundle assets now resolve animation cadence internally, preserve optional canonical references and 256px runtime frames, and regenerate retryable source-image failures before stopping.

--- a/skills/assets/_shared/missing_family_standalone_validation.py
+++ b/skills/assets/_shared/missing_family_standalone_validation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from copy import deepcopy
 import json
+import os
 from pathlib import Path
 from typing import Any
 import warnings
@@ -1047,7 +1048,15 @@ def compile_and_validate(
             )
             for output, _ in declarations
         ]
-        report = GodotProbe(godot_path).probe(root, probe_requests)
+        # Eval runners inject a pinned executable through this variable.  Callers
+        # that retained the historical generic ``godot`` placeholder must not
+        # silently bypass that pin and fall back to PATH.
+        resolved_godot_path = (
+            os.environ.get("GM_EVAL_GODOT_PATH")
+            if godot_path == "godot" and os.environ.get("GM_EVAL_GODOT_PATH")
+            else godot_path
+        )
+        report = GodotProbe(resolved_godot_path).probe(root, probe_requests)
         loaded = {item.res_path: item for item in report.resources}
         for output, _ in declarations:
             item = loaded.get(output["path"])

--- a/skills/assets/fx-bundle/SKILL.md
+++ b/skills/assets/fx-bundle/SKILL.md
@@ -115,6 +115,18 @@ STOP condition occurs. Never mark the first failed check as the final result.
    result, and run the request/result handoff checker. L5/L6 visual judgment
    belongs to the private Eval, not this production Skill.
 
+### Godot executable for L3/L4
+
+L3 is a real Godot import/load probe, not a PATH-presence check. When
+`GM_EVAL_GODOT_PATH` is set, it is the pinned executable for this run: pass
+that exact value to `compile_and_validate(..., godot_path=...)` (or leave its
+historical `"godot"` placeholder for the shared validator to resolve). Do not
+replace it with a bare `godot`, discover another installation, or mark L3 as
+passed without invoking it. Outside an Eval, resolve the configured executable
+with `python tools/agent_runtime.py godot_path`; if it is genuinely absent or
+unrunnable, record the diagnostic and STOP only after the production repair
+options are exhausted.
+
 ### Static path
 
 Use `tools/asset_sheet_process.py --snap-mode autoslice` only when every

--- a/skills/assets/fx-bundle/SKILL.md
+++ b/skills/assets/fx-bundle/SKILL.md
@@ -5,91 +5,181 @@ description: Produce a standalone static Texture2D effect or one explicitly time
 
 # FX Bundle
 
-Before choosing an animated effect's exact frame contract, read `.godotmaker/asset-runtime/animation-planning.md`. Use it to turn the requested effect rhythm into a recorded frame plan; its ranges are guidance, not a reason to reject a valid artistic direction.
+Use this Skill for one detached foreground effect: a projectile, impact,
+explosion, pickup, muzzle flash, slash arc, aura loop, or dust effect. It
+delivers either one static `Texture2D` or one animated `SpriteFrames`; it never
+delivers a `PackedScene`, particle node, trail, shader, sound, light, collision
+shape, lifecycle script, or a multi-node effect.
 
-Use this skill for a projectile, impact, explosion, pickup, muzzle flash, slash
-arc, aura loop, dust, or another detached foreground effect. A request produces
-either one static `Texture2D` effect or one independently animated
-`SpriteFrames` effect.
+Read `.godotmaker/asset-runtime/asset-skill-contract.md` before accepting the
+request. For animation rhythm, also read
+`.godotmaker/asset-runtime/animation-planning.md`; it supplies planning ranges,
+not a reason to change an explicit request or reject a valid style.
 
-Read `.godotmaker/asset-runtime/asset-skill-contract.md` before accepting a request. First
-validate the shared request/result shape with
-`tools/asset_skill_contract_check.py`, then validate this family contract with
-`tools/asset_animated_bundle_contract_check.py --kind request`. For final
-runtime handoff, call the same checker with `--request <request.json> --result
-<result.json>`; this is required to bind `spec.mode` to the output type and
-source layout. Final handoff accepts only `validation.passed: true` with
-explicit passing `L0` through `L4` evidence. The family checker is the callable
-enforcement for the `spec` rules below; the shared checker alone intentionally
-validates only cross-family shape.
+Validate the shared request with `tools/asset_skill_contract_check.py`, then
+validate this family with
+`tools/asset_animated_bundle_contract_check.py --kind request`. At final
+handoff, call the latter with `--request <request.json> --result <result.json>`.
+The family checker binds `spec.mode` to the runtime type and source layout.
 
-## Standalone boundary
+## Boundary and STOP
 
-Accept only an asset request. Do not read or require `/gm-asset`, tags, stage
-state, `ASSETS.md`, generated manifests, stable entries, worker dispatch, or
-any other registration state. Return the shared asset result directly; a caller
-may register it separately.
+The request has `asset_type: "fx-bundle"` and `spec.mode` equal to `static` or
+`animated`. References are optional. Pixel-art requests are unsupported in this
+version: stop clearly rather than quantizing, nearest-neighbour scaling, or
+labelling ordinary art as pixel art.
+
+Stop only when a required input is unreadable, a declared provider or required
+reference attachment is objectively unavailable, the request is contradictory,
+or it asks for an unsupported deliverable such as a particle `PackedScene`.
+An image-processing, import, compiler, metadata, path, or validation failure is
+a production diagnostic: repair it and recheck it before deciding to stop.
+
+This is a standalone Skill. Do not require `/gm-asset`, tags, stage state,
+`ASSETS.md`, generated manifests, or worker registration. A caller may register
+the returned ready entry separately.
 
 ## Request contract
 
-The request has `asset_type: "fx-bundle"` and `spec.mode` equal to either
-`static` or `animated`.
+- `static` has no `required_actions` or `actions`. It returns one transparent
+  `Texture2D` at `assets/generated/fx-bundle/<asset_id>/<asset_id>.png` with a
+  `single` source layout.
+- `animated` has exactly one required action and exactly one action with the
+  same name. The action has `grid.columns`, `grid.rows`, non-empty ordered
+  `frame_names`, positive `fps`, explicit boolean `loop`, and one positive
+  relative duration per frame. The grid contains exactly one cell per frame.
+  It returns one `SpriteFrames` resource at
+  `assets/generated/fx-bundle/<asset_id>/<asset_id>.tres` with a `grid_sheet`
+  source layout.
 
-- `static` has one transparent foreground image and no animation contract. It
-  returns a `Texture2D` at the image path.
-- `animated` has `required_actions` containing exactly one name and exactly one
-  action with the same name. The action has non-empty ordered `frame_names`,
-  positive `fps`, an explicit boolean `loop`, and one positive relative duration
-  per frame. Its action name is both required and the sole `SpriteFrames`
-  animation name.
+Never infer timing, frame order, grid, or loop state. Reject duplicates,
+missing frames, non-positive timing, mismatched durations, or mismatched grid
+cell count.
 
-Reject mixed static/animated requests, an animated effect with zero or multiple
-actions, missing frames, duplicate frame names, non-positive FPS or durations,
-or a duration count that differs from the frame count. Never infer timing or
-hard-code loop state.
+## Provider, references, and provenance
 
-## Produce
+1. Read the declared provider guide under
+   `skills/core/gm-asset/references/providers/<provider>.md`. Execute that
+   provider route only; do not silently substitute `native`, `codex`, `gemini`,
+   or `openai`.
+2. With no references, generate from the request's identity, gameplay role,
+   direction, scale, frame count or static target, intended visual style,
+   isolated foreground, solid `#FF00FF` source background, and no text or UI.
+3. With references, validate every referenced path is readable, preserve its
+   role, and attach the actual image to the chosen provider. A pathname in a
+   text prompt is not an attachment. For Codex, resolve each `res://` reference
+   to its actual local readable path and pass those exact paths through
+   `referenced_image_paths`; for the scripted OpenAI/Gemini routes use
+   `asset_source_generate.py` reference inputs. If the selected route cannot
+   attach them, stop rather than dropping or replacing the reference.
+4. For Codex, write a one-item generation plan with `require_provider_trace:
+   true`, then record the actual generated image path, tool-call ID, coding
+   model/reasoning, image-model identity (or
+   `not_exposed_by_subscription_runtime`), reference roles, and resolved
+   attachment paths. Claim that image with
+   `python .godotmaker/asset-runtime/tools/codex_image_claim.py --plan
+   <plan.json> --report <generated-paths.json> --project-root . --out-report
+   <claim.json>`. Never directly copy a Codex image into the project. Missing
+   claim evidence is a STOP.
+5. Write `.godotmaker/asset-generation/traces/<asset_id>.json`. It contains
+   `asset_id`; `provider.requested`, `provider.actual`, and, when applicable,
+   `provider.referenced_image_paths` (the resolved local attachment paths);
+   ordered `references` with the request `role`, `path`, `sha256`, and
+   `attachment`; `artifacts.raw_sources`, `provider_claim`, `process_reports`,
+   `final_frames`, `source_layout`, and `godot_artifact`; and ordered `steps`.
+   Every artifact path is a contained `res://` or project-relative path.
+   Each step records `reason`, `command_or_code`, `inputs`, `outputs`,
+   `modified_files`, `diagnostic`, and `repair`. Project tools are preferred,
+   but a temporary image tool or diagnostic script is allowed when this trace
+   is truthful; its name alone is never a failure.
 
-1. State the effect identity, gameplay role, direction, scale, and either one
-   image or the exact requested animation frame count. Keep the foreground effect
-   separate on a solid `#FF00FF` source background and include no text or UI.
-2. For an animated effect, process the source with
-   `tools/asset_action_process.py` using `kind: fx`, the explicit action name,
-   grid, frame names, FPS, loop flag, and frame durations. Use center alignment
-   for floating effects, projectiles, and detached FX.
-3. Pass the processed frame paths and this public request to
-   `build_spriteframes_spec()` from
-   `tools/asset_animated_bundle_contract_check.py`. Compile that one action
-   through the shared `grid_sheet` to `SpriteFrames` route. Its compiler input
-   has `required_actions` plus the action `name`, `fps`, `loop`, `frame_paths`,
-   and `frame_durations`. Validate L0-L4, including headless Godot load and L4
-   frame order, texture bindings, FPS, loop, and durations. Use
-   `standalone_validation.compile_and_validate()` to perform that work; it
-   derives stable processed frame paths using `<asset_id>_<action>_<frame>.png`
-   and overwrites any supplied validation assertion.
-4. For a static effect, process/select exactly one transparent foreground PNG
-   and publish it through the shared `single` to `Texture2D` route. Validate
-   its L0-L4 texture evidence.
+References influence scale, direction, palette, and visual style. Do not claim
+they were attached or validated unless the provider trace proves it.
 
-Do not use a source sheet as the runtime effect. Do not generate a
-`PackedScene`, particle node, shader, sound, light, or lifecycle script. Those
-are consumer responsibilities; this skill supplies only a texture or
-SpriteFrames resource.
+## Production loop
 
-## Results
+Work in the following loop until every applicable L0-L4 check passes or a real
+STOP condition occurs. Never mark the first failed check as the final result.
 
-An animated result has one `SpriteFrames` runtime output:
+1. Generate and preserve a raw source image. Keep the foreground on a solid
+   `#FF00FF` background before deterministic cleanup, with no text or UI.
+2. Choose the static or animated path below. Keep raw sheets, final PNGs,
+   reports, source layout, stable entry, and Godot artifact in the trace.
+3. Construct the shared asset result and run
+   `standalone_validation.compile_and_validate()` for the applicable L0-L4
+   checks. Read the diagnostic, then repair source art, processing parameters,
+   metadata, paths, or Godot artifact and rerun the checks.
+4. The entry builders below write `processing_status: compiled`. Only after all
+   applicable L0-L4 levels pass, promote that same stable entry to
+   `processing_status: ready`, set `validation.passed: true`, write the final
+   result, and run the request/result handoff checker. L5/L6 visual judgment
+   belongs to the private Eval, not this production Skill.
 
-```json
-{
-  "asset_type": "fx-bundle",
-  "outputs": [{ "role": "runtime", "name": "impact", "path": "res://assets/generated/fx-bundle/impact/impact.tres", "godot_type": "SpriteFrames" }],
-  "sources": [{ "path": "res://assets/generated/fx-bundle/impact/impact_sheet.png", "layout": "grid_sheet" }],
-  "previews": [],
-  "validation": { "passed": true, "levels": { "L0": true, "L1": true, "L2": true, "L3": true, "L4": true } }
-}
+### Static path
+
+Use `tools/asset_sheet_process.py --snap-mode autoslice` only when every
+disconnected foreground component is itself one logical effect. Do not supply
+`--grid` to autoslice. Follow it with curation and
+`tools/asset_curation_select.py`; selection invokes
+`asset_image_finalize.py` for transparent cleanup, aspect-preserving scaling,
+centering, and padding before the stable PNG is published.
+
+If disconnected sparks, fragments, glow, or dust semantically form one effect,
+preserve the whole composition instead. Use an explicit one-cell/grid curation
+route or finalize the full source deterministically; do not let autoslice split
+one effect into unrelated runtime assets. If autoslice `--names` does not match
+the detected regions it returns `needs_regeneration` without partial output.
+Treat that as a repair diagnostic: regenerate or relayout the source, or correct
+the intended naming; never drop regions or silently assemble a different effect.
+
+After selecting one candidate at the stable PNG path, write its compiler-bound
+entry with:
+
+```bash
+python tools/asset_curation_entry_draft.py \
+  --report <curation-report.json> \
+  --candidate <candidate> \
+  --request <request.json> \
+  --asset-id <asset_id> \
+  --tag <tag> \
+  --production-family fx-bundle \
+  --project-root <project_root> \
+  --out <entry.json>
 ```
 
-A static result has one `Texture2D` runtime output whose path is the selected
-single image and whose source layout is `single`. Set `validation.passed` only
-from the standalone runner after the applicable L0-L4 checks pass.
+This produces the `single -> Texture2D` compiled entry. Do not promote or hand
+it to a worker until the production loop's L0-L4 validation has passed.
+
+### Animated path
+
+Use `tools/asset_action_process.py` with `--kind fx`, the declared explicit
+grid, ordered frame names, action name, FPS, loop flag, durations, magenta
+cleanup, and `--align center`. Preserve raw sheet, processed transparent frames,
+delivery sheet, GIF preview, processing report, and action metadata. Animation
+never uses autoslice or an atlas assembler. Publish each processed frame at
+`assets/generated/fx-bundle/<asset_id>/<asset_id>_<action>_<frame>.png`; this is
+the canonical frame path consumed by the L0-L4 SpriteFrames validation route.
+
+Compile its one action through the shared `grid_sheet -> SpriteFrames` route:
+
+```bash
+python tools/asset_action_entry_draft.py \
+  --metadata <pipeline-meta.json> \
+  --request <request.json> \
+  --asset-id <asset_id> \
+  --tag <tag> \
+  --production-family fx-bundle \
+  --project-root <project_root> \
+  --out <entry.json>
+```
+
+The builder verifies frame order, grid, timing, loop state, center alignment,
+stable paths, and compiles exactly one `SpriteFrames` resource into a compiled
+entry. The production loop promotes it only after L0-L4 pass.
+
+## Result shape
+
+An animated result has one `SpriteFrames` runtime output and one stable
+`grid_sheet` source. A static result has one `Texture2D` runtime output at the
+same stable PNG path as its `single` source. Both final results include explicit
+passing `L0` through `L4` evidence; no other runtime Godot type is valid.

--- a/skills/assets/fx-bundle/SKILL.md
+++ b/skills/assets/fx-bundle/SKILL.md
@@ -58,10 +58,11 @@ cell count.
 
 ## Provider, references, and provenance
 
-1. Read the declared provider guide under
-   `skills/core/gm-asset/references/providers/<provider>.md`. Execute that
-   provider route only; do not silently substitute `native`, `codex`, `gemini`,
-   or `openai`.
+1. Read the declared provider guide at
+   `.godotmaker/asset-runtime/references/providers/<provider>.md`. The runtime
+   installs this guide from the shared `gm-asset` provider contract. Execute
+   that provider route only; do not silently substitute `native`, `codex`,
+   `gemini`, or `openai`.
 2. With no references, generate from the request's identity, gameplay role,
    direction, scale, frame count or static target, intended visual style,
    isolated foreground, solid `#FF00FF` source background, and no text or UI.
@@ -83,15 +84,25 @@ cell count.
    claim evidence is a STOP.
 5. Write `.godotmaker/asset-generation/traces/<asset_id>.json`. It contains
    `asset_id`; `provider.requested`, `provider.actual`, and, when applicable,
-   `provider.referenced_image_paths` (the resolved local attachment paths);
-   ordered `references` with the request `role`, `path`, `sha256`, and
-   `attachment`; `artifacts.raw_sources`, `provider_claim`, `process_reports`,
-   `final_frames`, `source_layout`, and `godot_artifact`; and ordered `steps`.
-   Every artifact path is a contained `res://` or project-relative path.
+   `provider.referenced_image_paths` as the exact absolute local paths passed to
+   the image-provider call; ordered `references` with the request `role`,
+   `res://` `path`, `sha256`, and literal
+   `attachment: "referenced_image_paths"`; `artifacts.raw_sources`,
+   `provider_claim`, `process_reports`, `final_frames`, `source_layout`, and
+   `godot_artifact`; and ordered `steps`. `source_layout` and
+   `godot_artifact` are objects with exactly `type` and `path`: animated FX
+   uses `{ "type": "grid_sheet", "path": "res://..._sheet.png" }` and
+   `{ "type": "SpriteFrames", "path": "res://....tres" }`; static FX uses
+   `{ "type": "single", "path": "res://....png" }` and
+   `{ "type": "Texture2D", "path": "res://....png" }`. Every artifact path
+   is a contained `res://` or project-relative path.
    Each step records `reason`, `command_or_code`, `inputs`, `outputs`,
    `modified_files`, `diagnostic`, and `repair`. Project tools are preferred,
    but a temporary image tool or diagnostic script is allowed when this trace
-   is truthful; its name alone is never a failure.
+   is truthful; its name alone is never a failure. When a temporary script is
+   created, list that script's exact path in the same step's `modified_files`
+   as well as the generated assets it changes; do not omit the script merely
+   because it is an implementation detail.
 
 References influence scale, direction, palette, and visual style. Do not claim
 they were attached or validated unless the provider trace proves it.
@@ -112,8 +123,10 @@ STOP condition occurs. Never mark the first failed check as the final result.
 4. The entry builders below write `processing_status: compiled`. Only after all
    applicable L0-L4 levels pass, promote that same stable entry to
    `processing_status: ready`, set `validation.passed: true`, write the final
-   result, and run the request/result handoff checker. L5/L6 visual judgment
-   belongs to the private Eval, not this production Skill.
+   result, and run the request/result handoff checker. Then write that same
+   generic result object to `ASSET_RESULT.json` in the project root and return
+   only its JSON contents: no Markdown links, prose, or alternate result shape.
+   L5/L6 visual judgment belongs to the private Eval, not this production Skill.
 
 ### Godot executable for L3/L4
 
@@ -171,6 +184,13 @@ delivery sheet, GIF preview, processing report, and action metadata. Animation
 never uses autoslice or an atlas assembler. Publish each processed frame at
 `assets/generated/fx-bundle/<asset_id>/<asset_id>_<action>_<frame>.png`; this is
 the canonical frame path consumed by the L0-L4 SpriteFrames validation route.
+Pass `--final-dir assets/generated/fx-bundle/<asset_id>` and
+`--final-prefix <asset_id>_<action>` and `--final-sheet-name
+<asset_id>_sheet.png` to the action processor. Do not use only `<asset_id>` as
+the final prefix: each declared `frame_name` already carries its own ordered
+frame label, so omitting the action prefix changes the stable runtime path. The
+separate final sheet name preserves the one stable source-layout path consumed
+by the SpriteFrames entry compiler.
 
 Compile its one action through the shared `grid_sheet -> SpriteFrames` route:
 
@@ -195,3 +215,25 @@ An animated result has one `SpriteFrames` runtime output and one stable
 `grid_sheet` source. A static result has one `Texture2D` runtime output at the
 same stable PNG path as its `single` source. Both final results include explicit
 passing `L0` through `L4` evidence; no other runtime Godot type is valid.
+`ASSET_RESULT.json` is the final machine-readable handoff, not a report link or
+a summary of another JSON file.
+
+### Trace finalization
+
+Before writing `ASSET_RESULT.json`, reread the emitted trace and validate its
+own paths against the files on disk. `source_layout` and `godot_artifact` live
+inside `trace.artifacts`, never at the trace root. For an animation,
+`trace.artifacts.final_frames` is the exact ordered list from the action
+processor's recorded final-frame paths; do not reconstruct or edit these names
+by string concatenation. Reject and repair the trace if a listed frame is
+missing, the count differs from the request, a field is outside `artifacts`, or
+the layout/artifact `type` and `path` do not match the final result.
+
+```json
+{
+  "artifacts": {
+    "source_layout": { "type": "grid_sheet", "path": "res://assets/generated/fx-bundle/<asset_id>/<asset_id>_sheet.png" },
+    "godot_artifact": { "type": "SpriteFrames", "path": "res://assets/generated/fx-bundle/<asset_id>/<asset_id>.tres" }
+  }
+}
+```

--- a/skills/assets/fx-bundle/fixtures/animated-request.json
+++ b/skills/assets/fx-bundle/fixtures/animated-request.json
@@ -9,6 +9,7 @@
     "actions": [
       {
         "name": "impact",
+        "grid": { "columns": 3, "rows": 1 },
         "frame_names": ["impact_01", "impact_02", "impact_03"],
         "fps": 14,
         "loop": false,

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -88,7 +88,7 @@ Use `references/asset-planner.md` for production-unit selection.
 | --- | --- |
 | `screen-reference` | First-class `screen-reference` Asset Skill |
 | `character-bundle` | First-class `character-bundle` Asset Skill |
-| `fx-bundle` | `references/production-units/fx-bundle.md` |
+| `fx-bundle` | First-class `fx-bundle` Asset Skill |
 | `ui-kit` | First-class `ui-kit` Asset Skill |
 | `card-kit` | First-class `card-kit` Asset Skill |
 | `compact-prop-pack` | First-class `compact-prop-pack` Asset Skill |
@@ -171,6 +171,7 @@ never substitute a deleted production-unit document:
 | --- | --- |
 | `background-map` | First-class Asset Skill: `background-map` |
 | `character-bundle` | First-class Asset Skill: `character-bundle` |
+| `fx-bundle` | First-class Asset Skill: `fx-bundle` |
 | `platform-strip` | First-class Asset Skill: `platform-strip` |
 | `screen-reference` | First-class Asset Skill: `screen-reference` |
 | `ui-kit` | First-class Asset Skill: `ui-kit` |
@@ -188,7 +189,8 @@ Brief shape:
 
 ### Production Contract
 - Legacy unit: First Entry Document: {references/production-units/<unit>.md}
-- First-class unit: First-class Asset Skill: {background-map | character-bundle | platform-strip | screen-reference | ui-kit | card-kit | compact-prop-pack | scene-prop-set}
+- First-class unit: First-class Asset Skill: {background-map | character-bundle | fx-bundle | platform-strip | screen-reference | ui-kit | card-kit | compact-prop-pack}
+  | scene-prop-set}
 - For a first-class unit, invoke that named Skill with one shared generic asset
   request. Do not read a production-unit path for that family.
 
@@ -205,6 +207,11 @@ Brief shape:
 - For `compact-prop-pack`, pass the request and fully validated result to
   `tools/asset_compact_prop_pack_entry_draft.py`. It writes one ready logical
   entry draft per AtlasTexture while retaining the shared physical bundle path.
+- For `fx-bundle`, use `tools/asset_curation_entry_draft.py` request mode for a
+   static `single -> Texture2D` result, or `tools/asset_action_entry_draft.py`
+   request mode for its one animated `grid_sheet -> SpriteFrames` result. Both
+   start compiled; pass a ready entry onward only after the Skill's L0-L4
+   production loop succeeds.
 - For `scene-prop-set`, pass the original request, successful result, and first
   declared logical prop to `tools/asset_scene_prop_set_entry_draft.py` before
   writing its ready draft. The builder binds metadata geometry to the request.

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -84,7 +84,7 @@ user explicitly requested generated image assets.
 | --- | --- |
 | `screen-reference` | First-class `screen-reference` Asset Skill |
 | `character-bundle` | First-class `character-bundle` Asset Skill |
-| `fx-bundle` | `references/production-units/fx-bundle.md` |
+| `fx-bundle` | First-class `fx-bundle` Asset Skill |
 | `ui-kit` | First-class `ui-kit` Asset Skill |
 | `card-kit` | First-class `card-kit` Asset Skill |
 | `compact-prop-pack` | First-class `compact-prop-pack` Asset Skill |

--- a/skills/core/gm-asset/references/production-units/fx-bundle.md
+++ b/skills/core/gm-asset/references/production-units/fx-bundle.md
@@ -17,8 +17,10 @@ flashes, slash arcs, aura loops, dust, and detached effects.
 3. Generate the source through the provider doc.
 4. Process action sources with `tools/asset_action_process.py` using
    `kind: fx`.
-5. Process single projectiles, pickups, and one-frame effects with
-   `tools/asset_sheet_process.py --snap-mode autoslice`.
+5. For a single effect, use `tools/asset_sheet_process.py --snap-mode autoslice`
+   only when every disconnected component is an independent logical effect.
+   Preserve semantically collective sparks, fragments, and glow as one full
+   composition through an explicit one-cell route or deterministic finalize.
 6. Use action metadata for animated frames or delivery sheets.
 7. Use selected transparent PNGs for one-frame foreground effects.
 8. Write stable entry drafts.
@@ -73,14 +75,13 @@ python tools/asset_sheet_process.py \
 
 Match `--names` to the separated effects in row-major reading order.
 
-Select one-frame foreground effects with `tools/asset_curation_select.py`.
-Draft selected one-frame entries with `tools/asset_curation_entry_draft.py`
-(`--production-family fx-bundle --source-layout single`).
-Draft animated FX entries with `tools/asset_action_entry_draft.py`
-(`--production-family fx-bundle`), which writes `source_layout.type: grid_sheet`.
-Both stop at `processing_status: source_ready` with no `godot_artifact`; each
-animated FX action supplies explicit FPS, loop state, frame order, and relative
-frame durations to one SpriteFrames compile.
+Select one-frame foreground effects with `tools/asset_curation_select.py`, then
+use `tools/asset_curation_entry_draft.py --request <request.json>` for its compiler-
+bound `single -> Texture2D` compiled entry. Draft animated FX entries with
+`tools/asset_action_entry_draft.py --request <request.json>`; it writes one compiled
+`grid_sheet -> SpriteFrames` entry from the explicit grid, FPS, loop state,
+frame order, and relative frame durations. The FX Skill runs L0-L4 and repairs
+diagnostics before worker handoff.
 Do not use a source sheet as an independent final effect.
 
 ## Outputs

--- a/tests/assets/test_animated_bundle_skill_contracts.py
+++ b/tests/assets/test_animated_bundle_skill_contracts.py
@@ -203,6 +203,8 @@ def test_fx_fixture_reaches_the_real_spriteframes_compiler_through_public_handof
         pytest.param(lambda d: d["spec"].update(required_actions=["impact", "flash"]), id="multiple-required-actions"),
         pytest.param(lambda d: d["spec"]["actions"].append(copy.deepcopy(d["spec"]["actions"][0])), id="multiple-actions"),
         pytest.param(lambda d: d["spec"]["actions"][0].update(name="flash"), id="mismatched-action-name"),
+        pytest.param(lambda d: d["spec"]["actions"][0].pop("grid"), id="missing-grid"),
+        pytest.param(lambda d: d["spec"]["actions"][0].update(grid={"columns": 2, "rows": 1}), id="grid-frame-mismatch"),
         pytest.param(lambda d: d["spec"]["actions"][0].update(frame_names=[]), id="missing-frames"),
         pytest.param(lambda d: d["spec"]["actions"][0].update(frame_names=["impact", "impact"]), id="duplicate-frame-name"),
         pytest.param(lambda d: d["spec"]["actions"][0].update(fps=0), id="non-positive-fps"),
@@ -230,6 +232,17 @@ def test_static_fx_rejects_animation_fields_and_keeps_its_texture_result_boundar
     request["spec"]["actions"] = []
     with pytest.raises(AnimatedBundleContractError, match="not allowed for a static"):
         check_bundle_request(request)
+
+
+def test_fx_skill_keeps_static_autoslice_and_animated_grid_paths_separate():
+    skill = (REPO_ROOT / "skills/assets/fx-bundle/SKILL.md").read_text(encoding="utf-8")
+
+    assert "--snap-mode autoslice" in skill
+    assert "Do not supply\n`--grid` to autoslice" in skill
+    assert "semantically form one effect" in skill
+    assert "needs_regeneration" in skill
+    assert "Animation\nnever uses autoslice" in skill
+    assert "--align center" in skill
 
 
 @pytest.mark.parametrize(

--- a/tests/assets/test_animated_bundle_skill_contracts.py
+++ b/tests/assets/test_animated_bundle_skill_contracts.py
@@ -243,6 +243,14 @@ def test_fx_skill_keeps_static_autoslice_and_animated_grid_paths_separate():
     assert "needs_regeneration" in skill
     assert "Animation\nnever uses autoslice" in skill
     assert "--align center" in skill
+    assert "--final-prefix <asset_id>_<action>" in skill
+    assert "list that script's exact path in the same step's `modified_files`" in skill
+    assert "ASSET_RESULT.json" in skill
+    assert 'attachment: \"referenced_image_paths\"' in skill
+    assert "source_layout` and\n   `godot_artifact` are objects with exactly `type` and `path`" in skill
+    assert ".godotmaker/asset-runtime/references/providers/<provider>.md" in skill
+    assert "source_layout` and `godot_artifact` live\ninside `trace.artifacts`" in skill
+    assert "do not reconstruct or edit these names\nby string concatenation" in skill
 
 
 @pytest.mark.parametrize(

--- a/tests/assets/test_fx_bundle_processing_paths.py
+++ b/tests/assets/test_fx_bundle_processing_paths.py
@@ -1,4 +1,5 @@
 """FX-specific regression coverage for static and animated processing routes."""
+import json
 from pathlib import Path
 import sys
 
@@ -9,6 +10,7 @@ TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
 
 from asset_action_process import process_action_sheet  # noqa: E402
+from asset_action_entry_draft import build_fx_bundle_entry_draft  # noqa: E402
 from asset_sheet_process import process_sheet  # noqa: E402
 
 
@@ -120,6 +122,7 @@ def test_fx_animation_uses_explicit_grid_and_centered_action_frames(tmp_path):
         align="center",
         final_dir=final_dir,
         final_prefix="forge-impact_impact",
+        final_sheet_name="forge-impact_sheet.png",
     )
 
     assert result["grid"] == {"cols": 2, "rows": 2}
@@ -131,3 +134,40 @@ def test_fx_animation_uses_explicit_grid_and_centered_action_frames(tmp_path):
         "forge-impact_impact_impact_03.png",
         "forge-impact_impact_impact_04.png",
     ]
+    assert Path(result["final_sheet_path"]).name == "forge-impact_sheet.png"
+
+    request = {
+        "asset_type": "fx-bundle",
+        "asset_id": "forge-impact",
+        "brief": "A centered four-frame impact.",
+        "provider": "codex",
+        "spec": {
+            "mode": "animated",
+            "required_actions": ["impact"],
+            "actions": [{
+                "name": "impact",
+                "grid": {"columns": 2, "rows": 2},
+                "frame_names": ["impact_01", "impact_02", "impact_03", "impact_04"],
+                "fps": 16,
+                "loop": False,
+                "frame_durations": [1, 1, 1, 2],
+            }],
+        },
+    }
+    request_path = tmp_path / "ASSET_REQUEST.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    metadata_path = tmp_path / "work" / "fx-pipeline-meta.json"
+    metadata_path.write_text(json.dumps(result), encoding="utf-8")
+
+    built = build_fx_bundle_entry_draft(
+        metadata_path,
+        request_path=request_path,
+        asset_id="forge-impact",
+        tag="v0.1.0",
+        project_root=tmp_path,
+    )
+
+    assert built["entry"]["source_layout"]["path"] == (
+        "res://assets/generated/fx-bundle/forge-impact/forge-impact_sheet.png"
+    )
+    assert (final_dir / "forge-impact.tres").is_file()

--- a/tests/assets/test_fx_bundle_processing_paths.py
+++ b/tests/assets/test_fx_bundle_processing_paths.py
@@ -1,0 +1,133 @@
+"""FX-specific regression coverage for static and animated processing routes."""
+from pathlib import Path
+import sys
+
+from PIL import Image, ImageDraw
+
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_action_process import process_action_sheet  # noqa: E402
+from asset_sheet_process import process_sheet  # noqa: E402
+
+
+def _static_components(path: Path) -> None:
+    image = Image.new("RGBA", (32, 16), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((2, 2, 9, 10), fill=(255, 160, 32, 255))
+    draw.rectangle((23, 4, 27, 8), fill=(255, 224, 96, 255))
+    image.save(path)
+
+
+def _single_static(path: Path) -> None:
+    image = Image.new("RGBA", (32, 16), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(image)
+    draw.polygon(((4, 12), (12, 2), (20, 12), (12, 10)), fill=(255, 160, 32, 255))
+    image.save(path)
+
+
+def _action_sheet(path: Path) -> None:
+    image = Image.new("RGBA", (80, 80), (255, 0, 255, 255))
+    draw = ImageDraw.Draw(image)
+    for box in ((10, 8, 30, 36), (52, 10, 68, 34), (8, 48, 32, 72), (50, 50, 70, 74)):
+        draw.rectangle(box, fill=(40, 120, 230, 255))
+    image.save(path)
+
+
+def _visible_colors(path: Path) -> set[tuple[int, int, int]]:
+    with Image.open(path).convert("RGBA") as image:
+        pixels = image.tobytes()
+    return {
+        (pixels[index], pixels[index + 1], pixels[index + 2])
+        for index in range(0, len(pixels), 4)
+        if pixels[index + 3] > 0
+    }
+
+
+def test_fx_static_autoslice_extracts_one_independent_effect(tmp_path):
+    source = tmp_path / "static.png"
+    _single_static(source)
+
+    result = process_sheet(
+        source,
+        tmp_path / "out",
+        names="flare",
+        asset_id="sun_pollen",
+        snap_mode="autoslice",
+    )
+
+    assert result["snap_mode"] == "autoslice"
+    assert result["grid"] is None
+    assert result["accepted_count"] == 1
+
+
+def test_fx_static_collective_components_stay_in_one_grid_cell(tmp_path):
+    source = tmp_path / "collective.png"
+    _static_components(source)
+
+    result = process_sheet(
+        source,
+        tmp_path / "out",
+        grid="1x1",
+        names="sun_pollen_flare",
+        asset_id="sun_pollen",
+        snap_mode="grid",
+        component_mode="all",
+        min_component_area=1,
+    )
+
+    assert result["accepted_count"] == 1
+    assert result["accepted"][0]["component_count"] == 2
+    assert _visible_colors(tmp_path / "out" / "sun_pollen_flare.png") == {
+        (255, 160, 32), (255, 224, 96),
+    }
+
+
+def test_fx_static_autoslice_name_mismatch_is_a_repair_diagnostic(tmp_path):
+    source = tmp_path / "static.png"
+    _static_components(source)
+
+    result = process_sheet(
+        source,
+        tmp_path / "out",
+        names="only_one_name",
+        asset_id="sun_pollen",
+        snap_mode="autoslice",
+    )
+
+    assert result["status"] == "needs_regeneration"
+    assert result["accepted_count"] == 0
+    assert not list((tmp_path / "out").glob("*.png"))
+
+
+def test_fx_animation_uses_explicit_grid_and_centered_action_frames(tmp_path):
+    source = tmp_path / "impact-source.png"
+    _action_sheet(source)
+    final_dir = tmp_path / "assets" / "generated" / "fx-bundle" / "forge-impact"
+
+    result = process_action_sheet(
+        source,
+        tmp_path / "work",
+        grid="2x2",
+        names="impact_01,impact_02,impact_03,impact_04",
+        asset_id="forge-impact",
+        tag="v0.1.0",
+        action_name="impact",
+        fps=16,
+        loop=False,
+        frame_durations=[1, 1, 1, 2],
+        align="center",
+        final_dir=final_dir,
+        final_prefix="forge-impact_impact",
+    )
+
+    assert result["grid"] == {"cols": 2, "rows": 2}
+    assert result["align"] == "center"
+    assert result["frame_labels"] == ["impact_01", "impact_02", "impact_03", "impact_04"]
+    assert [Path(frame).name for frame in result["final_frame_paths"]] == [
+        "forge-impact_impact_impact_01.png",
+        "forge-impact_impact_impact_02.png",
+        "forge-impact_impact_impact_03.png",
+        "forge-impact_impact_impact_04.png",
+    ]

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -602,6 +602,44 @@ def test_background_executes_l2_to_l4_with_a_real_png_and_probe(monkeypatch, tmp
     }
 
 
+def test_standalone_validation_prefers_the_pinned_eval_godot(monkeypatch, tmp_path):
+    source = tmp_path / "assets/generated/background-map/sky/sky.png"
+    source.parent.mkdir(parents=True)
+    Image.new("RGBA", (2, 3), (1, 2, 3, 255)).save(source)
+    seen_paths: list[str] = []
+
+    class Probe:
+        def __init__(self, path):
+            seen_paths.append(path)
+
+        def probe(self, _root, requests):
+            return ProbeReport(
+                "pinned-eval-godot",
+                (
+                    ProbeResult(
+                        requests[0].res_path,
+                        "Texture2D",
+                        True,
+                        "CompressedTexture2D",
+                        True,
+                        structure={"texture2d": {"width": 2, "height": 3}},
+                    ),
+                ),
+            )
+
+    monkeypatch.setenv("GM_EVAL_GODOT_PATH", "pinned-eval-godot")
+    monkeypatch.setattr(runner, "GodotProbe", Probe)
+    actual = compile_and_validate(
+        {"asset_type": "background-map", "asset_id": "sky", "brief": "A blue sky."},
+        _background_result(),
+        project_root=tmp_path,
+        godot_path="godot",
+    )
+
+    assert seen_paths == ["pinned-eval-godot"]
+    assert actual["validation"]["passed"] is True
+
+
 @pytest.mark.parametrize("source", [None, 5], ids=["missing", "wrong-type"])
 def test_prop_slot_errors_fail_closed_at_l0(tmp_path, source):
     slot = {"name": "coin", "rect": [0, 0, 1, 1]}

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -126,13 +126,6 @@ def test_production_unit_docs_are_first_entry_points():
     planner = _read("skills/core/gm-asset/references/asset-planner.md")
     runtime = _read("skills/core/gm-asset/references/asset-runtime-pipeline.md")
 
-    units = ["fx-bundle"]
-    for unit in units:
-        path = f"skills/core/gm-asset/references/production-units/{unit}.md"
-        assert (REPO_ROOT / path).exists(), f"missing production unit: {unit}"
-        assert f"references/production-units/{unit}.md" in skill
-        assert f"`{unit}`" in planner
-
     compact = _read("skills/assets/compact-prop-pack/SKILL.md")
     assert not (
         REPO_ROOT / "skills/core/gm-asset/references/production-units/compact-prop-pack.md"
@@ -140,6 +133,8 @@ def test_production_unit_docs_are_first_entry_points():
     assert "First-class `compact-prop-pack` Asset Skill" in skill
     assert "First-class `compact-prop-pack` Asset Skill" in planner
     assert "one provider source sheet" in compact
+    assert "| `fx-bundle` | First-class `fx-bundle` Asset Skill |" in planner
+    assert "references/production-units/fx-bundle.md" not in planner
 
     assert "## Production Families" in runtime
     assert "## Source Layouts" in runtime

--- a/tests/tools/test_asset_action_entry_draft.py
+++ b/tests/tools/test_asset_action_entry_draft.py
@@ -13,7 +13,9 @@ from asset_action_entry_draft import (  # noqa: E402
     ActionEntryDraftError,
     build_action_entry_draft,
     build_character_bundle_entry_draft,
+    build_fx_bundle_entry_draft,
     write_action_entry_draft,
+    write_fx_bundle_entry_draft,
 )
 from asset_stable_entry import stable_output_dir, validate_entry  # noqa: E402
 
@@ -543,3 +545,125 @@ def test_character_bundle_entry_requires_an_unchecked_scale_root(tmp_path):
             tag=TAG,
             project_root=tmp_path,
         )
+
+
+def _fx_bundle_inputs(tmp_path):
+    asset_id = "arc_blast"
+    root = stable_dir(asset_id, "fx-bundle")
+    request = {
+        "asset_type": "fx-bundle",
+        "asset_id": asset_id,
+        "brief": "A centered three-frame arc blast.",
+        "provider": "codex",
+        "spec": {
+            "mode": "animated",
+            "required_actions": ["blast"],
+            "actions": [{
+                "name": "blast",
+                "grid": {"columns": 3, "rows": 1},
+                "frame_names": ["blast_01", "blast_02", "blast_03"],
+                "fps": 12,
+                "loop": False,
+                "frame_durations": [1, 2, 1],
+            }],
+        },
+    }
+    request_path = tmp_path / "ASSET_REQUEST.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    metadata = {
+        "frame_count": 3,
+        "final_sheet_path": f"{root}/{asset_id}_sheet.png",
+        "final_frame_paths": [
+            f"{root}/{asset_id}_blast_{frame}.png"
+            for frame in request["spec"]["actions"][0]["frame_names"]
+        ],
+        "align": "center",
+        "shared_scale": True,
+        "action_name": "blast",
+        "fps": 12,
+        "loop": False,
+        "frame_durations": [1, 2, 1],
+        "edge_touch_frames": [],
+        "scale_reference": {"checked": False},
+        "cell_size": 256,
+        "grid": {"cols": 3, "rows": 1},
+        "frame_labels": ["blast_01", "blast_02", "blast_03"],
+    }
+    for relative in [metadata["final_sheet_path"], *metadata["final_frame_paths"]]:
+        path = tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        Image.new("RGBA", (8, 8), (255, 255, 255, 128)).save(path)
+    metadata_path = tmp_path / ".godotmaker/asset-generation/work/blast/pipeline-meta.json"
+    metadata_path.parent.mkdir(parents=True, exist_ok=True)
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+    return asset_id, root, request_path, metadata_path
+
+
+def test_fx_bundle_entry_compiles_exactly_one_explicit_action(tmp_path):
+    asset_id, root, request_path, metadata_path = _fx_bundle_inputs(tmp_path)
+
+    built = build_fx_bundle_entry_draft(
+        metadata_path,
+        request_path=request_path,
+        asset_id=asset_id,
+        tag=TAG,
+        project_root=tmp_path,
+    )
+
+    assert built["entry"]["processing_status"] == "compiled"
+    assert built["entry"]["godot_artifact"] == {
+        "type": "SpriteFrames", "path": f"res://{root}/{asset_id}.tres"
+    }
+    assert (tmp_path / root / f"{asset_id}.tres").is_file()
+    assert built["support"]["action"]["frame_labels"] == [
+        "blast_01", "blast_02", "blast_03"
+    ]
+    assert built["support"]["action"]["frame_paths"] == [
+        f"res://{root}/{asset_id}_blast_blast_01.png",
+        f"res://{root}/{asset_id}_blast_blast_02.png",
+        f"res://{root}/{asset_id}_blast_blast_03.png",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("align", "feet", "metadata.align must be center"),
+        ("grid", {"cols": 1, "rows": 3}, "grid must match"),
+        ("frame_labels", ["blast_02", "blast_01", "blast_03"], "frame_labels must match"),
+    ],
+)
+def test_fx_bundle_entry_rejects_animation_metadata_that_bypasses_the_request(
+    tmp_path, field, value, message
+):
+    asset_id, _, request_path, metadata_path = _fx_bundle_inputs(tmp_path)
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    metadata[field] = value
+    metadata_path.write_text(json.dumps(metadata), encoding="utf-8")
+
+    with pytest.raises(ActionEntryDraftError, match=message):
+        build_fx_bundle_entry_draft(
+            metadata_path,
+            request_path=request_path,
+            asset_id=asset_id,
+            tag=TAG,
+            project_root=tmp_path,
+        )
+
+
+def test_fx_bundle_cli_writes_the_compiled_entry(tmp_path):
+    asset_id, root, request_path, metadata_path = _fx_bundle_inputs(tmp_path)
+    out = tmp_path / ".godotmaker/asset-generation/work/entries/arc_blast.json"
+
+    result = write_fx_bundle_entry_draft(
+        metadata_path,
+        request_path=request_path,
+        asset_id=asset_id,
+        tag=TAG,
+        project_root=tmp_path,
+        out=out,
+    )
+
+    assert result["ok"] is True
+    assert result["support"] == f"{root}/{asset_id}.json"
+    assert json.loads(out.read_text(encoding="utf-8"))["processing_status"] == "compiled"

--- a/tests/tools/test_asset_curation_entry_draft.py
+++ b/tests/tools/test_asset_curation_entry_draft.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
@@ -11,7 +12,9 @@ sys.path.insert(0, str(TOOLS_DIR))
 from asset_curation_entry_draft import (  # noqa: E402
     CurationEntryDraftError,
     build_curation_entry_draft,
+    build_fx_static_entry_draft,
     write_curation_entry_draft,
+    write_fx_static_entry_draft,
 )
 from asset_stable_entry import stable_output_dir, validate_entry  # noqa: E402
 
@@ -296,3 +299,93 @@ def test_write_emits_the_draft_file(tmp_path):
 
     assert result["ok"] is True
     assert out.exists()
+
+
+def _fx_static_inputs(tmp_path):
+    asset_id = "lantern_spark"
+    family = "fx-bundle"
+    relative = final_relative(asset_id, family)
+    image = tmp_path / relative
+    image.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGBA", (16, 16), (255, 192, 0, 160)).save(image)
+    report = make_report()
+    report["candidates"][0].update(
+        candidate_id="fx.lantern_spark",
+        name="lantern_spark",
+        final_path=relative,
+    )
+    report_path = write_report(tmp_path, report)
+    request = {
+        "asset_type": "fx-bundle",
+        "asset_id": asset_id,
+        "brief": "A static lantern spark.",
+        "provider": "codex",
+        "spec": {"mode": "static"},
+    }
+    request_path = tmp_path / "ASSET_REQUEST.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+    return asset_id, relative, report_path, request_path
+
+
+def test_fx_static_entry_binds_selected_png_to_texture2d(tmp_path):
+    asset_id, relative, report_path, request_path = _fx_static_inputs(tmp_path)
+
+    entry = build_fx_static_entry_draft(
+        report_path,
+        candidate="lantern_spark",
+        request_path=request_path,
+        asset_id=asset_id,
+        tag=TAG,
+        project_root=tmp_path,
+    )
+
+    assert entry["processing_status"] == "compiled"
+    assert entry["source_layout"] == {"type": "single", "path": f"res://{relative}"}
+    assert entry["godot_artifact"] == {"type": "Texture2D", "path": f"res://{relative}"}
+
+
+def test_fx_static_entry_requires_the_static_request_mode(tmp_path):
+    asset_id, _, report_path, request_path = _fx_static_inputs(tmp_path)
+    request = json.loads(request_path.read_text(encoding="utf-8"))
+    request["spec"] = {
+        "mode": "animated",
+        "required_actions": ["spark"],
+        "actions": [{
+            "name": "spark",
+            "grid": {"columns": 1, "rows": 1},
+            "frame_names": ["spark_01"],
+            "fps": 1,
+            "loop": False,
+            "frame_durations": [1],
+        }],
+    }
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    with pytest.raises(CurationEntryDraftError, match="static fx-bundle"):
+        build_fx_static_entry_draft(
+            report_path,
+            candidate="lantern_spark",
+            request_path=request_path,
+            asset_id=asset_id,
+            tag=TAG,
+            project_root=tmp_path,
+        )
+
+
+def test_fx_static_entry_writer_emits_compiled_draft(tmp_path):
+    asset_id, relative, report_path, request_path = _fx_static_inputs(tmp_path)
+    out = tmp_path / ".godotmaker/asset-generation/work/entries/lantern_spark.json"
+
+    result = write_fx_static_entry_draft(
+        report_path,
+        candidate="lantern_spark",
+        request_path=request_path,
+        asset_id=asset_id,
+        tag=TAG,
+        project_root=tmp_path,
+        out=out,
+    )
+
+    assert result["ok"] is True
+    assert result["path"] == f"res://{relative}"
+    assert json.loads(out.read_text(encoding="utf-8"))["processing_status"] == "compiled"

--- a/tests/tools/test_codex_image_claim.py
+++ b/tests/tools/test_codex_image_claim.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import subprocess
 import sys
@@ -35,6 +36,9 @@ def test_claim_codex_image_copies_explicit_generated_path(tmp_path):
     assert result["generated_path"] == str(source)
     assert result["claimed_path"] == str(output)
     assert result["exists"] is True
+    expected_sha256 = hashlib.sha256(source.read_bytes()).hexdigest()
+    assert result["generated_sha256"] == expected_sha256
+    assert result["claimed_sha256"] == expected_sha256
     assert result["width"] == 12
     assert result["height"] == 8
     assert output.read_bytes() == source.read_bytes()

--- a/tests/tools/test_publish.py
+++ b/tests/tools/test_publish.py
@@ -1011,6 +1011,7 @@ class TestPublishedAssetRuntime:
         assert (runtime / "asset_compiler" / "registry.py").exists()
         assert (runtime / "asset_validation" / "ladder.py").exists()
         assert (runtime / "tools" / "codex_image_claim.py").exists()
+        assert (runtime / "references" / "providers" / "native.md").exists()
         assert not (target / skill_root / "_shared").exists()
 
     @pytest.mark.parametrize(
@@ -1038,9 +1039,16 @@ class TestPublishedAssetRuntime:
             references = re.findall(r"`(\.godotmaker/asset-runtime/[^`]+)`", content)
             assert references, f"{skill_name} must reference the published asset runtime"
             for reference in references:
-                assert (target / reference).exists(), (
-                    f"{skill_name} references a missing published runtime path: {reference}"
-                )
+                if "<provider>" in reference:
+                    providers = ("native", "codex", "gemini", "openai")
+                    assert all(
+                        (target / reference.replace("<provider>", provider)).exists()
+                        for provider in providers
+                    ), f"{skill_name} references missing published provider guides: {reference}"
+                else:
+                    assert (target / reference).exists(), (
+                        f"{skill_name} references a missing published runtime path: {reference}"
+                    )
 
     @pytest.mark.parametrize("agent", publish.AGENT_CHOICES)
     def test_published_standalone_runners_import_and_validate_without_source_checkout(

--- a/tools/asset_action_entry_draft.py
+++ b/tools/asset_action_entry_draft.py
@@ -15,9 +15,10 @@ and containment of every runtime path inside the asset's stable output
 directory.
 
 Single-action drafts stop at ``processing_status: source_ready`` and carry no
-``godot_artifact``. Character-bundle mode receives every required action,
-constructs the one shared ``SpriteFrames`` resource with the native compiler,
-and then writes a ready draft.
+``godot_artifact``. Character-bundle mode receives every required action, while
+animated FX mode receives its one explicit action. The latter constructs one
+shared ``SpriteFrames`` resource with the native compiler and writes a compiled
+entry; the FX Skill promotes it to ready only after L0-L4 pass.
 """
 from __future__ import annotations
 
@@ -295,14 +296,14 @@ def write_action_entry_draft(
     }
 
 
-def _load_request(path: Path) -> dict[str, Any]:
+def _load_bundle_request(path: Path, asset_type: str) -> dict[str, Any]:
     request = _load_object(path, "request")
     try:
         check_bundle_request(request)
     except AnimatedBundleContractError as exc:
         raise ActionEntryDraftError(str(exc)) from exc
-    if request["asset_type"] != "character-bundle":
-        raise ActionEntryDraftError("--request must describe a character-bundle")
+    if request["asset_type"] != asset_type:
+        raise ActionEntryDraftError(f"--request must describe a {asset_type}")
     return request
 
 
@@ -315,7 +316,7 @@ def build_character_bundle_entry_draft(
     project_root: Path,
 ) -> dict[str, Any]:
     """Build one ready SpriteFrames stable entry from every required action."""
-    request = _load_request(request_path)
+    request = _load_bundle_request(request_path, "character-bundle")
     if request["asset_id"] != asset_id:
         raise ActionEntryDraftError("--asset-id must match request.asset_id")
     if not tag.strip():
@@ -494,6 +495,106 @@ def build_character_bundle_entry_draft(
     )}
 
 
+def build_fx_bundle_entry_draft(
+    metadata_path: Path,
+    *,
+    request_path: Path,
+    asset_id: str,
+    tag: str,
+    project_root: Path,
+) -> dict[str, Any]:
+    """Build the compiled SpriteFrames entry for an animated FX request."""
+    request = _load_bundle_request(request_path, "fx-bundle")
+    if request["spec"]["mode"] != "animated":
+        raise ActionEntryDraftError("--request must describe an animated fx-bundle")
+    if request["asset_id"] != asset_id:
+        raise ActionEntryDraftError("--asset-id must match request.asset_id")
+    if not tag.strip():
+        raise ActionEntryDraftError("--tag must be a non-empty string")
+
+    action = request["spec"]["actions"][0]
+    action_name = action["name"]
+    metadata = _load_object(metadata_path, "metadata")
+    if metadata.get("action_name") != action_name:
+        raise ActionEntryDraftError("FX action metadata must match the request action name")
+    if metadata.get("align") != "center":
+        raise ActionEntryDraftError("animated FX metadata.align must be center")
+    if metadata.get("frame_labels") != action["frame_names"]:
+        raise ActionEntryDraftError(
+            "FX action frame_labels must match the request frame_names in order"
+        )
+    expected_grid = {"cols": action["grid"]["columns"], "rows": action["grid"]["rows"]}
+    if metadata.get("grid") != expected_grid:
+        raise ActionEntryDraftError("FX action grid must match the request grid")
+
+    built = build_action_entry_draft(
+        metadata_path,
+        asset_id=asset_id,
+        tag=tag,
+        production_family="fx-bundle",
+        project_root=project_root,
+    )
+    support = built["support"]
+    if support["fps"] != float(action["fps"]):
+        raise ActionEntryDraftError("FX action fps must match the request")
+    if support["loop"] is not action["loop"]:
+        raise ActionEntryDraftError("FX action loop must match the request")
+    if support["frame_durations"] != [float(value) for value in action["frame_durations"]]:
+        raise ActionEntryDraftError("FX action frame_durations must match the request")
+    expected_sheet_path = _res(
+        f"{stable_output_dir('fx-bundle', asset_id)}/{asset_id}_sheet.png"
+    )
+    if support["sheet_path"] != expected_sheet_path:
+        raise ActionEntryDraftError("FX action sheet path must match the stable action path")
+    expected_frame_paths = [
+        _res(
+            f"{stable_output_dir('fx-bundle', asset_id)}/{asset_id}_{action_name}_{label}.png"
+        )
+        for label in action["frame_names"]
+    ]
+    if support["frame_paths"] != expected_frame_paths:
+        raise ActionEntryDraftError("FX action frame paths must match the stable action paths in order")
+
+    try:
+        compiler_spec = build_spriteframes_spec(request, {action_name: support["frame_paths"]})
+    except AnimatedBundleContractError as exc:
+        raise ActionEntryDraftError(str(exc)) from exc
+    artifact_path = _res(f"{stable_output_dir('fx-bundle', asset_id)}/{asset_id}.tres")
+    entry = {
+        "version": SCHEMA_VERSION,
+        "asset_id": asset_id,
+        "tag": tag,
+        "production_family": "fx-bundle",
+        "source_layout": {"type": SOURCE_LAYOUT_TYPE, "path": support["sheet_path"]},
+        "godot_artifact": {"type": "SpriteFrames", "path": artifact_path},
+        "processing_status": "compiled",
+    }
+    try:
+        validate_entry(entry, project_root=Path(project_root))
+        build_default_registry().compile(
+            CompileRequest(
+                "fx-bundle",
+                asset_id,
+                "grid_sheet",
+                support["sheet_path"],
+                "SpriteFrames",
+                artifact_path,
+                Path(project_root),
+                compiler_spec,
+            )
+        )
+    except (CompilerError, StableEntryError) as exc:
+        raise ActionEntryDraftError(str(exc)) from exc
+
+    support["frame_labels"] = list(action["frame_names"])
+    support["grid"] = expected_grid
+    return {
+        "entry": entry,
+        "support": {"version": SCHEMA_VERSION, "action": support},
+        "support_path": f"{stable_output_dir('fx-bundle', asset_id)}/{asset_id}.json",
+    }
+
+
 def write_character_bundle_entry_draft(
     metadata_paths: list[Path],
     *,
@@ -505,6 +606,31 @@ def write_character_bundle_entry_draft(
 ) -> dict[str, Any]:
     built = build_character_bundle_entry_draft(
         metadata_paths,
+        request_path=request_path,
+        asset_id=asset_id,
+        tag=tag,
+        project_root=project_root,
+    )
+    support_path = Path(project_root) / built["support_path"]
+    support_path.parent.mkdir(parents=True, exist_ok=True)
+    support_path.write_text(json.dumps(built["support"], indent=2) + "\n", encoding="utf-8")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(built["entry"], indent=2) + "\n", encoding="utf-8")
+    return {"ok": True, "draft": str(out), "support": built["support_path"], "asset_id": asset_id, "tag": tag}
+
+
+def write_fx_bundle_entry_draft(
+    metadata_path: Path,
+    *,
+    request_path: Path,
+    asset_id: str,
+    tag: str,
+    project_root: Path,
+    out: Path,
+) -> dict[str, Any]:
+    """Write the compiled animated FX entry and its action support metadata."""
+    built = build_fx_bundle_entry_draft(
+        metadata_path,
         request_path=request_path,
         asset_id=asset_id,
         tag=tag,
@@ -533,16 +659,32 @@ def _main() -> int:
 
     try:
         if args.request:
-            if args.production_family != "character-bundle":
-                raise ActionEntryDraftError("--request bundle mode supports character-bundle only")
-            result = write_character_bundle_entry_draft(
-                args.metadata,
-                request_path=args.request,
-                asset_id=args.asset_id,
-                tag=args.tag,
-                project_root=args.project_root,
-                out=args.out,
-            )
+            if args.production_family == "character-bundle":
+                result = write_character_bundle_entry_draft(
+                    args.metadata,
+                    request_path=args.request,
+                    asset_id=args.asset_id,
+                    tag=args.tag,
+                    project_root=args.project_root,
+                    out=args.out,
+                )
+            elif args.production_family == "fx-bundle":
+                if len(args.metadata) != 1:
+                    raise ActionEntryDraftError(
+                        "animated fx-bundle mode accepts exactly one --metadata"
+                    )
+                result = write_fx_bundle_entry_draft(
+                    args.metadata[0],
+                    request_path=args.request,
+                    asset_id=args.asset_id,
+                    tag=args.tag,
+                    project_root=args.project_root,
+                    out=args.out,
+                )
+            else:
+                raise ActionEntryDraftError(
+                    "--request bundle mode supports character-bundle or fx-bundle only"
+                )
         else:
             if len(args.metadata) != 1:
                 raise ActionEntryDraftError("single-action mode accepts exactly one --metadata")

--- a/tools/asset_action_process.py
+++ b/tools/asset_action_process.py
@@ -283,6 +283,7 @@ def _copy_runtime_outputs(
     *,
     final_dir: Path | None,
     final_prefix: str | None,
+    final_sheet_name: str | None,
 ) -> tuple[list[str], str | None, str | None]:
     if final_dir is None:
         return [str(path) for path in frame_paths], None, None
@@ -301,7 +302,11 @@ def _copy_runtime_outputs(
         target = final_dir / output_name
         shutil.copy2(path, target)
         final_frames.append(str(target))
-    final_sheet = final_dir / f"{final_prefix}_sheet.png"
+    if final_sheet_name is not None:
+        if (not final_sheet_name.endswith(".png")
+                or Path(final_sheet_name).name != final_sheet_name):
+            raise ActionProcessError("--final-sheet-name must be a PNG filename without directories")
+    final_sheet = final_dir / (final_sheet_name or f"{final_prefix}_sheet.png")
     shutil.copy2(sheet_path, final_sheet)
     final_gif = final_dir / f"{final_prefix}.gif"
     shutil.copy2(gif_path, final_gif)
@@ -678,6 +683,7 @@ def process_action_sheet(
     match_scale_reference: bool = False,
     final_dir: Path | None = None,
     final_prefix: str | None = None,
+    final_sheet_name: str | None = None,
     report: Path | None = None,
 ) -> dict[str, object]:
     """Normalize one action sheet into frames, a transparent sheet, GIF, and metadata."""
@@ -850,6 +856,7 @@ def process_action_sheet(
         gif_path,
         final_dir=final_dir,
         final_prefix=final_prefix,
+        final_sheet_name=final_sheet_name,
     )
 
     metadata: dict[str, object] = {
@@ -923,6 +930,7 @@ def _main() -> int:
     parser.add_argument("--match-scale-reference", action="store_true")
     parser.add_argument("--final-dir", type=Path)
     parser.add_argument("--final-prefix")
+    parser.add_argument("--final-sheet-name")
     parser.add_argument("--action-name", required=True)
     parser.add_argument("--fps", required=True, type=float)
     loop_group = parser.add_mutually_exclusive_group(required=True)
@@ -954,6 +962,7 @@ def _main() -> int:
             match_scale_reference=args.match_scale_reference,
             final_dir=args.final_dir,
             final_prefix=args.final_prefix,
+            final_sheet_name=args.final_sheet_name,
             action_name=args.action_name,
             fps=args.fps,
             loop=args.loop,

--- a/tools/asset_animated_bundle_contract_check.py
+++ b/tools/asset_animated_bundle_contract_check.py
@@ -230,7 +230,12 @@ def _fx_spec(spec: Any, issues: list[str]) -> None:
         return
 
     required = _required_actions(spec.get("required_actions"), label="request.spec.required_actions", issues=issues)
-    actions = _actions(spec.get("actions"), label="request.spec.actions", issues=issues)
+    actions = _actions(
+        spec.get("actions"),
+        label="request.spec.actions",
+        issues=issues,
+        require_grid=True,
+    )
     if len(required) != 1:
         issues.append("request.spec.required_actions must contain exactly one animated FX action")
     if len(actions) != 1:

--- a/tools/asset_curation_entry_draft.py
+++ b/tools/asset_curation_entry_draft.py
@@ -10,10 +10,10 @@ a producer to honour by hand: the named candidate must exist, be unambiguous, an
 actually be ``selected``; the report's selected/rejected counts must be coherent;
 and the finalized path must sit inside the asset's stable output directory.
 
-The draft stops at ``processing_status: source_ready`` and carries no
-``godot_artifact``. A selected image becomes worker-consumable only once a native
-compiler produces its Godot resource and the L0-L4 runner verifies it; neither
-exists yet, so declaring anything further here would be a false readiness claim.
+The default draft stops at ``processing_status: source_ready`` and carries no
+``godot_artifact``. The dedicated static FX mode binds the selected image to its
+native ``Texture2D`` import and writes a compiled entry; the FX Skill owns the
+L0-L4 validation loop and promotes it to ready before worker handoff.
 """
 from __future__ import annotations
 
@@ -33,6 +33,15 @@ from asset_stable_entry import (
     check_output_path,
     validate_entry,
 )
+from asset_animated_bundle_contract_check import (
+    AnimatedBundleContractError,
+    check_bundle_request,
+)
+
+SHARED_ROOT = Path(__file__).resolve().parents[1] / "skills" / "assets" / "_shared"
+if str(SHARED_ROOT) not in sys.path:
+    sys.path.insert(0, str(SHARED_ROOT))
+from asset_compiler import CompileRequest, CompilerError, build_default_registry  # noqa: E402
 
 DRAFT_STATUS = "source_ready"
 
@@ -196,12 +205,102 @@ def write_curation_entry_draft(
     }
 
 
+def _load_fx_static_request(path: Path) -> dict[str, Any]:
+    request = _load_object(path, "request")
+    try:
+        check_bundle_request(request)
+    except AnimatedBundleContractError as exc:
+        raise CurationEntryDraftError(str(exc)) from exc
+    if request["asset_type"] != "fx-bundle" or request["spec"]["mode"] != "static":
+        raise CurationEntryDraftError("--request must describe a static fx-bundle")
+    return request
+
+
+def build_fx_static_entry_draft(
+    report_path: Path,
+    *,
+    candidate: str,
+    request_path: Path,
+    asset_id: str,
+    tag: str,
+    project_root: Path,
+) -> dict[str, Any]:
+    """Build the selected static FX image as a compiled Texture2D stable entry."""
+    request = _load_fx_static_request(request_path)
+    if request["asset_id"] != asset_id:
+        raise CurationEntryDraftError("--asset-id must match request.asset_id")
+    source_ready = build_curation_entry_draft(
+        report_path,
+        candidate=candidate,
+        asset_id=asset_id,
+        tag=tag,
+        production_family="fx-bundle",
+        project_root=project_root,
+        source_layout="single",
+    )
+    source_path = source_ready["source_layout"]["path"]
+    expected = f"res://assets/generated/fx-bundle/{asset_id}/{asset_id}.png"
+    if source_path != expected:
+        raise CurationEntryDraftError("static FX selected path must match its stable PNG path")
+    entry = {
+        **source_ready,
+        "godot_artifact": {"type": "Texture2D", "path": source_path},
+        "processing_status": "compiled",
+    }
+    try:
+        validate_entry(entry, project_root=Path(project_root), check_files=True)
+        build_default_registry().compile(
+            CompileRequest(
+                "fx-bundle",
+                asset_id,
+                "single",
+                source_path,
+                "Texture2D",
+                source_path,
+                Path(project_root),
+            )
+        )
+    except (CompilerError, StableEntryError) as exc:
+        raise CurationEntryDraftError(str(exc)) from exc
+    return entry
+
+
+def write_fx_static_entry_draft(
+    report_path: Path,
+    *,
+    candidate: str,
+    request_path: Path,
+    asset_id: str,
+    tag: str,
+    project_root: Path,
+    out: Path,
+) -> dict[str, Any]:
+    entry = build_fx_static_entry_draft(
+        report_path,
+        candidate=candidate,
+        request_path=request_path,
+        asset_id=asset_id,
+        tag=tag,
+        project_root=project_root,
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(entry, indent=2) + "\n", encoding="utf-8")
+    return {
+        "ok": True,
+        "draft": str(out),
+        "asset_id": asset_id,
+        "tag": tag,
+        "path": entry["godot_artifact"]["path"],
+    }
+
+
 def _main() -> int:
     parser = argparse.ArgumentParser(
         description="Build a v1 stable-entry draft from a selected curation candidate"
     )
     parser.add_argument("--report", required=True, type=Path)
     parser.add_argument("--candidate", required=True)
+    parser.add_argument("--request", type=Path)
     parser.add_argument("--asset-id", required=True)
     parser.add_argument("--tag", required=True)
     parser.add_argument("--production-family", required=True)
@@ -211,16 +310,31 @@ def _main() -> int:
     args = parser.parse_args()
 
     try:
-        result = write_curation_entry_draft(
-            args.report,
-            candidate=args.candidate,
-            asset_id=args.asset_id,
-            tag=args.tag,
-            production_family=args.production_family,
-            project_root=args.project_root,
-            source_layout=args.source_layout,
-            out=args.out,
-        )
+        if args.request:
+            if args.production_family != "fx-bundle":
+                raise CurationEntryDraftError(
+                    "--request static mode supports fx-bundle only"
+                )
+            result = write_fx_static_entry_draft(
+                args.report,
+                candidate=args.candidate,
+                request_path=args.request,
+                asset_id=args.asset_id,
+                tag=args.tag,
+                project_root=args.project_root,
+                out=args.out,
+            )
+        else:
+            result = write_curation_entry_draft(
+                args.report,
+                candidate=args.candidate,
+                asset_id=args.asset_id,
+                tag=args.tag,
+                production_family=args.production_family,
+                project_root=args.project_root,
+                source_layout=args.source_layout,
+                out=args.out,
+            )
     except CurationEntryDraftError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}))
         return 1

--- a/tools/codex_image_claim.py
+++ b/tools/codex_image_claim.py
@@ -7,6 +7,7 @@ This script never scans Codex image directories or guesses the newest file.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import shutil
 import sys
@@ -85,6 +86,14 @@ def _write_atomic_json(path: Path, data: dict[str, Any]) -> None:
             tmp_path.unlink()
 
 
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
 def claim_codex_image(generated_path: str, output: Path, *, asset_id: str | None = None) -> dict[str, object]:
     source_path = _path_from_arg(generated_path)
     output = Path(output)
@@ -106,6 +115,12 @@ def claim_codex_image(generated_path: str, output: Path, *, asset_id: str | None
     _copy_atomic(source_path, output)
     if not output.exists() or not output.is_file():
         raise CodexImageClaimError(f"Claimed image was not written: {output}")
+    generated_sha256 = _sha256(source_path)
+    claimed_sha256 = _sha256(output)
+    if claimed_sha256 != generated_sha256:
+        raise CodexImageClaimError(
+            f"Claimed image content does not match generated image: {output}"
+        )
 
     result: dict[str, object] = {
         "ok": True,
@@ -117,6 +132,8 @@ def claim_codex_image(generated_path: str, output: Path, *, asset_id: str | None
         "height": height,
         "format": fmt or output.suffix.lstrip(".").upper() or "PNG",
         "mode": mode,
+        "generated_sha256": generated_sha256,
+        "claimed_sha256": claimed_sha256,
     }
     if asset_id:
         result["asset_id"] = asset_id

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -84,6 +84,7 @@ AGENT_HOOK_CONFIGS = {
 # discovered or invoked as a standalone skill.
 ASSET_RUNTIME_SOURCE = Path("skills") / "assets" / "_shared"
 ASSET_RUNTIME_TARGET = Path(".godotmaker") / "asset-runtime"
+ASSET_PROVIDER_REFERENCES_SOURCE = Path("skills") / "core" / "gm-asset" / "references" / "providers"
 
 @dataclass(frozen=True)
 class AgentPublishAdapter:
@@ -434,6 +435,12 @@ def publish_asset_runtime(repo_root: Path, target: Path) -> int:
         return 0
     dst = target / ASSET_RUNTIME_TARGET
     copy_tree(src, dst)
+    provider_references = repo_root / ASSET_PROVIDER_REFERENCES_SOURCE
+    if not provider_references.exists():
+        raise FileNotFoundError(
+            f"asset provider references are missing: {provider_references}"
+        )
+    copy_tree(provider_references, dst / "references" / "providers")
     # The Codex generated-path claim is part of the portable asset runtime:
     # published Skills must not rely on the framework checkout's top-level
     # tools directory being present in a consumer project.


### PR DESCRIPTION
## Summary

Restore `fx-bundle` as a first-class production asset Skill for static and animated effects, with deterministic processing and stable Godot output paths.

## Motivation

Tracks WOR-296 for progress only; this PR does not close it. The current split Skill had lost the previous FX production contract and could not reliably hand animated sheets through to `SpriteFrames`.

## Changes

- [x] Restore static FX and explicit-grid animated FX production paths, including transparent processing, frame order, alignment, and stable `Texture2D` / `SpriteFrames` artifacts.
- [x] Bind Codex claims to source hashes, preserve provider/reference provenance, and keep declared providers pinned.
- [x] Align action processing, compiler metadata, runtime validation, and published provider-reference guides; add end-to-end processing-to-compiler regressions.

## Testing

- [x] New and updated tests pass: pre-push hook ran `ruff check .` and `pytest --tb=short` (`2163 passed, 7 skipped`).
- [x] Gitleaks passed during both commits.
- [x] Manual testing completed where applicable: the private companion Eval exercised approved real-provider animated FX cases; this public PR's contract/tooling behavior is covered by automated regressions.

## Benchmark Verification

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

- [x] **No** - no migration needed for existing target projects.
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
