### PR TITLE
feat(runtime): hand workers the minimal godot_artifact snapshot

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -102,7 +102,34 @@ Your brief lists the files you own. You may:
 - **WRITE** only files listed in your Deliverables
 - **CREATE** new files only if listed in your Deliverables
 
-If you need to modify a file not in your deliverables, report this in your Notes — do NOT modify it.
+If you need to modify a file not in your deliverables, report this in your Notes — do NOT modify it. The one exception is runtime asset integration repair, below.
+
+### Exception: runtime asset integration repair
+
+One exception overrides the rule above, and nothing else does. When a runtime
+artifact from `Asset Runtime Snapshot` will not integrate — it fails to load,
+its type does not fit the node that must bind it, or the scene or script
+binding it breaks on it — you MAY edit or replace the project-local Godot file
+needed to make that binding work, even though it is not in your Deliverables.
+This holds even when your brief's `Scope Boundaries` or `Prohibited Actions`
+repeat the generic "MUST NOT modify files outside Deliverables": this exception
+is the narrower rule and it wins.
+
+It covers exactly two things:
+- the `.tres` / `.res` artifact you were told to bind;
+- the project-local scene or script that binds it.
+
+It never covers:
+- images, or any art you would have to produce yourself — see **Art production
+  is never yours** below;
+- `.godotmaker/asset-generation/` entries, the root index, or `sources/`; the
+  source-generation truth is not yours to rewrite;
+- `PLAN.md`, `STRUCTURE.md`, `SCENES.md`, `GAP.md`, `ASSETS.md`, or `e2e/`;
+- unrelated files, refactors, or improvements you noticed on the way.
+
+List every file you touched under this exception in your report's Notes. That
+report line is the entire obligation — no repair record, no revalidation pass,
+no new skill.
 
 ## Runtime Asset Rules
 
@@ -132,10 +159,12 @@ If you need to modify a file not in your deliverables, report this in your Notes
   tool to fill a gap. That responsibility stays with `/gm-asset`.
 - **Integration repair is yours.** When a listed artifact genuinely does not fit
   the project, you may edit or replace a project-local Godot resource, scene, or
-  script — including a generated `.tres` — to make the integration work. Say what
-  you changed in Notes. No repair record, revalidation pass, or new skill is
-  required of you. Be aware that explicitly regenerating that asset through
-  `/gm-asset` may overwrite an edit made at its generated artifact path.
+  script — including a generated `.tres` — to make the integration work, under
+  the File Ownership exception above, which overrides the Deliverables
+  restriction for exactly those files. Say what you changed in Notes. No repair
+  record, revalidation pass, or new skill is required of you. Be aware that
+  explicitly regenerating that asset through `/gm-asset` may overwrite an edit
+  made at its generated artifact path.
 - Do not use `.godotmaker/asset-generation/sources/`, curation candidates,
   prompt files, or scene references as runtime assets.
 - Do not replace listed final assets with placeholders, procedural shapes, or

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -82,9 +82,10 @@ The lead agent provides your brief with these fields. REQUIRED fields are always
 {Known pitfalls from reviewer skills}
 
 ### Asset Runtime Snapshot                               [REQUIRED for visual tasks]
-{Final runtime asset paths from ASSETS.md or from the stable entries that the
-.godotmaker/asset-generation/manifest.json pointer index resolves to.
-Include support metadata paths for grid sheets and region atlases.}
+{One `tools/asset_runtime_resolver.py` JSON block per generated runtime asset
+the lead agent resolved from the .godotmaker/asset-generation/manifest.json
+pointer index. Each block carries exactly asset_id, production_family,
+source_layout, and godot_artifact.}
 
 ### Visual Self-Check                                  [OPTIONAL]
 - Source: {evaluation.json.visual_checks scene and blocking finding}
@@ -105,32 +106,42 @@ If you need to modify a file not in your deliverables, report this in your Notes
 
 ## Runtime Asset Rules
 
-- Use final runtime asset paths from `Asset Runtime Snapshot`.
-- For `grid_sheet`, read the listed action metadata JSON and wire animation
-  frames from it.
-- If a `grid_sheet` has frame_count > 1, do not use the sheet as a static
-  `Sprite2D.texture` and do not use only the first frame. Create runtime
-  playback with `AnimatedSprite2D`/`SpriteFrames`, `AnimationPlayer`, or an
-  equivalent frame-advance system.
-- For gameplay actors, wire at least the default action playback and any
-  action/state switches named in the brief.
+- `Asset Runtime Snapshot` is the whole generated-asset contract. Each block
+  gives you `godot_artifact.type` and `godot_artifact.path`: load that path and
+  bind it as that type.
+- **Bind the artifact, do not rebuild it.** Never reconstruct a `SpriteFrames`,
+  `AtlasTexture`, `StyleBoxTexture`, `Theme`, or `TileSet` out of
+  `source_layout.path`, and never re-slice, re-grid, or re-region that image.
+  `source_layout` is provenance so you know what the artifact came from; it is
+  not an input to your code.
+- `SpriteFrames` → `AnimatedSprite2D.sprite_frames` (or an equivalent
+  `SpriteFrames`-driven player). Frame order, timing, and loop state already
+  live in the resource. Play the actions the brief's mechanic needs; do not
+  reduce a multi-frame actor or FX to one static frame.
+- `AtlasTexture` → the texture of the single node that shows that element. It is
+  already exactly one region — never substitute the physical atlas image behind
+  it.
+- `Texture2D` → the node's texture. `StyleBoxTexture` → the Theme or StyleBox
+  slot it belongs to. `Theme` → `Control.theme`. `TileSet` →
+  `TileMapLayer.tile_set`; map layout, layers, and gameplay structure stay
+  yours to author.
 - For temporary projectile, impact, pickup, slash, aura, or feedback FX, wire
   the effect lifecycle so it disappears or clears after playback.
-- For `region_atlas`, read the listed atlas metadata JSON and resolve the
-  matching region by name from it. Use the region named in the brief when given;
-  otherwise match the element to its region by name.
-- A node that shows one element (a single button, icon, prop, or FX sprite)
-  from a `region_atlas` must reference its named region via `AtlasTexture` with
-  the region `rect` from the metadata (or an equivalent region binding). Do not
-  assign the whole atlas image as a `Sprite2D`/`TextureRect` texture where a
-  single region is required.
-- Do not use a whole `region_atlas` or `grid_sheet` image as one visible sprite
-  when the brief names a single region or frame to show.
+- **Art production is never yours.** Do not draw, generate, synthesize, or
+  procedurally substitute images, and do not run an asset-generation skill or
+  tool to fill a gap. That responsibility stays with `/gm-asset`.
+- **Integration repair is yours.** When a listed artifact genuinely does not fit
+  the project, you may edit or replace a project-local Godot resource, scene, or
+  script — including a generated `.tres` — to make the integration work. Say what
+  you changed in Notes. No repair record, revalidation pass, or new skill is
+  required of you. Be aware that explicitly regenerating that asset through
+  `/gm-asset` may overwrite an edit made at its generated artifact path.
 - Do not use `.godotmaker/asset-generation/sources/`, curation candidates,
   prompt files, or scene references as runtime assets.
 - Do not replace listed final assets with placeholders, procedural shapes, or
   freshly drawn stand-ins.
-- If a final asset or metadata path is missing, report `PARTIAL` or `FAILED`.
+- If the snapshot is empty for a visual task, or a listed artifact path does not
+  exist, report `PARTIAL` or `FAILED` with the missing path. Do not invent one.
 
 ## Error Handling
 

--- a/agents/worker.md
+++ b/agents/worker.md
@@ -106,65 +106,55 @@ If you need to modify a file not in your deliverables, report this in your Notes
 
 ### Exception: runtime asset integration repair
 
-One exception overrides the rule above, and nothing else does. When a runtime
-artifact from `Asset Runtime Snapshot` will not integrate — it fails to load,
-its type does not fit the node that must bind it, or the scene or script
-binding it breaks on it — you MAY edit or replace the project-local Godot file
-needed to make that binding work, even though it is not in your Deliverables.
-This holds even when your brief's `Scope Boundaries` or `Prohibited Actions`
-repeat the generic "MUST NOT modify files outside Deliverables": this exception
-is the narrower rule and it wins.
+This exception overrides the rule above, and nothing else does. It also
+overrides your brief's `Scope Boundaries` and `Prohibited Actions` lines.
+
+When an `Asset Runtime Snapshot` artifact fails to load, does not fit the node
+that must bind it, or breaks the scene or script binding it, edit or replace
+the project-local Godot file needed to make that binding work, even when it is
+not in your Deliverables.
 
 It covers exactly two things:
 - the `.tres` / `.res` artifact you were told to bind;
 - the project-local scene or script that binds it.
 
 It never covers:
-- images, or any art you would have to produce yourself — see **Art production
-  is never yours** below;
-- `.godotmaker/asset-generation/` entries, the root index, or `sources/`; the
-  source-generation truth is not yours to rewrite;
+- images, or any art you would have to produce yourself (see **Art production
+  is never yours** below);
+- `.godotmaker/asset-generation/` entries, the root index, or `sources/`;
 - `PLAN.md`, `STRUCTURE.md`, `SCENES.md`, `GAP.md`, `ASSETS.md`, or `e2e/`;
 - unrelated files, refactors, or improvements you noticed on the way.
 
-List every file you touched under this exception in your report's Notes. That
-report line is the entire obligation — no repair record, no revalidation pass,
-no new skill.
+List every file you touched under this exception in your report's Notes. Do not
+write a repair record, run a revalidation pass, or author a new skill.
 
 ## Runtime Asset Rules
 
-- `Asset Runtime Snapshot` is the whole generated-asset contract. Each block
-  gives you `godot_artifact.type` and `godot_artifact.path`: load that path and
-  bind it as that type.
+- Take every generated runtime asset from `Asset Runtime Snapshot`. For each
+  block, load `godot_artifact.path` and bind it as `godot_artifact.type`.
 - **Bind the artifact, do not rebuild it.** Never reconstruct a `SpriteFrames`,
-  `AtlasTexture`, `StyleBoxTexture`, `Theme`, or `TileSet` out of
+  `AtlasTexture`, `StyleBoxTexture`, `Theme`, or `TileSet` from
   `source_layout.path`, and never re-slice, re-grid, or re-region that image.
-  `source_layout` is provenance so you know what the artifact came from; it is
-  not an input to your code.
+  Read `source_layout` as provenance only; do not pass it to your code.
 - `SpriteFrames` → `AnimatedSprite2D.sprite_frames` (or an equivalent
-  `SpriteFrames`-driven player). Frame order, timing, and loop state already
-  live in the resource. Play the actions the brief's mechanic needs; do not
-  reduce a multi-frame actor or FX to one static frame.
-- `AtlasTexture` → the texture of the single node that shows that element. It is
-  already exactly one region — never substitute the physical atlas image behind
-  it.
+  `SpriteFrames`-driven player). Play the actions the brief's mechanic needs; do
+  not reduce a multi-frame actor or FX to one static frame. Do not re-declare
+  frame order, timing, or loop state.
+- `AtlasTexture` → the texture of the single node that shows that element. Never
+  substitute the physical atlas image behind it.
 - `Texture2D` → the node's texture. `StyleBoxTexture` → the Theme or StyleBox
   slot it belongs to. `Theme` → `Control.theme`. `TileSet` →
-  `TileMapLayer.tile_set`; map layout, layers, and gameplay structure stay
-  yours to author.
+  `TileMapLayer.tile_set`. Author map layout, layers, and gameplay structure
+  yourself.
 - For temporary projectile, impact, pickup, slash, aura, or feedback FX, wire
   the effect lifecycle so it disappears or clears after playback.
 - **Art production is never yours.** Do not draw, generate, synthesize, or
   procedurally substitute images, and do not run an asset-generation skill or
-  tool to fill a gap. That responsibility stays with `/gm-asset`.
-- **Integration repair is yours.** When a listed artifact genuinely does not fit
-  the project, you may edit or replace a project-local Godot resource, scene, or
-  script — including a generated `.tres` — to make the integration work, under
-  the File Ownership exception above, which overrides the Deliverables
-  restriction for exactly those files. Say what you changed in Notes. No repair
-  record, revalidation pass, or new skill is required of you. Be aware that
-  explicitly regenerating that asset through `/gm-asset` may overwrite an edit
-  made at its generated artifact path.
+  tool to fill a gap.
+- **Integration repair is yours.** When a listed artifact does not fit the
+  project, edit or replace the project-local Godot resource, scene, or script —
+  including a generated `.tres` — to make the integration work, under the File
+  Ownership exception above. Report what you changed in Notes.
 - Do not use `.godotmaker/asset-generation/sources/`, curation candidates,
   prompt files, or scene references as runtime assets.
 - Do not replace listed final assets with placeholders, procedural shapes, or

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -61,6 +61,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
   names can reuse one declared atlas region, and standalone UI validation now
   compiles icon resources before the Theme that binds them.
 
+- `/gm-build` and `/gm-fixgap` now hand workers a resolver-produced minimal `godot_artifact` snapshot instead of hand-copied stable-entry fields, and workers bind the compiled Godot resource rather than rebuilding it from the source layout.
 - `/gm-asset` now registers every generated asset as a v1 stable entry plus a pointer-only root index entry instead of a full-body `runtime_artifact` manifest.
 - Generated runtime handoff for gm-build, gm-fixgap, worker dispatch, and ASSETS.md rows now resolves the stable entry behind each root-index pointer.
 - An ASSETS.md runtime row reaches `generated` only from a `ready` non-reference stable entry, while a finalized registered screen reference completes its reference row at `source_ready` without becoming a worker runtime artifact.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -62,6 +62,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
   compiles icon resources before the Theme that binds them.
 
 - `/gm-build` and `/gm-fixgap` now hand workers a resolver-produced minimal `godot_artifact` snapshot instead of hand-copied stable-entry fields, and workers bind the compiled Godot resource rather than rebuilding it from the source layout.
+- A worker may now edit or replace the bound runtime artifact and the project-local scene or script that binds it to fix a concrete integration failure, as a narrow file-ownership exception that outranks the generic "no files outside Deliverables" restriction.
 - `/gm-asset` now registers every generated asset as a v1 stable entry plus a pointer-only root index entry instead of a full-body `runtime_artifact` manifest.
 - Generated runtime handoff for gm-build, gm-fixgap, worker dispatch, and ASSETS.md rows now resolves the stable entry behind each root-index pointer.
 - An ASSETS.md runtime row reaches `generated` only from a `ready` non-reference stable entry, while a finalized registered screen reference completes its reference row at `source_ready` without becoming a worker runtime artifact.

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -63,7 +63,7 @@ Agent({
 ### Prohibited Actions                                   [REQUIRED]
 - DO NOT ask for approval, wait for user input, or pause for confirmation. Execute the task directly. If required information or external state is missing, report `PARTIAL` or `FAILED` with the blocker.
 - DO NOT fabricate resource paths — only use paths listed in ASSETS.md or verified to exist in the project. If you need an asset that doesn't exist, report it in your summary; do NOT invent a path.
-- DO NOT modify files outside your Deliverables list — read-only access to all other files. The single exception is runtime asset integration repair (worker agent, File Ownership): the artifact you were told to bind, plus the project-local scene or script that binds it, may be edited or replaced to fix a concrete integration failure. That exception overrides this line for those files only; report every one of them in Notes.
+- DO NOT modify files outside your Deliverables list — read-only access to all other files. Exception: runtime asset integration repair (worker agent, File Ownership) overrides this line for the bound artifact and the project-local scene or script that binds it; report every such file in Notes.
 - DO NOT write `test_system_has_query` tests — system.q is null outside World (see gecs gotcha G14).
 - DO NOT introduce E2E-only gameplay changes.
 - DO NOT write files outside the project tree (system temp dirs, home directory, etc.). If you genuinely need a scratch file, create it under `.godotmaker/scratch/` (mkdir -p the directory if missing) and delete it before reporting DONE. Claude Code's own scratchpad system is gated behind a feature flag we cannot rely on, so this rule is what guarantees clean tear-down.
@@ -78,20 +78,16 @@ python tools/asset_runtime_resolver.py --project-root . --assets-md ASSETS.md \
   --tag <tag> --asset-id <asset_id>
 ```
 
-The resolver output IS this section. Do not copy fields out of a stable entry,
-the root index, or an ASSETS.md row by hand, and do not enrich the snapshot with
-target size, frame_count, fps, loop, frame paths, region names, region rects, or
-support metadata paths — the compiled `godot_artifact` already carries them, and
-a hand-added field is what makes a worker rebuild the resource instead of
-binding it.
+Paste the resolver output as this section. Do not copy fields out of a stable
+entry, the root index, or an ASSETS.md row by hand. Do not add target size,
+frame_count, fps, loop, frame paths, region names, region rects, or support
+metadata paths.
 Name the runtime state or FX lifecycle a `SpriteFrames` artifact should play in
 `Game Mechanic Function`, not by pasting frame data here.
-The resolver fails closed: an unregistered pointer, a non-`ready` entry, a
-missing source or artifact file, and a reference-only asset all exit non-zero
-with an `error`. On failure, state the resolver's `error` and do not dispatch a
-visual task against an invented path — a reference-only asset never becomes a
-runtime asset, and a missing artifact means the asset must go back through
-`/gm-asset` first.
+The resolver exits non-zero with an `error` on an unregistered pointer, a
+non-`ready` entry, a missing source or artifact file, and a reference-only
+asset. On failure, state the resolver's `error` and do not dispatch the visual
+task. Never fill this section with an artifact path the resolver did not emit.
 Do not use `.godotmaker/asset-generation/sources/`, curation candidates,
 prompt files, or scene references as runtime assets.}
 
@@ -107,8 +103,7 @@ prompt files, or scene references as runtime assets.}
  or ASSETS.md rows whose type is `reference` as runtime assets.
  Do not replace an available final asset with placeholder art, procedural
  shapes, or freshly drawn stand-ins.
- Image production belongs to `/gm-asset`: never ask a worker to generate,
- draw, or synthesize art as part of runtime integration.}
+ Never ask a worker to generate, draw, or synthesize art.}
 
 ### Visual Self-Check                                    [REQUIRED for fixgap visual tasks]
 - Source: {evaluation.json.visual_checks scene and blocking finding}
@@ -150,15 +145,13 @@ PLAN.md, or evaluation evidence that cites GDD.md or PLAN.md.
 18. **Non-interactive execution.** Every worker brief MUST prohibit approval requests, user-input waits, and confirmation pauses.
 19. **Visual tasks require runtime assets.** Fill `Asset Runtime Snapshot` and
 `Visual Asset Contract` for visual tasks.
-20. **The resolver owns the snapshot.** `tools/asset_runtime_resolver.py` output
-is the only legal `Asset Runtime Snapshot` content. Never hand-copy entry
-fields, and never widen the four-field contract — the manager's job is to run
-the resolver and paste it, not to interpret a stable entry.
+20. **The resolver owns the snapshot.** Use `tools/asset_runtime_resolver.py`
+output as the only `Asset Runtime Snapshot` content. Never hand-copy entry
+fields and never widen the four-field contract.
 21. **Bind the artifact, do not rebuild it.** The brief must ask the worker to
 load `godot_artifact.path` as `godot_artifact.type`. Never ask a worker to
 reconstruct a `SpriteFrames`, `AtlasTexture`, `StyleBoxTexture`, `Theme`, or
-`TileSet` from `source_layout` — that resource is already compiled and
-L0-L4-validated.
+`TileSet` from `source_layout`.
 22. **Animated artifacts are runtime behavior.** If the snapshot lists a
 `SpriteFrames` artifact, the worker brief must require animated runtime playback
 of the actions the mechanic needs. Do not collapse the task into "readable
@@ -166,14 +159,12 @@ presentation" or static feedback.
 23. **Temporary FX need lifecycle.** Animated projectile, impact, pickup,
 slash, aura, or feedback effects must state how the effect starts and how it
 disappears or clears.
-24. **Workers keep integration autonomy.** A worker may edit or replace a
+24. **Workers keep integration autonomy.** Let a worker edit or replace a
 project-local Godot resource, scene, or script — including a generated
 artifact — to fix an integration problem it hits. Do not demand a repair
-record, a revalidation pass, or a worker-authored skill for that; a note in the
-report is enough. What stays off-limits is producing the art itself. Never
-write a `Scope Boundaries` or `Prohibited Actions` line that cancels this: the
-File Ownership exception is narrower than the generic Deliverables restriction
-and must survive into the brief you send.
+record, a revalidation pass, or a worker-authored skill; accept a note in the
+report. Do not let a worker produce art. Never write a `Scope Boundaries` or
+`Prohibited Actions` line that cancels this exception.
 25. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
 
 ## Worker Utility Convention

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -40,9 +40,9 @@ Agent({
 - [ ] {file path}: {what it should contain}
 - [ ] {unit test file path}: {test scenarios — minimum 2 unit tests per changed system}
 - [ ] e2e-testable interface: public methods / signals / simulate_* helpers for affected systems/scenes/UI, with unit tests covering each one
-- [ ] If runtime assets include multi-frame `grid_sheet` entries: wire animation playback from metadata, not a static sheet or first frame
+- [ ] Load every `Asset Runtime Snapshot` `godot_artifact.path` and bind it as its declared `godot_artifact.type`; do not rebuild it from `source_layout`
+- [ ] If runtime assets include a `SpriteFrames` artifact: wire animation playback from that resource, not one static frame
 - [ ] If runtime assets include temporary animated FX: implement end-of-life behavior (animation finished, timer, tween completion, or equivalent state clear)
-- [ ] If runtime assets include `region_atlas` entries: bind each single-element node to its named region via AtlasTexture/region, not the whole atlas image
 - [ ] Run headless-build and confirm compilation
 - [ ] Run unit tests and include pass/fail output
 - [ ] If `Visual Self-Check` is present: capture screenshot(s), run visual-qa, include output
@@ -69,27 +69,31 @@ Agent({
 - DO NOT write files outside the project tree (system temp dirs, home directory, etc.). If you genuinely need a scratch file, create it under `.godotmaker/scratch/` (mkdir -p the directory if missing) and delete it before reporting DONE. Claude Code's own scratchpad system is gated behind a feature flag we cannot rely on, so this rule is what guarantees clean tear-down.
 
 ### Asset Runtime Snapshot                               [REQUIRED for visual tasks]
-{Resolve each `entry_path` in .godotmaker/asset-generation/manifest.json and copy
-the matching `ready` stable entries plus their ASSETS.md rows.
-Include: asset_id, production_family, source_layout.type, godot_artifact.type,
-godot_artifact.path, target size, frame_count, and the support metadata path for
-`grid_sheet` or `region_atlas`. Support metadata is always
-assets/generated/<production_family>/<asset_id>/<asset_id>.json.
-Use cwd-relative artifact paths and metadata paths.
-Use `ready` stable entries only; skip any other processing_status.
-The native compilers and the L0-L4 runner are not implemented, so generated
-entries currently stop at `source_ready` and this section is empty for them. Say
-so instead of listing a `source_ready` asset or inventing an artifact path.
+{List the assets the task binds from the current tag's `.godotmaker/asset-generation/manifest.json`
+pointer index, then resolve each one and paste the tool's JSON verbatim, one
+block per asset:
+
+```bash
+python tools/asset_runtime_resolver.py --project-root . --assets-md ASSETS.md \
+  --tag <tag> --asset-id <asset_id>
+```
+
+The resolver output IS this section. Do not copy fields out of a stable entry,
+the root index, or an ASSETS.md row by hand, and do not enrich the snapshot with
+target size, frame_count, fps, loop, frame paths, region names, region rects, or
+support metadata paths — the compiled `godot_artifact` already carries them, and
+a hand-added field is what makes a worker rebuild the resource instead of
+binding it.
+Name the runtime state or FX lifecycle a `SpriteFrames` artifact should play in
+`Game Mechanic Function`, not by pasting frame data here.
+The resolver fails closed: an unregistered pointer, a non-`ready` entry, a
+missing source or artifact file, and a reference-only asset all exit non-zero
+with an `error`. On failure, state the resolver's `error` and do not dispatch a
+visual task against an invented path — a reference-only asset never becomes a
+runtime asset, and a missing artifact means the asset must go back through
+`/gm-asset` first.
 Do not use `.godotmaker/asset-generation/sources/`, curation candidates,
-prompt files, or scene references as runtime assets.
-For `grid_sheet` with frame_count > 1, include the action metadata path,
-frame_paths, fps/loop when present, and the expected runtime state or FX
-lifecycle that should play it.
-For `region_atlas`, include the atlas metadata path and let the worker resolve
-the region and its rect from that metadata by name. Name the target region only
-when the element-to-region match is not obvious from the binding.
-If a required final asset or metadata file is missing, report PARTIAL or
-FAILED with the missing path.}
+prompt files, or scene references as runtime assets.}
 
 ### Visual Asset Contract                                [REQUIRED for visual tasks]
 {Copy the relevant PLAN.md Runtime Asset Assignments, SCENES.md Asset
@@ -97,12 +101,14 @@ FAILED with the missing path.}
  Include: asset row/path, runtime size, visual role, readability requirement,
  animation/lifecycle requirement when present, anchor/derivative source, and
  final runtime asset path.
- Use existing final paths from ASSETS.md or from the stable entries the
- .godotmaker/asset-generation/manifest.json index points at.
+ Take every generated runtime path from the resolved `Asset Runtime Snapshot`
+ above; only user-provided asset paths come from ASSETS.md directly.
  Do not use source sheets, curation candidates, prompt files, scene references,
  or ASSETS.md rows whose type is `reference` as runtime assets.
  Do not replace an available final asset with placeholder art, procedural
- shapes, or freshly drawn stand-ins.}
+ shapes, or freshly drawn stand-ins.
+ Image production belongs to `/gm-asset`: never ask a worker to generate,
+ draw, or synthesize art as part of runtime integration.}
 
 ### Visual Self-Check                                    [REQUIRED for fixgap visual tasks]
 - Source: {evaluation.json.visual_checks scene and blocking finding}
@@ -140,23 +146,32 @@ PLAN.md, or evaluation evidence that cites GDD.md or PLAN.md.
 14. **Worker self-check is mandatory**: Workers must run the self-check protocol before submitting their report. If self-check is not mentioned in the report, reject it.
 15. **UI/scene tasks require SCENES.md reference.** When dispatching a worker for any UI screen, HUD, menu, or scene layout task, you MUST copy the relevant scene description from SCENES.md into the brief. Workers without layout specs will produce inconsistent UIs.
 16. **Worker model from config.** Read `worker_model` from `.godotmaker/config.yaml` (default: `sonnet`) and include it as `model:` in every Agent() call. See the Agent Call template at the top.
-17. **Cwd-relative paths in the brief.** Fill every `{path}` placeholder as cwd-relative (e.g. `src/systems/s_jump.gd`, not `D:/.../src/systems/s_jump.gd`).
+17. **Cwd-relative paths in the brief.** Fill every `{path}` placeholder as cwd-relative (e.g. `src/systems/s_jump.gd`, not `D:/.../src/systems/s_jump.gd`). The one exception is `Asset Runtime Snapshot`: leave the resolver's `res://` paths exactly as emitted — that is what the worker passes to `load()`.
 18. **Non-interactive execution.** Every worker brief MUST prohibit approval requests, user-input waits, and confirmation pauses.
 19. **Visual tasks require runtime assets.** Fill `Asset Runtime Snapshot` and
 `Visual Asset Contract` for visual tasks.
-20. **Multi-frame assets are runtime behavior.** If the snapshot lists a
-`grid_sheet` with frame_count > 1, the worker brief must require animated
-runtime playback from metadata. Do not collapse the task into "readable
+20. **The resolver owns the snapshot.** `tools/asset_runtime_resolver.py` output
+is the only legal `Asset Runtime Snapshot` content. Never hand-copy entry
+fields, and never widen the four-field contract — the manager's job is to run
+the resolver and paste it, not to interpret a stable entry.
+21. **Bind the artifact, do not rebuild it.** The brief must ask the worker to
+load `godot_artifact.path` as `godot_artifact.type`. Never ask a worker to
+reconstruct a `SpriteFrames`, `AtlasTexture`, `StyleBoxTexture`, `Theme`, or
+`TileSet` from `source_layout` — that resource is already compiled and
+L0-L4-validated.
+22. **Animated artifacts are runtime behavior.** If the snapshot lists a
+`SpriteFrames` artifact, the worker brief must require animated runtime playback
+of the actions the mechanic needs. Do not collapse the task into "readable
 presentation" or static feedback.
-21. **Temporary FX need lifecycle.** Animated projectile, impact, pickup,
+23. **Temporary FX need lifecycle.** Animated projectile, impact, pickup,
 slash, aura, or feedback effects must state how the effect starts and how it
 disappears or clears.
-22. **Region atlases are single regions.** If the snapshot lists a
-`region_atlas`, require selecting the element's named region from the atlas
-metadata via AtlasTexture/region. Name the target region only when the match is
-not obvious from the binding. Never assign the whole atlas image as one texture
-where a single element is required.
-23. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
+24. **Workers keep integration autonomy.** A worker may edit or replace a
+project-local Godot resource, scene, or script — including a generated
+artifact — to fix an integration problem it hits. Do not demand a repair
+record, a revalidation pass, or a worker-authored skill for that; a note in the
+report is enough. What stays off-limits is producing the art itself.
+25. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
 
 ## Worker Utility Convention
 

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -54,7 +54,7 @@ Agent({
 
 ### Scope Boundaries                                     [REQUIRED]
 - MUST: {explicit requirements}
-- MUST NOT: {explicit prohibitions — always include "MUST NOT modify files outside Deliverables"}
+- MUST NOT: {explicit prohibitions — always include "MUST NOT modify files outside Deliverables, except the runtime asset integration repair exception in the worker agent's File Ownership section"}
 
 ### Gotchas                                              [REQUIRED for ECS tasks]
 - MUST include: "Read .claude/skills/gecs/gotchas.md before writing any code"
@@ -63,7 +63,7 @@ Agent({
 ### Prohibited Actions                                   [REQUIRED]
 - DO NOT ask for approval, wait for user input, or pause for confirmation. Execute the task directly. If required information or external state is missing, report `PARTIAL` or `FAILED` with the blocker.
 - DO NOT fabricate resource paths — only use paths listed in ASSETS.md or verified to exist in the project. If you need an asset that doesn't exist, report it in your summary; do NOT invent a path.
-- DO NOT modify files outside your Deliverables list — read-only access to all other files.
+- DO NOT modify files outside your Deliverables list — read-only access to all other files. The single exception is runtime asset integration repair (worker agent, File Ownership): the artifact you were told to bind, plus the project-local scene or script that binds it, may be edited or replaced to fix a concrete integration failure. That exception overrides this line for those files only; report every one of them in Notes.
 - DO NOT write `test_system_has_query` tests — system.q is null outside World (see gecs gotcha G14).
 - DO NOT introduce E2E-only gameplay changes.
 - DO NOT write files outside the project tree (system temp dirs, home directory, etc.). If you genuinely need a scratch file, create it under `.godotmaker/scratch/` (mkdir -p the directory if missing) and delete it before reporting DONE. Claude Code's own scratchpad system is gated behind a feature flag we cannot rely on, so this rule is what guarantees clean tear-down.
@@ -170,7 +170,10 @@ disappears or clears.
 project-local Godot resource, scene, or script — including a generated
 artifact — to fix an integration problem it hits. Do not demand a repair
 record, a revalidation pass, or a worker-authored skill for that; a note in the
-report is enough. What stays off-limits is producing the art itself.
+report is enough. What stays off-limits is producing the art itself. Never
+write a `Scope Boundaries` or `Prohibited Actions` line that cancels this: the
+File Ownership exception is narrower than the generic Deliverables restriction
+and must survive into the brief you send.
 25. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
 
 ## Worker Utility Convention

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -190,11 +190,10 @@ straight from the root index.
 
 ## Runtime Snapshot Resolution
 
-The resolver is the deterministic reader for one registered runtime asset, and
-its output *is* the worker-dispatch `Asset Runtime Snapshot`. `/gm-build` and
-`/gm-fixgap` paste one resolver block per asset into the worker brief; they do
-not copy entry fields by hand or enrich the four-field contract with target
-size, support metadata, or frame data.
+The resolver is the deterministic reader for one registered runtime asset. Its
+output is the complete worker runtime snapshot: one resolver block per asset,
+carrying no hand-copied entry field and no added target size, support metadata
+path, or frame data.
 
 Resolve the current-tag ASSETS.md row:
 

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -190,11 +190,11 @@ straight from the root index.
 
 ## Runtime Snapshot Resolution
 
-The resolver is the deterministic reader for one registered runtime asset. It
-does not by itself change the published worker-dispatch brief format; that
-integration remains a follow-up for WOR-233 because this v1 entry exposes only
-the four-field runtime contract, while the existing brief also requires target
-size, support metadata, frame data, and cwd-relative paths.
+The resolver is the deterministic reader for one registered runtime asset, and
+its output *is* the worker-dispatch `Asset Runtime Snapshot`. `/gm-build` and
+`/gm-fixgap` paste one resolver block per asset into the worker brief; they do
+not copy entry fields by hand or enrich the four-field contract with target
+size, support metadata, or frame data.
 
 Resolve the current-tag ASSETS.md row:
 

--- a/skills/core/gm-build/SKILL.md
+++ b/skills/core/gm-build/SKILL.md
@@ -44,7 +44,7 @@ Apply the resume gates in this order:
 Then read context:
 - `PLAN.md` → current tag's `**Tag:**` header + Tag Mechanics + Inherited Mechanics + Playable Unit + pending/in_progress/completed tasks (anything not `verified`)
 - `STRUCTURE.md` → architecture and build order (current tag scope: previous tags' systems already exist on disk and may be touched only when PLAN.md explicitly lists a refactor task for them)
-- `ASSETS.md` and `.godotmaker/asset-generation/manifest.json` → the pointer index to generated assets; resolve each `entry_path` to a stable entry for `godot_artifact`, `source_layout`, and support metadata paths for visual tasks
+- `ASSETS.md` and `.godotmaker/asset-generation/manifest.json` → the pointer index to generated assets; for a visual task, resolve each asset with `tools/asset_runtime_resolver.py` instead of reading stable-entry fields yourself
 - `MEMORY.md` index + sub-files (cross-tag accumulating notebook) → avoid repeating known mistakes
 - `docs/tags/<prev_tag>/STRUCTURE.md` (only if PLAN.md has Inherited Mechanics or refactor tasks touching prior systems) → know what already exists before adding/refactoring
 
@@ -118,7 +118,10 @@ Do NOT delete project code as a "fix" for a tool crash.
 - Use `subagent_type: "worker"`. Each worker implements ONE game mechanic function + its tests.
 - Include the relevant Playable Unit fields in each worker brief.
 - For visual tasks, fill the `Asset Runtime Snapshot` and
-  `Visual Asset Contract` sections from `references/worker-dispatch.md`.
+  `Visual Asset Contract` sections from `references/worker-dispatch.md`. The
+  snapshot is `tools/asset_runtime_resolver.py` output pasted verbatim — never
+  hand-copied entry fields. If the resolver fails for an asset, report its
+  `error` instead of dispatching the task against an invented path.
 - Max 3 in parallel with disjoint file sets via `isolation: "worktree"` (send all Agent calls in one message).
 - After each worker reports DONE, mark its task in PLAN.md as `completed`.
 - **`main_scene` retarget is your job.** Scaffold leaves `run/main_scene="res://scenes/main.tscn"` (placeholder). After the worker that creates this tag's entry scene (per SCENES.md) completes and the `.tscn` is on disk, `Edit` `project.godot`'s `[application] run/main_scene` to `res://<path>`.

--- a/skills/core/gm-fixgap/SKILL.md
+++ b/skills/core/gm-fixgap/SKILL.md
@@ -39,7 +39,7 @@ Then read context:
 - `.godotmaker/verify_report.json` → mechanical-layer failures from the most recent verify
 - `PLAN.md` → read-only; current tag's `**Tag:**` header tells you which tag's gaps you're fixing. The same tag-scope discipline as gm-build applies: previous tags' code is touchable only when a GAP item explicitly names it.
 - `STRUCTURE.md` → architecture (fixes need to respect existing system boundaries)
-- `ASSETS.md` and `.godotmaker/asset-generation/manifest.json` → the pointer index to generated assets; resolve each `entry_path` to a stable entry for `godot_artifact`, `source_layout`, and support metadata paths for visual tasks
+- `ASSETS.md` and `.godotmaker/asset-generation/manifest.json` → the pointer index to generated assets; for a visual task, resolve each asset with `tools/asset_runtime_resolver.py` instead of reading stable-entry fields yourself
 - `MEMORY.md` index + sub-files → past decisions and known gotchas
 
 ## Hard Rules
@@ -173,7 +173,10 @@ Worker-dispatch tasks only — Step 1b classified main-agent-direct and escalate
 - Use `subagent_type: "worker"`. Max 3 in parallel with disjoint file sets via `isolation: "worktree"`.
 - In each brief, paste the specific finding from GAP.md, the file(s) to modify, and the correct behavior from GDD.md.
 - For visual tasks, fill `Asset Runtime Snapshot` from
-  `references/worker-dispatch.md`.
+  `references/worker-dispatch.md`. The snapshot is
+  `tools/asset_runtime_resolver.py` output pasted verbatim — never hand-copied
+  entry fields. If the resolver fails for an asset, report its `error` instead
+  of dispatching the task against an invented path.
 - For blocking evaluation-source visual tasks, fill `Visual Asset Contract` and
   `Visual Self-Check` from `references/worker-dispatch.md`.
 - Update task status `pending` → `in_progress` when dispatched, `in_progress` → `completed` when worker reports DONE.

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -373,7 +373,12 @@ def test_manager_never_copies_stable_entry_fields_into_a_brief():
     assert prohibition in worker_dispatch
     assert "**The resolver owns the snapshot.**" in worker_dispatch
     assert "never widen the four-field contract" in worker_dispatch
-    assert "they do not copy entry fields by hand" in runtime
+    # The pipeline reference states the same contract as a neutral fact about
+    # the snapshot, without assigning the work to a consuming skill.
+    assert (
+        "carrying no hand-copied entry field and no added target size, support "
+        "metadata path, or frame data" in runtime
+    )
 
     # The retired enrichment instructions must not come back. Scan with the
     # prohibition itself removed — it necessarily names the fields it forbids.
@@ -586,29 +591,35 @@ def test_worker_repairs_integration_without_absorbing_art_production():
     assert "Never ask a worker to generate, draw, or synthesize art." in flat_dispatch
 
 
-def test_worker_prompts_state_boundaries_without_naming_another_skills_owner():
-    """A prohibition here must stop at the prohibition.
+def test_runtime_handoff_docs_never_assign_work_to_another_skill():
+    """Each document states its own role's boundary and stops.
 
-    Appending "— that's `/gm-asset`'s job" to a worker rule pins another skill's
-    ownership into a prompt that does not own it, so the reference has to be
-    chased and updated whenever that responsibility moves. The worker only needs
-    its own boundary.
+    Attribution cuts both ways: a worker rule ending "— that's `/gm-asset`'s
+    job", and a `gm-asset` reference declaring what `/gm-build` does, both pin a
+    responsibility into a document that does not own it, so every future move of
+    that responsibility has to chase the copies. The owning SKILL is the one
+    place it belongs.
     """
-    owned_by_this_role = {
-        "agents/worker.md": _read("agents/worker.md"),
-        "skills/core/_shared/worker-dispatch.md": _read(
-            "skills/core/_shared/worker-dispatch.md"
+    # Each doc is checked against the skills it must not speak for.
+    foreign_owners = {
+        "agents/worker.md": ("gm-asset",),
+        "skills/core/_shared/worker-dispatch.md": ("gm-asset",),
+        "skills/core/gm-asset/references/asset-runtime-pipeline.md": (
+            "gm-build",
+            "gm-fixgap",
         ),
     }
 
     offenders = []
-    for name, text in owned_by_this_role.items():
-        for index, line in enumerate(text.splitlines(), start=1):
-            if "gm-asset" in line:
-                offenders.append(f"{name}:{index}: {line.strip()}")
+    for name, skills in foreign_owners.items():
+        for index, line in enumerate(_read(name).splitlines(), start=1):
+            for skill in skills:
+                if skill in line:
+                    offenders.append(f"{name}:{index}: {line.strip()}")
+                    break
 
     assert not offenders, (
-        "worker-side prompts must not attribute work to another skill: "
+        "these lines assign work to a skill that does not own this document: "
         + "; ".join(offenders)
     )
 

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -331,7 +331,7 @@ def test_build_and_fixgap_handoff_runtime_assets_to_workers():
 
     assert "### Asset Runtime Snapshot" in worker_dispatch
     assert "tools/asset_runtime_resolver.py --project-root . --assets-md ASSETS.md" in worker_dispatch
-    assert "The resolver output IS this section." in worker_dispatch
+    assert "Paste the resolver output as this section." in worker_dispatch
     assert "Do not use `.godotmaker/asset-generation/sources/`" in worker_dispatch
     # Generated-asset runtime handoff reads the generated manifest, never the
     # analyst's user-provided-asset classification manifest.
@@ -342,7 +342,7 @@ def test_build_and_fixgap_handoff_runtime_assets_to_workers():
 
     # The worker binds the compiled resource; animation and FX lifecycle stay
     # runtime behavior, they just come out of `SpriteFrames` now.
-    assert "bind it as that type" in worker
+    assert "bind it as `godot_artifact.type`" in _flat(worker)
     assert "wire animation playback from that resource" in worker_dispatch
     assert "`SpriteFrames` artifact" in worker_dispatch
     assert "temporary animated FX" in worker_dispatch
@@ -363,10 +363,13 @@ def test_manager_never_copies_stable_entry_fields_into_a_brief():
     runtime = _flat(_read("skills/core/gm-asset/references/asset-runtime-pipeline.md"))
 
     prohibition = (
-        "do not enrich the snapshot with target size, frame_count, fps, loop, "
-        "frame paths, region names, region rects, or support metadata paths"
+        "Do not add target size, frame_count, fps, loop, frame paths, region "
+        "names, region rects, or support metadata paths."
     )
-    assert "Do not copy fields out of a stable entry, the root index, or an ASSETS.md row by hand" in worker_dispatch
+    assert (
+        "Do not copy fields out of a stable entry, the root index, or an ASSETS.md row by hand."
+        in worker_dispatch
+    )
     assert prohibition in worker_dispatch
     assert "**The resolver owns the snapshot.**" in worker_dispatch
     assert "never widen the four-field contract" in worker_dispatch
@@ -411,12 +414,12 @@ def test_worker_binds_the_compiled_artifact_instead_of_rebuilding_it():
             assert f"`{artifact_type}`" in flat, (
                 f"{artifact_type} has no stated binding contract"
             )
-        assert "from `source_layout`" in flat or "out of `source_layout.path`" in flat
+        assert "reconstruct a" in flat and "source_layout" in flat
 
-    assert "it is not an input to your code" in _flat(worker)
+    assert "do not pass it to your code" in _flat(worker)
     assert "re-slice, re-grid, or re-region" in worker
-    # The compiled AtlasTexture already is one region — nothing to look up.
-    assert "already exactly one region" in worker
+    # The compiled AtlasTexture is the region, so the sheet is never the texture.
+    assert "Never substitute the physical atlas image behind it." in _flat(worker)
     assert "`TileMapLayer.tile_set`" in worker
 
 
@@ -431,10 +434,13 @@ def test_a_missing_artifact_fails_closed_instead_of_reaching_a_worker():
     build = _flat(_read("skills/core/gm-build/SKILL.md"))
     fixgap = _flat(_read("skills/core/gm-fixgap/SKILL.md"))
 
-    assert "The resolver fails closed" in worker_dispatch
+    assert "The resolver exits non-zero with an `error`" in worker_dispatch
     assert "a missing source or artifact file" in worker_dispatch
-    assert "do not dispatch a visual task against an invented path" in worker_dispatch
-    assert "must go back through `/gm-asset` first" in worker_dispatch
+    assert "do not dispatch the visual task" in worker_dispatch
+    assert (
+        "Never fill this section with an artifact path the resolver did not emit."
+        in worker_dispatch
+    )
     for doc in (build, fixgap):
         assert "report its `error` instead of dispatching the task against an invented path" in doc
 
@@ -449,8 +455,7 @@ def test_reference_only_assets_never_become_worker_runtime_assets():
         ),
     }
 
-    assert "a reference-only asset never becomes a runtime asset" in reference_docs["worker-dispatch.md"]
-    assert "a reference-only asset all exit non-zero" in reference_docs["worker-dispatch.md"]
+    assert "and a reference-only asset." in reference_docs["worker-dispatch.md"]
     assert (
         "Reference-only entries are valid manifest records but never produce a worker runtime snapshot."
         in reference_docs["asset-runtime-pipeline.md"]
@@ -505,9 +510,15 @@ def test_integration_repair_exception_is_explicit_narrow_and_wins():
 
     assert "### Exception: runtime asset integration repair" in worker
     # Precedence is stated, not left to the reader to infer from ordering.
-    assert "One exception overrides the rule above, and nothing else does." in flat_worker
-    assert "this exception is the narrower rule and it wins" in flat_worker
-    assert "That exception overrides this line for those files only" in flat_dispatch
+    assert "This exception overrides the rule above, and nothing else does." in flat_worker
+    assert (
+        "It also overrides your brief's `Scope Boundaries` and `Prohibited Actions` lines."
+        in flat_worker
+    )
+    assert (
+        "overrides this line for the bound artifact and the project-local scene "
+        "or script that binds it" in flat_dispatch
+    )
     # A brief must not be able to re-close the door the agent definition opened.
     assert (
         "Never write a `Scope Boundaries` or `Prohibited Actions` line that cancels this"
@@ -532,7 +543,10 @@ def test_integration_repair_exception_is_explicit_narrow_and_wins():
 
     # The only obligation stays a report line.
     assert "List every file you touched under this exception in your report's Notes." in flat_worker
-    assert "no repair record, no revalidation pass, no new skill" in flat_worker
+    assert (
+        "Do not write a repair record, run a revalidation pass, or author a new skill."
+        in flat_worker
+    )
 
 
 def test_worker_repairs_integration_without_absorbing_art_production():
@@ -549,26 +563,53 @@ def test_worker_repairs_integration_without_absorbing_art_production():
 
     # Autonomy: the worker owns project-local Godot resources, scenes, scripts.
     assert "**Integration repair is yours.**" in worker
-    assert "edit or replace a project-local Godot resource, scene, or script" in flat_worker
+    assert "edit or replace the project-local Godot resource, scene, or script" in flat_worker
     assert "including a generated `.tres`" in flat_worker
     assert "**Workers keep integration autonomy.**" in worker_dispatch
     assert (
-        "may edit or replace a project-local Godot resource, scene, or script"
+        "Let a worker edit or replace a project-local Godot resource, scene, or script"
         in flat_dispatch
     )
 
     # No repair bureaucracy: no record, no revalidation pass, no worker-authored skill.
-    assert "No repair record, revalidation pass, or new skill is required of you." in flat_worker
+    assert (
+        "Do not write a repair record, run a revalidation pass, or author a new skill."
+        in flat_worker
+    )
     assert "Do not demand a repair record, a revalidation pass, or a worker-authored skill" in flat_dispatch
 
-    # But art production stays with /gm-asset on both sides of the handoff.
+    # Art production is refused outright, with no owner named on either side.
     assert "**Art production is never yours.**" in worker
+    assert "Do not draw, generate, synthesize, or procedurally substitute images" in flat_worker
     assert "do not run an asset-generation skill or tool to fill a gap" in flat_worker
-    assert "That responsibility stays with `/gm-asset`." in flat_worker
-    assert "What stays off-limits is producing the art itself." in flat_dispatch
-    assert (
-        "never ask a worker to generate, draw, or synthesize art as part of runtime integration"
-        in flat_dispatch
+    assert "Do not let a worker produce art." in flat_dispatch
+    assert "Never ask a worker to generate, draw, or synthesize art." in flat_dispatch
+
+
+def test_worker_prompts_state_boundaries_without_naming_another_skills_owner():
+    """A prohibition here must stop at the prohibition.
+
+    Appending "— that's `/gm-asset`'s job" to a worker rule pins another skill's
+    ownership into a prompt that does not own it, so the reference has to be
+    chased and updated whenever that responsibility moves. The worker only needs
+    its own boundary.
+    """
+    owned_by_this_role = {
+        "agents/worker.md": _read("agents/worker.md"),
+        "skills/core/_shared/worker-dispatch.md": _read(
+            "skills/core/_shared/worker-dispatch.md"
+        ),
+    }
+
+    offenders = []
+    for name, text in owned_by_this_role.items():
+        for index, line in enumerate(text.splitlines(), start=1):
+            if "gm-asset" in line:
+                offenders.append(f"{name}:{index}: {line.strip()}")
+
+    assert not offenders, (
+        "worker-side prompts must not attribute work to another skill: "
+        + "; ".join(offenders)
     )
 
 
@@ -843,7 +884,7 @@ def test_region_atlas_single_region_contract():
     evaluate = _read("skills/core/gm-evaluate/SKILL.md")
 
     # The worker binds the compiled region and never falls back to the sheet.
-    assert "never substitute the physical atlas image behind" in _flat(worker)
+    assert "Never substitute the physical atlas image behind it." in _flat(worker)
     assert "the element-to-region match is not obvious" in reviewer_dispatch
 
     # Reviewer flags whole-atlas misuse as an issue.

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -313,6 +313,11 @@ def test_asset_stage_runs_stable_entry_gate_before_assets_update():
 
 
 def test_build_and_fixgap_handoff_runtime_assets_to_workers():
+    """Normal handoff: the resolver output travels from manager to worker.
+
+    The manager's only job is to run `asset_runtime_resolver.py` per asset and
+    paste the result; the worker's only job is to load the artifact it names.
+    """
     build = _read("skills/core/gm-build/SKILL.md")
     fixgap = _read("skills/core/gm-fixgap/SKILL.md")
     worker_dispatch = _read("skills/core/_shared/worker-dispatch.md")
@@ -321,24 +326,177 @@ def test_build_and_fixgap_handoff_runtime_assets_to_workers():
     for doc in (build, fixgap):
         assert "`ASSETS.md` and `.godotmaker/asset-generation/manifest.json`" in doc
         assert "Asset Runtime Snapshot" in doc
+        assert "tools/asset_runtime_resolver.py" in doc
+        assert "pasted verbatim" in _flat(doc)
 
     assert "### Asset Runtime Snapshot" in worker_dispatch
-    assert "Use `ready` stable entries only" in worker_dispatch
-    assert "`grid_sheet` or `region_atlas`" in worker_dispatch
+    assert "tools/asset_runtime_resolver.py --project-root . --assets-md ASSETS.md" in worker_dispatch
+    assert "The resolver output IS this section." in worker_dispatch
     assert "Do not use `.godotmaker/asset-generation/sources/`" in worker_dispatch
     # Generated-asset runtime handoff reads the generated manifest, never the
     # analyst's user-provided-asset classification manifest.
     assert ".godotmaker/asset-generation/manifest.json" in worker_dispatch
     assert ".godotmaker/asset-generation/manifest.json" in worker
     assert "## Runtime Asset Rules" in worker
-    assert "For `grid_sheet`, read the listed action metadata JSON" in worker
-    assert "For `region_atlas`, read the listed atlas metadata JSON" in worker
-    assert "wire animation playback from metadata" in worker_dispatch
-    assert "frame_count > 1" in worker_dispatch
+    assert "tools/asset_runtime_resolver.py" in worker
+
+    # The worker binds the compiled resource; animation and FX lifecycle stay
+    # runtime behavior, they just come out of `SpriteFrames` now.
+    assert "bind it as that type" in worker
+    assert "wire animation playback from that resource" in worker_dispatch
+    assert "`SpriteFrames` artifact" in worker_dispatch
     assert "temporary animated FX" in worker_dispatch
-    assert "do not use the sheet as a static" in worker
-    assert "do not use only the first frame" in worker
+    assert "`AnimatedSprite2D.sprite_frames`" in worker
+    assert "do not reduce a multi-frame actor or FX to one static frame" in _flat(worker)
     assert "effect lifecycle" in worker
+
+
+def test_manager_never_copies_stable_entry_fields_into_a_brief():
+    """A hand-copied field is how a rebuild instruction gets back into a brief.
+
+    The v1 snapshot is exactly asset_id / production_family / source_layout /
+    godot_artifact. The moment a manager re-adds frame counts, region rects, or
+    support-metadata paths, the worker has everything it needs to reconstruct
+    the resource — and will, instead of loading the compiled one.
+    """
+    worker_dispatch = _flat(_read("skills/core/_shared/worker-dispatch.md"))
+    runtime = _flat(_read("skills/core/gm-asset/references/asset-runtime-pipeline.md"))
+
+    prohibition = (
+        "do not enrich the snapshot with target size, frame_count, fps, loop, "
+        "frame paths, region names, region rects, or support metadata paths"
+    )
+    assert "Do not copy fields out of a stable entry, the root index, or an ASSETS.md row by hand" in worker_dispatch
+    assert prohibition in worker_dispatch
+    assert "**The resolver owns the snapshot.**" in worker_dispatch
+    assert "never widen the four-field contract" in worker_dispatch
+    assert "they do not copy entry fields by hand" in runtime
+
+    # The retired enrichment instructions must not come back. Scan with the
+    # prohibition itself removed — it necessarily names the fields it forbids.
+    remainder = worker_dispatch.replace(prohibition, "")
+    for token in (
+        "Support metadata is always",
+        "atlas metadata path",
+        "action metadata path",
+        "frame_paths",
+        "frame_count",
+    ):
+        assert token not in remainder, (
+            f"worker-dispatch.md re-introduced hand-copied snapshot data: {token}"
+        )
+
+
+def test_worker_binds_the_compiled_artifact_instead_of_rebuilding_it():
+    """`source_layout` is provenance. Rebuilding from it discards L0-L4.
+
+    Every compiled type is named explicitly: a rule that only forbids rebuilding
+    `SpriteFrames` still lets a worker hand-assemble a `Theme` or re-slice an
+    atlas.
+    """
+    worker = _read("agents/worker.md")
+    worker_dispatch = _read("skills/core/_shared/worker-dispatch.md")
+
+    assert "**Bind the artifact, do not rebuild it.**" in worker
+    assert "**Bind the artifact, do not rebuild it.**" in worker_dispatch
+    for doc in (worker, worker_dispatch):
+        flat = _flat(doc)
+        for artifact_type in (
+            "SpriteFrames",
+            "AtlasTexture",
+            "StyleBoxTexture",
+            "Theme",
+            "TileSet",
+        ):
+            assert f"`{artifact_type}`" in flat, (
+                f"{artifact_type} has no stated binding contract"
+            )
+        assert "from `source_layout`" in flat or "out of `source_layout.path`" in flat
+
+    assert "it is not an input to your code" in _flat(worker)
+    assert "re-slice, re-grid, or re-region" in worker
+    # The compiled AtlasTexture already is one region — nothing to look up.
+    assert "already exactly one region" in worker
+    assert "`TileMapLayer.tile_set`" in worker
+
+
+def test_a_missing_artifact_fails_closed_instead_of_reaching_a_worker():
+    """No artifact means no visual dispatch — not an invented path.
+
+    The resolver already refuses; these docs are what stops a manager from
+    routing around the refusal and a worker from silently substituting art.
+    """
+    worker_dispatch = _flat(_read("skills/core/_shared/worker-dispatch.md"))
+    worker = _read("agents/worker.md")
+    build = _flat(_read("skills/core/gm-build/SKILL.md"))
+    fixgap = _flat(_read("skills/core/gm-fixgap/SKILL.md"))
+
+    assert "The resolver fails closed" in worker_dispatch
+    assert "a missing source or artifact file" in worker_dispatch
+    assert "do not dispatch a visual task against an invented path" in worker_dispatch
+    assert "must go back through `/gm-asset` first" in worker_dispatch
+    for doc in (build, fixgap):
+        assert "report its `error` instead of dispatching the task against an invented path" in doc
+
+    assert "report `PARTIAL` or `FAILED` with the missing path. Do not invent one." in _flat(worker)
+
+
+def test_reference_only_assets_never_become_worker_runtime_assets():
+    reference_docs = {
+        "worker-dispatch.md": _flat(_read("skills/core/_shared/worker-dispatch.md")),
+        "asset-runtime-pipeline.md": _flat(
+            _read("skills/core/gm-asset/references/asset-runtime-pipeline.md")
+        ),
+    }
+
+    assert "a reference-only asset never becomes a runtime asset" in reference_docs["worker-dispatch.md"]
+    assert "a reference-only asset all exit non-zero" in reference_docs["worker-dispatch.md"]
+    assert (
+        "Reference-only entries are valid manifest records but never produce a worker runtime snapshot."
+        in reference_docs["asset-runtime-pipeline.md"]
+    )
+    # ASSETS.md `reference` rows stay out of the visual contract too.
+    assert (
+        "or ASSETS.md rows whose type is `reference` as runtime assets"
+        in reference_docs["worker-dispatch.md"]
+    )
+
+
+def test_worker_repairs_integration_without_absorbing_art_production():
+    """Two boundaries in one place, because they fail in opposite directions.
+
+    Too tight and a worker stalls on a project-integration problem it could fix;
+    too loose and it starts drawing replacement art, which silently moves image
+    production out of `/gm-asset` and out of L0-L4.
+    """
+    worker = _read("agents/worker.md")
+    worker_dispatch = _read("skills/core/_shared/worker-dispatch.md")
+    flat_worker = _flat(worker)
+    flat_dispatch = _flat(worker_dispatch)
+
+    # Autonomy: the worker owns project-local Godot resources, scenes, scripts.
+    assert "**Integration repair is yours.**" in worker
+    assert "edit or replace a project-local Godot resource, scene, or script" in flat_worker
+    assert "including a generated `.tres`" in flat_worker
+    assert "**Workers keep integration autonomy.**" in worker_dispatch
+    assert (
+        "may edit or replace a project-local Godot resource, scene, or script"
+        in flat_dispatch
+    )
+
+    # No repair bureaucracy: no record, no revalidation pass, no worker-authored skill.
+    assert "No repair record, revalidation pass, or new skill is required of you." in flat_worker
+    assert "Do not demand a repair record, a revalidation pass, or a worker-authored skill" in flat_dispatch
+
+    # But art production stays with /gm-asset on both sides of the handoff.
+    assert "**Art production is never yours.**" in worker
+    assert "do not run an asset-generation skill or tool to fill a gap" in flat_worker
+    assert "That responsibility stays with `/gm-asset`." in flat_worker
+    assert "What stays off-limits is producing the art itself." in flat_dispatch
+    assert (
+        "never ask a worker to generate, draw, or synthesize art as part of runtime integration"
+        in flat_dispatch
+    )
 
 
 def test_reviewer_checks_runtime_asset_usage_and_evaluate_uses_scene_contract():
@@ -599,25 +757,20 @@ def test_runtime_resolver_is_documented_as_a_registered_assets_reader():
 
 
 def test_region_atlas_single_region_contract():
+    """Whole-atlas misuse stays a finding after the artifact handoff change.
+
+    The worker no longer looks a region up by name — its `AtlasTexture` already
+    is the region (see the artifact-binding test). What must survive is the
+    review side: substituting the physical atlas for a single element is still
+    caught.
+    """
     worker = _read("agents/worker.md")
-    worker_dispatch = _read("skills/core/_shared/worker-dispatch.md")
     reviewer_dispatch = _read("skills/core/_shared/reviewer-dispatch.md")
     reviewer = _read("agents/reviewer.md")
     evaluate = _read("skills/core/gm-evaluate/SKILL.md")
 
-    # Worker resolves the region by name from metadata, not the whole atlas image.
-    assert "matching region by name from it" in worker
-    assert "Use the region named in the brief when given" in worker
-    assert "must reference its named region via `AtlasTexture`" in worker
-    assert "Do not use a whole `region_atlas` or `grid_sheet` image as one visible sprite" in worker
-
-    # Dispatch passes only the metadata path; region names come from metadata,
-    # and the target region is named only when the match is not obvious.
-    assert "bind each single-element node to its named region via AtlasTexture/region" in worker_dispatch
-    assert "Region atlases are single regions." in worker_dispatch
-    assert "the region and its rect from that metadata by name" in worker_dispatch
-    assert "the element-to-region match is not obvious" in worker_dispatch
-    assert "region names/count" not in worker_dispatch
+    # The worker binds the compiled region and never falls back to the sheet.
+    assert "never substitute the physical atlas image behind" in _flat(worker)
     assert "the element-to-region match is not obvious" in reviewer_dispatch
 
     # Reviewer flags whole-atlas misuse as an issue.

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -462,6 +462,79 @@ def test_reference_only_assets_never_become_worker_runtime_assets():
     )
 
 
+def test_no_deliverables_restriction_cancels_the_integration_repair_exception():
+    """The autonomy grant is worthless if a nearby MUST NOT overrides it.
+
+    File ownership and runtime asset repair live in the same prompt, so stating
+    the exception once is not enough — an agent that reads only the generic
+    "MUST NOT modify files outside Deliverables" stops and reports instead of
+    repairing. Every place that states the restriction must carry the carve-out,
+    which is a structural property no single text-presence assertion catches.
+    """
+    restriction = re.compile(r"modify (?:files|a file) (?:outside|not in) [^\n]*", re.IGNORECASE)
+    sources = {
+        "agents/worker.md": _read("agents/worker.md"),
+        "skills/core/_shared/worker-dispatch.md": _read(
+            "skills/core/_shared/worker-dispatch.md"
+        ),
+    }
+
+    uncarved = []
+    for name, text in sources.items():
+        statements = [
+            (index, line)
+            for index, line in enumerate(text.splitlines(), start=1)
+            if restriction.search(line)
+        ]
+        assert statements, f"{name} lost its file-ownership restriction entirely"
+        for index, line in statements:
+            if "exception" not in line.lower():
+                uncarved.append(f"{name}:{index}: {line.strip()}")
+
+    assert not uncarved, (
+        "these Deliverables restrictions cancel the runtime asset integration "
+        "repair exception: " + "; ".join(uncarved)
+    )
+
+
+def test_integration_repair_exception_is_explicit_narrow_and_wins():
+    """The exception must beat the general rule, and stop right after it."""
+    worker = _read("agents/worker.md")
+    flat_worker = _flat(worker)
+    flat_dispatch = _flat(_read("skills/core/_shared/worker-dispatch.md"))
+
+    assert "### Exception: runtime asset integration repair" in worker
+    # Precedence is stated, not left to the reader to infer from ordering.
+    assert "One exception overrides the rule above, and nothing else does." in flat_worker
+    assert "this exception is the narrower rule and it wins" in flat_worker
+    assert "That exception overrides this line for those files only" in flat_dispatch
+    # A brief must not be able to re-close the door the agent definition opened.
+    assert (
+        "Never write a `Scope Boundaries` or `Prohibited Actions` line that cancels this"
+        in flat_dispatch
+    )
+
+    # Narrow: exactly the artifact plus the scene/script that binds it.
+    assert "the `.tres` / `.res` artifact you were told to bind" in flat_worker
+    assert "the project-local scene or script that binds it" in flat_worker
+
+    # And bounded — an unbounded exception is just a repeal of file ownership.
+    for excluded in (
+        "images, or any art you would have to produce yourself",
+        "`.godotmaker/asset-generation/` entries, the root index, or `sources/`",
+        "unrelated files, refactors, or improvements",
+    ):
+        assert excluded in flat_worker, f"the exception lost a boundary: {excluded}"
+    for protected in ("PLAN.md", "STRUCTURE.md", "SCENES.md", "GAP.md", "ASSETS.md", "e2e/"):
+        assert protected in flat_worker.split("It never covers:", 1)[1].split("List every file", 1)[0], (
+            f"{protected} dropped out of the exception's exclusion list"
+        )
+
+    # The only obligation stays a report line.
+    assert "List every file you touched under this exception in your report's Notes." in flat_worker
+    assert "no repair record, no revalidation pass, no new skill" in flat_worker
+
+
 def test_worker_repairs_integration_without_absorbing_art_production():
     """Two boundaries in one place, because they fail in opposite directions.
 


### PR DESCRIPTION
## Summary

Give runtime workers the resolver-produced minimal `godot_artifact` snapshot, so they bind compiled Godot artifacts rather than reconstructing them from provenance metadata.

## Motivation

The prior worker brief expanded stable-entry fields by hand. That allowed runtime integration to rebuild resources instead of loading the compiler-produced artifact and its validation evidence. No public GitHub issue.

## Changes

- [x] Update `/gm-build` and `/gm-fixgap` to resolve and pass through the four-field artifact snapshot without enrichment.
- [x] Define type-specific artifact binding and a narrow runtime-integration repair exception for project-local resources, scenes, and scripts.
- [x] Add contract coverage for handoff, resolver failures, reference-only assets, bind-versus-rebuild, and the repair-boundary exception.
- [x] Update the next-release documentation.

## Testing

- [x] New or updated tests pass (`python -m pytest tests/test_asset_runtime_contract_docs.py -q`: 31 passed; `python -m pytest -q`: 2231 passed, 7 skipped)
- [x] Gitleaks passes or no secret-bearing files were touched (Secret Scan check passed)
- [x] Manual testing completed, if applicable (not applicable: this changes documentation contracts and Python contract tests; no GDScript changed)

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [ ] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md)); this is an intentional v1.0.0 breaking contract and no compatibility migration is included.

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Not applicable - no migration script is added or modified.
- [ ] Post-upgrade checks are not applicable - no migration script is added or modified.
- [ ] Post-upgrade on-disk inspection is not applicable - no migration script is added or modified.
- [ ] Re-run verification is not applicable - no migration script is added or modified.
- [ ] Result attachment is not applicable - no migration script is added or modified.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable: no ECS system changed)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
