### PR TITLE
Preserve foreground during magenta cleanup

### DIFF
--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -98,6 +98,14 @@ sheet for audit. It is intentionally not written when autoslice reports a
 name-count mismatch, so an unbound sheet cannot look like a valid production
 artifact.
 
+For `--background magenta`, `--magenta-threshold` (default `40`) is the only
+global cleanup radius and can be set to `0` to limit enclosed cleanup to exact
+`#FF00FF`. `--magenta-edge-threshold` (default `220`) does not delete pixels by
+distance: it only bounds edge pixels whose RGB values are a consistent composite
+of the key colour and an adjacent foreground pixel. This preserves independent
+purple and blue-purple sprites and fine lines while converting verified spill
+to a correctly coloured semitransparent edge.
+
 ## asset_action_process.py
 
 `asset_action_process.py` processes character, enemy, NPC, summon, and animated

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -100,9 +100,8 @@ artifact.
 
 For `--background magenta`, `--magenta-threshold` (default `60`) is the strict
 global cleanup radius and can be set to `0` to limit enclosed cleanup to exact
-`#FF00FF`. `--magenta-edge-threshold` (default `220`) extends only through
-locally smooth backdrop pixels originating at a strict key; it does not delete pixels
-by raw distance. A separate iterative pass only mattes edge pixels whose RGB
+`#FF00FF`. `--magenta-edge-threshold` (default `220`) is not a deletion radius;
+it only bounds the separate iterative pass that mattes edge pixels whose RGB
 values are a consistent composite of the key colour and an adjacent foreground
 pixel. This preserves independent purple and blue-purple sprites and fine lines
 while converting verified spill to a correctly coloured semitransparent edge.

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -98,13 +98,14 @@ sheet for audit. It is intentionally not written when autoslice reports a
 name-count mismatch, so an unbound sheet cannot look like a valid production
 artifact.
 
-For `--background magenta`, `--magenta-threshold` (default `40`) is the only
+For `--background magenta`, `--magenta-threshold` (default `60`) is the strict
 global cleanup radius and can be set to `0` to limit enclosed cleanup to exact
-`#FF00FF`. `--magenta-edge-threshold` (default `220`) does not delete pixels by
-distance: it only bounds edge pixels whose RGB values are a consistent composite
-of the key colour and an adjacent foreground pixel. This preserves independent
-purple and blue-purple sprites and fine lines while converting verified spill
-to a correctly coloured semitransparent edge.
+`#FF00FF`. `--magenta-edge-threshold` (default `220`) extends only through
+locally smooth backdrop pixels originating at a strict key; it does not delete pixels
+by raw distance. A separate iterative pass only mattes edge pixels whose RGB
+values are a consistent composite of the key colour and an adjacent foreground
+pixel. This preserves independent purple and blue-purple sprites and fine lines
+while converting verified spill to a correctly coloured semitransparent edge.
 
 ## asset_action_process.py
 

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -81,7 +81,7 @@ python tools/asset_sheet_process.py \
 供审计。Autoslice 报告名称数量不匹配时不会写出该文件，避免未绑定的 sheet 被
 误认为有效的生产产物。
 
-使用 `--background magenta` 时，`--magenta-threshold`（默认 `60`）是严格的全图清理半径；传入 `0` 可将封闭区域清理限制为精确的 `#FF00FF`。`--magenta-edge-threshold`（默认 `220`）只会从严格键色出发沿着局部颜色平滑的背景扩展，不会仅按色距删除像素；随后仅处理能由键色和相邻前景像素一致解释的边缘混色。这样会保留独立的紫色、蓝紫色精灵与细线，并将已验证的 spill 转为正确颜色的半透明边缘。
+使用 `--background magenta` 时，`--magenta-threshold`（默认 `60`）是严格的全图清理半径；传入 `0` 可将封闭区域清理限制为精确的 `#FF00FF`。`--magenta-edge-threshold`（默认 `220`）不是删除半径，只用于限制后续能由键色和相邻前景像素一致解释的边缘混色反解。这样会保留独立的紫色、蓝紫色精灵与细线，并将已验证的 spill 转为正确颜色的半透明边缘。
 
 ## asset_action_process.py
 

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -81,6 +81,8 @@ python tools/asset_sheet_process.py \
 供审计。Autoslice 报告名称数量不匹配时不会写出该文件，避免未绑定的 sheet 被
 误认为有效的生产产物。
 
+使用 `--background magenta` 时，`--magenta-threshold`（默认 `40`）是唯一全图清理半径；传入 `0` 可将封闭区域清理限制为精确的 `#FF00FF`。`--magenta-edge-threshold`（默认 `220`）不会仅按色距删除像素，而只处理能由键色和相邻前景像素一致解释的边缘混色。这样会保留独立的紫色、蓝紫色精灵与细线，并将已验证的 spill 转为正确颜色的半透明边缘。
+
 ## asset_action_process.py
 
 `asset_action_process.py` 用于处理角色、敌人、NPC、召唤物和动画道具的动作 source。它会写出规范化 frame PNG、`sheet-transparent.png`、`animation.gif`、`pipeline-meta.json` 和中间 curation report。

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -81,7 +81,7 @@ python tools/asset_sheet_process.py \
 供审计。Autoslice 报告名称数量不匹配时不会写出该文件，避免未绑定的 sheet 被
 误认为有效的生产产物。
 
-使用 `--background magenta` 时，`--magenta-threshold`（默认 `40`）是唯一全图清理半径；传入 `0` 可将封闭区域清理限制为精确的 `#FF00FF`。`--magenta-edge-threshold`（默认 `220`）不会仅按色距删除像素，而只处理能由键色和相邻前景像素一致解释的边缘混色。这样会保留独立的紫色、蓝紫色精灵与细线，并将已验证的 spill 转为正确颜色的半透明边缘。
+使用 `--background magenta` 时，`--magenta-threshold`（默认 `60`）是严格的全图清理半径；传入 `0` 可将封闭区域清理限制为精确的 `#FF00FF`。`--magenta-edge-threshold`（默认 `220`）只会从严格键色出发沿着局部颜色平滑的背景扩展，不会仅按色距删除像素；随后仅处理能由键色和相邻前景像素一致解释的边缘混色。这样会保留独立的紫色、蓝紫色精灵与细线，并将已验证的 spill 转为正确颜色的半透明边缘。
 
 ## asset_action_process.py
 

--- a/skills/assets/compact-prop-pack/SKILL.md
+++ b/skills/assets/compact-prop-pack/SKILL.md
@@ -108,10 +108,11 @@ Never fabricate any of those records.
    plentiful gaps between objects, a solid `#FF00FF` background, and no text,
    labels, UI, floor plane, borders, or grid. Archive the raw provider PNG.
 3. Process that sheet with `asset_sheet_process.py --snap-mode autoslice`,
-   `--background magenta`, `--magenta-soft-matte`, `--padding 2`, and
-   `--min-component-area 100`; never pass `--grid` to autoslice. The soft matte
-   removes #FF00FF-composited antialiasing and purple spill before candidates
-   are tightly finalized. Write the cleaned transparent sheet using
+   `--background magenta`, `--padding 2`, and `--min-component-area 100`; never
+   pass `--grid` to autoslice. The shared cleanup removes the strict #FF00FF
+   backdrop (including enclosed background holes) and only edge-connected
+   spill, preserving real red, purple, and blue-purple foreground details.
+   Write the cleaned transparent sheet using
    `--processed-out`, candidates, AABB report, and report JSON. Supply `--names`
    in source-sheet reading order. A count mismatch returns `needs_regeneration`
    with no candidate or processed-sheet output: inspect spacing, names, or

--- a/skills/assets/compact-prop-pack/SKILL.md
+++ b/skills/assets/compact-prop-pack/SKILL.md
@@ -109,10 +109,11 @@ Never fabricate any of those records.
    labels, UI, floor plane, borders, or grid. Archive the raw provider PNG.
 3. Process that sheet with `asset_sheet_process.py --snap-mode autoslice`,
    `--background magenta`, `--padding 2`, and `--min-component-area 100`; never
-   pass `--grid` to autoslice. The shared cleanup uses a narrow strict-key
-   radius for background holes, then mattes a spill edge only when it matches
-   a neighbouring foreground/background composite; it does not delete purple
-   or blue-purple pixels merely for touching transparency.
+   pass `--grid` to autoslice. The shared cleanup removes strict-key holes and
+   locally smooth background gradients connected to that key, then iteratively
+   mattes a spill edge only when it matches a neighbouring foreground/background
+   composite; it does not delete purple or blue-purple pixels merely for
+   touching transparency.
    Write the cleaned transparent sheet using
    `--processed-out`, candidates, AABB report, and report JSON. Supply `--names`
    in source-sheet reading order. A count mismatch returns `needs_regeneration`

--- a/skills/assets/compact-prop-pack/SKILL.md
+++ b/skills/assets/compact-prop-pack/SKILL.md
@@ -109,11 +109,10 @@ Never fabricate any of those records.
    labels, UI, floor plane, borders, or grid. Archive the raw provider PNG.
 3. Process that sheet with `asset_sheet_process.py --snap-mode autoslice`,
    `--background magenta`, `--padding 2`, and `--min-component-area 100`; never
-   pass `--grid` to autoslice. The shared cleanup removes strict-key holes and
-   locally smooth background gradients connected to that key, then iteratively
-   mattes a spill edge only when it matches a neighbouring foreground/background
-   composite; it does not delete purple or blue-purple pixels merely for
-   touching transparency.
+   pass `--grid` to autoslice. The shared cleanup removes strict-key holes,
+   then iteratively mattes a spill edge only when it matches a neighbouring
+   foreground/background composite; it does not delete purple or blue-purple
+   pixels merely for touching transparency.
    Write the cleaned transparent sheet using
    `--processed-out`, candidates, AABB report, and report JSON. Supply `--names`
    in source-sheet reading order. A count mismatch returns `needs_regeneration`

--- a/skills/assets/compact-prop-pack/SKILL.md
+++ b/skills/assets/compact-prop-pack/SKILL.md
@@ -109,9 +109,10 @@ Never fabricate any of those records.
    labels, UI, floor plane, borders, or grid. Archive the raw provider PNG.
 3. Process that sheet with `asset_sheet_process.py --snap-mode autoslice`,
    `--background magenta`, `--padding 2`, and `--min-component-area 100`; never
-   pass `--grid` to autoslice. The shared cleanup removes the strict #FF00FF
-   backdrop (including enclosed background holes) and only edge-connected
-   spill, preserving real red, purple, and blue-purple foreground details.
+   pass `--grid` to autoslice. The shared cleanup uses a narrow strict-key
+   radius for background holes, then mattes a spill edge only when it matches
+   a neighbouring foreground/background composite; it does not delete purple
+   or blue-purple pixels merely for touching transparency.
    Write the cleaned transparent sheet using
    `--processed-out`, candidates, AABB report, and report JSON. Supply `--names`
    in source-sheet reading order. A count mismatch returns `needs_regeneration`

--- a/tests/tools/test_asset_action_process.py
+++ b/tests/tools/test_asset_action_process.py
@@ -138,6 +138,37 @@ def test_process_action_sheet_outputs_runtime_bundle(tmp_path):
     assert meta["final_sheet_path"] == result["final_sheet_path"]
 
 
+def test_action_processing_uses_the_shared_magenta_cleanup_contract(tmp_path):
+    source = tmp_path / "provider-action.png"
+    image = Image.new("RGBA", (16, 16), (245, 2, 243, 255))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((4, 3, 11, 12), fill=(130, 20, 185, 255))
+    draw.line((4, 2, 11, 2), fill=(205, 45, 60, 96), width=1)
+    image.save(source)
+
+    result = process_action_sheet(
+        source,
+        tmp_path / "processed",
+        grid="1x1",
+        names="prop",
+        asset_id="prop",
+        action_name="idle",
+        fps=8,
+        loop=False,
+        frame_durations=[1],
+    )
+
+    with Image.open(tmp_path / "processed" / "candidates" / "prop.png") as candidate:
+        rgba = candidate.convert("RGBA")
+        assert rgba.getpixel((7, 8)) == (130, 20, 185, 255)
+        assert rgba.getpixel((7, 2)) == (205, 45, 60, 96)
+        assert not any(
+            pixel[:3] == (255, 0, 255) and pixel[3] > 0
+            for pixel in rgba.get_flattened_data()
+        )
+    assert result["frame_count"] == 1
+
+
 def test_process_action_sheet_rejects_missing_required_frame(tmp_path):
     source = tmp_path / "player_idle_source.png"
     make_action_sheet(source, missing_last=True)

--- a/tests/tools/test_asset_action_process.py
+++ b/tests/tools/test_asset_action_process.py
@@ -160,13 +160,42 @@ def test_action_processing_uses_the_shared_magenta_cleanup_contract(tmp_path):
 
     with Image.open(tmp_path / "processed" / "candidates" / "prop.png") as candidate:
         rgba = candidate.convert("RGBA")
-        assert rgba.getpixel((7, 8)) == (130, 20, 185, 255)
-        assert rgba.getpixel((7, 2)) == (205, 45, 60, 96)
+        assert sum(pixel == (130, 20, 185, 255) for pixel in rgba.get_flattened_data()) == 80
+        assert sum(pixel == (205, 45, 60, 96) for pixel in rgba.get_flattened_data()) == 8
         assert not any(
             pixel[:3] == (255, 0, 255) and pixel[3] > 0
             for pixel in rgba.get_flattened_data()
         )
     assert result["frame_count"] == 1
+
+
+def test_action_recovery_preserves_purple_and_semtransparent_edges(tmp_path):
+    source = tmp_path / "purple-edge-source.png"
+    image = Image.new("RGBA", (20, 20), (245, 2, 243, 255))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 4, 9, 15), fill=(130, 20, 185, 255))
+    draw.line((0, 3, 9, 3), fill=(205, 45, 60, 96), width=1)
+    image.save(source)
+
+    result = process_action_sheet(
+        source,
+        tmp_path / "processed",
+        grid="1x1",
+        names="prop",
+        asset_id="prop",
+        recover_edge_touch=True,
+        recovery_timestamp="20260802-000000",
+        action_name="idle",
+        fps=8,
+        loop=False,
+        frame_durations=[1],
+    )
+
+    assert result["source_recovery"] is not None
+    with Image.open(tmp_path / "processed" / "candidates" / "prop.png") as candidate:
+        rgba = candidate.convert("RGBA")
+        assert sum(pixel == (130, 20, 185, 255) for pixel in rgba.get_flattened_data()) == 120
+        assert sum(pixel == (205, 45, 60, 96) for pixel in rgba.get_flattened_data()) == 10
 
 
 def test_process_action_sheet_rejects_missing_required_frame(tmp_path):

--- a/tests/tools/test_asset_image_finalize.py
+++ b/tests/tools/test_asset_image_finalize.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from PIL import Image
+from PIL import Image, ImageDraw
 
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
@@ -169,7 +169,11 @@ def test_finalize_removes_magenta_background_when_requested(tmp_path):
     result = finalize_image_asset(source, output, background="magenta", resize="8x8")
 
     assert result["background"] == "magenta"
-    assert result["background_cleanup"]["removed_pixels"] == 48
+    assert (
+        result["background_cleanup"]["removed_pixels"]
+        + result["background_cleanup"]["edge_removed_pixels"]
+        == 48
+    )
     with Image.open(output) as image:
         rgba = image.convert("RGBA")
         assert rgba.getpixel((0, 0))[3] == 0
@@ -184,13 +188,39 @@ def test_finalize_removes_literal_internal_magenta_key_without_spreading(tmp_pat
 
     result = finalize_image_asset(source, output, background="magenta")
 
-    assert result["background_cleanup"]["removed_pixels"] == 68
+    assert (
+        result["background_cleanup"]["removed_pixels"]
+        + result["background_cleanup"]["edge_removed_pixels"]
+        == 68
+    )
     with Image.open(output) as image:
         rgba = image.convert("RGBA")
         assert rgba.getpixel((0, 0))[3] == 0
         assert rgba.getpixel((0, 5))[3] == 0
         assert rgba.getpixel((4, 4))[3] == 0
         assert rgba.getpixel((3, 3)) == (20, 60, 120, 255)
+
+
+def test_finalize_can_limit_enclosed_cleanup_to_exact_key_pixels(tmp_path):
+    source = tmp_path / "generated" / "accent.png"
+    output = tmp_path / "assets" / "sprites" / "accent.png"
+    source.parent.mkdir()
+    image = Image.new("RGBA", (10, 10), (255, 0, 255, 255))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((2, 2, 7, 7), fill=(20, 60, 120, 255))
+    draw.rectangle((4, 4, 5, 5), fill=(230, 20, 240, 255))
+    image.save(source)
+
+    finalize_image_asset(
+        source,
+        output,
+        background="magenta",
+        magenta_threshold=0,
+        magenta_edge_threshold=0,
+    )
+
+    with Image.open(output) as image:
+        assert image.convert("RGBA").getpixel((4, 4)) == (230, 20, 240, 255)
 
 
 def test_finalize_accepts_required_source_aspect_before_resize(tmp_path):

--- a/tests/tools/test_asset_image_finalize.py
+++ b/tests/tools/test_asset_image_finalize.py
@@ -177,19 +177,19 @@ def test_finalize_removes_magenta_background_when_requested(tmp_path):
         assert rgba.getpixel((3, 3)) == (20, 60, 120, 255)
 
 
-def test_finalize_keeps_internal_magenta_details(tmp_path):
+def test_finalize_removes_literal_internal_magenta_key_without_spreading(tmp_path):
     source = tmp_path / "generated" / "boss.png"
     output = tmp_path / "assets" / "sprites" / "boss.png"
     make_magenta_with_internal_detail_png(source)
 
     result = finalize_image_asset(source, output, background="magenta")
 
-    assert result["background_cleanup"]["removed_pixels"] == 64
+    assert result["background_cleanup"]["removed_pixels"] == 68
     with Image.open(output) as image:
         rgba = image.convert("RGBA")
         assert rgba.getpixel((0, 0))[3] == 0
         assert rgba.getpixel((0, 5))[3] == 0
-        assert rgba.getpixel((4, 4)) == (255, 0, 255, 255)
+        assert rgba.getpixel((4, 4))[3] == 0
         assert rgba.getpixel((3, 3)) == (20, 60, 120, 255)
 
 

--- a/tests/tools/test_asset_sheet_process.py
+++ b/tests/tools/test_asset_sheet_process.py
@@ -27,7 +27,7 @@ def make_magenta_sheet(path: Path, *, edge_touch: bool = False, fringe: bool = F
     image = Image.new("RGBA", (20, 20), (255, 0, 255, 255))
     draw = ImageDraw.Draw(image)
     if fringe:
-        draw.rectangle((1, 1, 8, 8), fill=(255, 120, 255, 255))
+        draw.rectangle((1, 1, 8, 8), fill=(250, 20, 250, 255))
     draw.rectangle((2, 2, 7, 7), fill=(255, 0, 0, 255))
     draw.rectangle((12, 2, 17, 7), fill=(0, 255, 0, 255))
     draw.rectangle((2, 12, 7, 17), fill=(0, 0, 255, 255))
@@ -114,7 +114,7 @@ def test_process_sheet_splits_magenta_background_source(tmp_path):
 
     assert result["strategy"] == "solid_background_grid"
     assert result["background"] == "magenta"
-    assert result["cleanup"]["removed_pixels"] > 0
+    assert result["cleanup"]["removed_pixels"] + result["cleanup"]["edge_removed_pixels"] > 0
     assert result["accepted_count"] == 3
     assert result["rejected_count"] == 1
     candidate = Image.open(tmp_path / "out" / "a.png").convert("RGBA")
@@ -296,7 +296,7 @@ def test_process_sheet_autoslice_reports_name_count_mismatch_without_outputs(tmp
     assert json.loads(report.read_text(encoding="utf-8"))["detected_region_count"] == 2
 
 
-def test_process_sheet_removes_edge_connected_magenta_fringe(tmp_path):
+def test_process_sheet_removes_strict_near_key_background(tmp_path):
     source = tmp_path / "magenta_fringe_sheet.png"
     make_magenta_sheet(source, fringe=True)
 
@@ -310,19 +310,18 @@ def test_process_sheet_removes_edge_connected_magenta_fringe(tmp_path):
         background="magenta",
     )
 
-    assert result["cleanup"]["removed_pixels"] > 0
-    assert result["cleanup"]["edge_removed_pixels"] > 0
+    assert result["cleanup"]["removed_pixels"] + result["cleanup"]["edge_removed_pixels"] > 0
     assert result["accepted"][0]["crop_bbox"] == [2, 2, 8, 8]
 
 
-def test_process_sheet_soft_matte_uses_safe_edge_connected_cleanup(tmp_path):
-    source = tmp_path / "magenta_soft_matte.png"
+def test_process_sheet_mattes_only_a_verified_magenta_composite_edge(tmp_path):
+    source = tmp_path / "magenta_composite.png"
     source.parent.mkdir(parents=True, exist_ok=True)
-    image = Image.new("RGBA", (12, 12), (255, 0, 255, 255))
+    image = Image.new("RGBA", (12, 12), (245, 2, 243, 255))
     draw = ImageDraw.Draw(image)
-    draw.rectangle((3, 3, 8, 8), fill=(80, 120, 70, 255))
-    # This is a foreground/background blend, not an exact key colour.
-    draw.rectangle((2, 2, 9, 9), outline=(185, 25, 190, 255))
+    draw.rectangle((3, 3, 8, 8), fill=(100, 200, 100, 255))
+    # Exact 50% composite of the foreground and #FF00FF.
+    draw.rectangle((2, 2, 9, 9), outline=(178, 100, 178, 255))
     image.save(source)
 
     result = process_sheet(
@@ -332,19 +331,15 @@ def test_process_sheet_soft_matte_uses_safe_edge_connected_cleanup(tmp_path):
         snap_mode="grid",
         names="mossy_prop",
         background="magenta",
-        magenta_soft_matte=True,
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "processed.png",
     )
 
-    assert result["cleanup"]["magenta_soft_matte"] is True
-    assert result["cleanup"]["removed_pixels"] > 0
-    candidate = Image.open(tmp_path / "out" / "mossy_prop.png").convert("RGBA")
-    try:
-        assert all(
-            alpha == 0 or (red, green, blue) != (185, 25, 190)
-            for red, green, blue, alpha in candidate.getdata()
-        )
-    finally:
-        candidate.close()
+    with Image.open(tmp_path / "processed.png") as processed:
+        rgba = processed.convert("RGBA")
+        assert rgba.getpixel((2, 5)) == (100, 200, 100, 127)
+        assert rgba.getpixel((3, 5)) == (100, 200, 100, 255)
+    assert result["cleanup"]["edge_spill_pixels"] > 0
 
 
 def test_magenta_cleanup_preserves_non_key_foreground_colours_and_alpha(tmp_path):
@@ -373,15 +368,41 @@ def test_magenta_cleanup_preserves_non_key_foreground_colours_and_alpha(tmp_path
     with Image.open(tmp_path / "processed.png") as processed:
         rgba = processed.convert("RGBA")
         assert rgba.getpixel((0, 0))[3] == 0
-        assert rgba.getpixel((4, 8)) == (190, 30, 45, 255)
-        assert rgba.getpixel((7, 8)) == (130, 20, 185, 255)
-        assert rgba.getpixel((10, 8)) == (90, 30, 175, 255)
-        assert rgba.getpixel((7, 2)) == (205, 45, 60, 96)
+        assert sum(pixel[3] > 0 for pixel in rgba.crop((3, 3, 12, 13)).get_flattened_data()) == 90
+        assert rgba.getpixel((3, 3)) == (190, 30, 45, 255)
+        assert rgba.getpixel((6, 3)) == (130, 20, 185, 255)
+        assert rgba.getpixel((11, 12)) == (90, 30, 175, 255)
+        assert rgba.getpixel((3, 2)) == (205, 45, 60, 96)
         assert not any(
             pixel[:3] == (255, 0, 255) and pixel[3] > 0
             for pixel in rgba.get_flattened_data()
         )
-    assert result["cleanup"]["removed_pixels"] > 0
+    assert result["cleanup"]["edge_spill_pixels"] == 0
+
+
+@pytest.mark.parametrize("color", [(130, 20, 185), (90, 30, 175), (150, 10, 200)])
+@pytest.mark.parametrize("line_height", [1, 2])
+def test_magenta_cleanup_preserves_purple_and_blue_purple_fine_lines(tmp_path, color, line_height):
+    source = tmp_path / "purple-line.png"
+    image = Image.new("RGBA", (28, 12), (245, 2, 243, 255))
+    ImageDraw.Draw(image).rectangle((2, 5, 25, 5 + line_height - 1), fill=(*color, 255))
+    image.save(source)
+
+    result = process_sheet(
+        source,
+        tmp_path / "out",
+        grid="1x1",
+        snap_mode="grid",
+        names="line",
+        background="magenta",
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "processed.png",
+    )
+
+    with Image.open(tmp_path / "processed.png") as processed:
+        rgba = processed.convert("RGBA")
+        assert all(rgba.getpixel((x, y)) == (*color, 255) for x in range(2, 26) for y in range(5, 5 + line_height))
+    assert result["cleanup"]["edge_spill_pixels"] == 0
 
 
 def test_process_sheet_rejects_magenta_edge_touch_when_requested(tmp_path):

--- a/tests/tools/test_asset_sheet_process.py
+++ b/tests/tools/test_asset_sheet_process.py
@@ -375,7 +375,7 @@ def test_process_sheet_removes_smooth_near_key_background_without_touching_foreg
             pixel[3] < 255 or _color_distance(pixel[:3]) > 60
             for pixel in rgba.get_flattened_data()
         )
-    assert result["cleanup"]["removed_pixels"] > 0
+    assert result["cleanup"]["removed_pixels"] + result["cleanup"]["edge_removed_pixels"] > 0
 
 
 def test_process_sheet_preserves_a_soft_edged_near_key_violet_foreground(tmp_path):

--- a/tests/tools/test_asset_sheet_process.py
+++ b/tests/tools/test_asset_sheet_process.py
@@ -315,7 +315,7 @@ def test_process_sheet_removes_edge_connected_magenta_fringe(tmp_path):
     assert result["accepted"][0]["crop_bbox"] == [2, 2, 8, 8]
 
 
-def test_process_sheet_soft_matte_removes_blended_magenta_spill(tmp_path):
+def test_process_sheet_soft_matte_uses_safe_edge_connected_cleanup(tmp_path):
     source = tmp_path / "magenta_soft_matte.png"
     source.parent.mkdir(parents=True, exist_ok=True)
     image = Image.new("RGBA", (12, 12), (255, 0, 255, 255))
@@ -336,15 +336,52 @@ def test_process_sheet_soft_matte_removes_blended_magenta_spill(tmp_path):
     )
 
     assert result["cleanup"]["magenta_soft_matte"] is True
-    assert result["cleanup"]["soft_matte_pixels"] > 0
+    assert result["cleanup"]["removed_pixels"] > 0
     candidate = Image.open(tmp_path / "out" / "mossy_prop.png").convert("RGBA")
     try:
-        assert not any(
-            alpha > 0 and red > green and blue > green
+        assert all(
+            alpha == 0 or (red, green, blue) != (185, 25, 190)
             for red, green, blue, alpha in candidate.getdata()
         )
     finally:
         candidate.close()
+
+
+def test_magenta_cleanup_preserves_non_key_foreground_colours_and_alpha(tmp_path):
+    source = tmp_path / "provider-regression.png"
+    image = Image.new("RGBA", (16, 16), (245, 2, 243, 255))
+    draw = ImageDraw.Draw(image)
+    # These colours represent real red/purple/blue-purple painted details;
+    # none is sufficiently key-like to be a background spill.
+    draw.rectangle((3, 3, 5, 12), fill=(190, 30, 45, 255))
+    draw.rectangle((6, 3, 8, 12), fill=(130, 20, 185, 255))
+    draw.rectangle((9, 3, 11, 12), fill=(90, 30, 175, 255))
+    draw.line((3, 2, 11, 2), fill=(205, 45, 60, 96), width=1)
+    image.save(source)
+
+    result = process_sheet(
+        source,
+        tmp_path / "out",
+        grid="1x1",
+        snap_mode="grid",
+        names="prop",
+        background="magenta",
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "processed.png",
+    )
+
+    with Image.open(tmp_path / "processed.png") as processed:
+        rgba = processed.convert("RGBA")
+        assert rgba.getpixel((0, 0))[3] == 0
+        assert rgba.getpixel((4, 8)) == (190, 30, 45, 255)
+        assert rgba.getpixel((7, 8)) == (130, 20, 185, 255)
+        assert rgba.getpixel((10, 8)) == (90, 30, 175, 255)
+        assert rgba.getpixel((7, 2)) == (205, 45, 60, 96)
+        assert not any(
+            pixel[:3] == (255, 0, 255) and pixel[3] > 0
+            for pixel in rgba.get_flattened_data()
+        )
+    assert result["cleanup"]["removed_pixels"] > 0
 
 
 def test_process_sheet_rejects_magenta_edge_touch_when_requested(tmp_path):

--- a/tests/tools/test_asset_sheet_process.py
+++ b/tests/tools/test_asset_sheet_process.py
@@ -351,7 +351,7 @@ def test_process_sheet_removes_smooth_near_key_background_without_touching_foreg
     # enter a similarly blurred foreground.
     for left, colour in zip(
         range(0, 30, 5),
-        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (220, 15, 220), (218, 18, 218)],
+        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (205, 20, 205), (195, 24, 195)],
     ):
         draw.rectangle((left, 0, left + 4, 19), fill=colour)
     draw.rectangle((11, 6, 18, 13), fill=(100, 200, 100, 255))
@@ -364,6 +364,7 @@ def test_process_sheet_removes_smooth_near_key_background_without_touching_foreg
         snap_mode="grid",
         names="prop",
         background="magenta",
+        magenta_threshold=120,
         preserve_cell_bounds=True,
         processed_out=tmp_path / "processed.png",
     )
@@ -372,10 +373,64 @@ def test_process_sheet_removes_smooth_near_key_background_without_touching_foreg
         rgba = processed.convert("RGBA")
         assert rgba.getpixel((14, 9)) == (100, 200, 100, 255)
         assert all(
-            pixel[3] < 255 or _color_distance(pixel[:3]) > 60
+            pixel[3] < 255 or _color_distance(pixel[:3]) > 120
             for pixel in rgba.get_flattened_data()
         )
     assert result["cleanup"]["removed_pixels"] + result["cleanup"]["edge_removed_pixels"] > 0
+
+
+def test_process_sheet_mattes_deterministically_noisy_magenta_edges(tmp_path):
+    """Keep the noisy provider-edge tolerance and deeper reference search pinned."""
+    source = tmp_path / "noisy-magenta-edge.png"
+    foreground = (100, 200, 100)
+    image = Image.new("RGBA", (80, 64), (245, 2, 243, 255))
+    draw = ImageDraw.Draw(image)
+
+    # This fixed RGB offset from a 30% key composite has residual 11 and
+    # channel-ratio spread ~0.11, unlike an ideal zero-residual composite.
+    draw.rectangle((9, 25, 17, 33), fill=foreground + (255,))
+    draw.rectangle((8, 24, 18, 34), outline=(222, 64, 205, 255))
+
+    # A deterministic nine-step ramp pins the radius-three platform search.
+    draw.rectangle((49, 25, 60, 36), fill=foreground + (255,))
+    for inset, coverage in enumerate((0.30, 0.37, 0.44, 0.51, 0.58, 0.65, 0.72, 0.79, 0.86)):
+        composite = tuple(
+            round(coverage * channel + (1 - coverage) * key)
+            for channel, key in zip(foreground, MAGENTA_RGB)
+        )
+        draw.rectangle((40 + inset, 16 + inset, 69 - inset, 45 - inset), outline=composite + (255,))
+    image.save(source)
+    source_core_count = sum(pixel == foreground + (255,) for pixel in image.get_flattened_data())
+
+    process_sheet(
+        source,
+        tmp_path / "out",
+        grid="1x1",
+        snap_mode="grid",
+        names="prop",
+        background="magenta",
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "processed.png",
+    )
+
+    with Image.open(tmp_path / "processed.png") as processed:
+        rgba = processed.convert("RGBA")
+        data = rgba.get_flattened_data()
+        assert sum(pixel == foreground + (255,) for pixel in data) == source_core_count
+        assert not any(pixel[3] == 255 and _color_distance(pixel[:3]) <= 60 for pixel in data)
+        assert not any(
+            rgba.getpixel((x, y))[3] == 255
+            and _color_distance(rgba.getpixel((x, y))[:3]) <= 120
+            and any(
+                rgba.getpixel((x + dx, y + dy))[3] < 255
+                for dx in (-1, 0, 1)
+                for dy in (-1, 0, 1)
+                if (dx or dy) and 0 <= x + dx < rgba.width and 0 <= y + dy < rgba.height
+            )
+            for y in range(rgba.height)
+            for x in range(rgba.width)
+        )
+        assert rgba.getpixel((40, 30))[3] <= 100
 
 
 def test_process_sheet_preserves_a_soft_edged_near_key_violet_foreground(tmp_path):

--- a/tests/tools/test_asset_sheet_process.py
+++ b/tests/tools/test_asset_sheet_process.py
@@ -9,7 +9,7 @@ from PIL import Image, ImageDraw
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
 
-from asset_sheet_process import SheetProcessError, process_sheet  # noqa: E402
+from asset_sheet_process import MAGENTA_RGB, SheetProcessError, _color_distance, process_sheet  # noqa: E402
 
 
 def make_sheet(path: Path):
@@ -340,6 +340,92 @@ def test_process_sheet_mattes_only_a_verified_magenta_composite_edge(tmp_path):
         assert rgba.getpixel((2, 5)) == (100, 200, 100, 127)
         assert rgba.getpixel((3, 5)) == (100, 200, 100, 255)
     assert result["cleanup"]["edge_spill_pixels"] > 0
+
+
+def test_process_sheet_removes_smooth_near_key_background_without_touching_foreground(tmp_path):
+    source = tmp_path / "soft-magenta-backdrop.png"
+    image = Image.new("RGBA", (30, 20), MAGENTA_RGB + (255,))
+    draw = ImageDraw.Draw(image)
+    # This is a locally smooth generated backdrop, not an alpha composite. Its
+    # final band is outside the strict 60-pixel radius but must remain part of
+    # the connected background rather than becoming an opaque magenta island.
+    for left, colour in zip(
+        range(0, 30, 5),
+        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (205, 20, 205), (195, 24, 195)],
+    ):
+        draw.rectangle((left, 0, left + 4, 19), fill=colour)
+    draw.rectangle((11, 6, 18, 13), fill=(100, 200, 100, 255))
+    image.save(source)
+
+    result = process_sheet(
+        source,
+        tmp_path / "out",
+        grid="1x1",
+        snap_mode="grid",
+        names="prop",
+        background="magenta",
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "processed.png",
+    )
+
+    with Image.open(tmp_path / "processed.png") as processed:
+        rgba = processed.convert("RGBA")
+        assert rgba.getpixel((14, 9)) == (100, 200, 100, 255)
+        assert all(
+            pixel[3] < 255 or _color_distance(pixel[:3]) > 120
+            for pixel in rgba.get_flattened_data()
+        )
+    assert result["cleanup"]["edge_removed_pixels"] > 0
+
+
+def test_process_sheet_iteratively_recovers_a_two_pixel_composite_ramp(tmp_path):
+    source = tmp_path / "two-pixel-matte.png"
+    foreground = (100, 200, 100)
+    image = Image.new("RGBA", (16, 16), (245, 2, 243, 255))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((4, 4, 11, 11), fill=foreground)
+    draw.rectangle((3, 3, 12, 12), outline=(153, 132, 153, 255))
+    draw.rectangle((2, 2, 13, 13), outline=(204, 66, 204, 255))
+    image.save(source)
+
+    process_sheet(
+        source,
+        tmp_path / "out",
+        grid="1x1",
+        snap_mode="grid",
+        names="prop",
+        background="magenta",
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "processed.png",
+    )
+
+    with Image.open(tmp_path / "processed.png") as processed:
+        rgba = processed.convert("RGBA")
+        assert rgba.getpixel((2, 8)) == (100, 200, 100, 84)
+        assert rgba.getpixel((3, 8)) == (100, 200, 100, 168)
+
+
+def test_process_sheet_mattes_saturated_red_with_a_single_informative_channel(tmp_path):
+    source = tmp_path / "red-matte.png"
+    image = Image.new("RGBA", (12, 12), (245, 2, 243, 255))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((4, 4, 7, 7), fill=(255, 0, 0, 255))
+    draw.rectangle((3, 3, 8, 8), outline=(255, 0, 128, 255))
+    image.save(source)
+
+    process_sheet(
+        source,
+        tmp_path / "out",
+        grid="1x1",
+        snap_mode="grid",
+        names="prop",
+        background="magenta",
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "processed.png",
+    )
+
+    with Image.open(tmp_path / "processed.png") as processed:
+        assert processed.convert("RGBA").getpixel((3, 6)) == (255, 0, 0, 127)
 
 
 def test_magenta_cleanup_preserves_non_key_foreground_colours_and_alpha(tmp_path):

--- a/tests/tools/test_asset_sheet_process.py
+++ b/tests/tools/test_asset_sheet_process.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageFilter
 
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
@@ -346,12 +346,12 @@ def test_process_sheet_removes_smooth_near_key_background_without_touching_foreg
     source = tmp_path / "soft-magenta-backdrop.png"
     image = Image.new("RGBA", (30, 20), MAGENTA_RGB + (255,))
     draw = ImageDraw.Draw(image)
-    # This is a locally smooth generated backdrop, not an alpha composite. Its
-    # final band is outside the strict 60-pixel radius but must remain part of
-    # the connected background rather than becoming an opaque magenta island.
+    # This generated backdrop contains non-exact key colours inside the strict
+    # radius. It must clear without using a smooth-path heuristic that could
+    # enter a similarly blurred foreground.
     for left, colour in zip(
         range(0, 30, 5),
-        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (205, 20, 205), (195, 24, 195)],
+        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (220, 15, 220), (218, 18, 218)],
     ):
         draw.rectangle((left, 0, left + 4, 19), fill=colour)
     draw.rectangle((11, 6, 18, 13), fill=(100, 200, 100, 255))
@@ -372,10 +372,36 @@ def test_process_sheet_removes_smooth_near_key_background_without_touching_foreg
         rgba = processed.convert("RGBA")
         assert rgba.getpixel((14, 9)) == (100, 200, 100, 255)
         assert all(
-            pixel[3] < 255 or _color_distance(pixel[:3]) > 120
+            pixel[3] < 255 or _color_distance(pixel[:3]) > 60
             for pixel in rgba.get_flattened_data()
         )
-    assert result["cleanup"]["edge_removed_pixels"] > 0
+    assert result["cleanup"]["removed_pixels"] > 0
+
+
+def test_process_sheet_preserves_a_soft_edged_near_key_violet_foreground(tmp_path):
+    source = tmp_path / "soft-violet.png"
+    violet = (150, 10, 200)
+    image = Image.new("RGBA", (48, 48), MAGENTA_RGB + (255,))
+    ImageDraw.Draw(image).rectangle((12, 12, 35, 35), fill=violet + (255,))
+    image = image.filter(ImageFilter.GaussianBlur(radius=2))
+    image.save(source)
+    source_core_count = sum(pixel == violet + (255,) for pixel in image.get_flattened_data())
+    assert source_core_count > 0
+
+    process_sheet(
+        source,
+        tmp_path / "out",
+        grid="1x1",
+        snap_mode="grid",
+        names="violet",
+        background="magenta",
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "processed.png",
+    )
+
+    with Image.open(tmp_path / "processed.png") as processed:
+        rgba = processed.convert("RGBA")
+        assert sum(pixel == violet + (255,) for pixel in rgba.get_flattened_data()) == source_core_count
 
 
 def test_process_sheet_iteratively_recovers_a_two_pixel_composite_ramp(tmp_path):

--- a/tests/tools/test_magenta_cleanup_contract.py
+++ b/tests/tools/test_magenta_cleanup_contract.py
@@ -1,0 +1,69 @@
+from collections import Counter
+import sys
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
+sys.path.insert(0, str(TOOLS_DIR))
+
+from asset_action_process import process_action_sheet  # noqa: E402
+from asset_image_finalize import finalize_image_asset  # noqa: E402
+from asset_sheet_process import process_sheet  # noqa: E402
+
+
+def _fixture(path: Path) -> None:
+    image = Image.new("RGBA", (24, 24), (245, 2, 243, 255))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((7, 6, 15, 14), fill=(100, 200, 100, 255))
+    # The outline is a real 50% composite of the green foreground and key.
+    draw.rectangle((6, 5, 16, 15), outline=(178, 100, 178, 255))
+    # Independent foreground details must not be mistaken for that composite.
+    draw.line((2, 19, 21, 19), fill=(130, 20, 185, 255), width=1)
+    draw.line((2, 21, 21, 21), fill=(90, 30, 175, 255), width=1)
+    image.save(path)
+
+
+def _visible_counter(image: Image.Image) -> Counter[tuple[int, int, int, int]]:
+    return Counter(pixel for pixel in image.convert("RGBA").get_flattened_data() if pixel[3] > 0)
+
+
+def test_sheet_finalize_and_action_share_the_magenta_cleanup_contract(tmp_path):
+    source = tmp_path / "provider-fixture.png"
+    _fixture(source)
+
+    process_sheet(
+        source,
+        tmp_path / "sheet-candidates",
+        grid="1x1",
+        snap_mode="grid",
+        names="fixture",
+        background="magenta",
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "sheet.png",
+    )
+    finalize_image_asset(source, tmp_path / "final.png", background="magenta")
+    action = process_action_sheet(
+        source,
+        tmp_path / "action",
+        grid="1x1",
+        names="fixture",
+        asset_id="fixture",
+        component_mode="all",
+        component_padding=0,
+        action_name="idle",
+        fps=8,
+        loop=False,
+        frame_durations=[1],
+    )
+
+    with Image.open(tmp_path / "sheet.png") as sheet, Image.open(tmp_path / "final.png") as final:
+        assert list(sheet.convert("RGBA").get_flattened_data()) == list(final.convert("RGBA").get_flattened_data())
+        expected = _visible_counter(sheet)
+    with Image.open(tmp_path / "action" / "candidates" / "fixture.png") as candidate:
+        assert _visible_counter(candidate) == expected
+        rgba = candidate.convert("RGBA")
+        assert sum(pixel == (130, 20, 185, 255) for pixel in rgba.get_flattened_data()) == 20
+        assert sum(pixel == (90, 30, 175, 255) for pixel in rgba.get_flattened_data()) == 20
+        assert sum(pixel == (100, 200, 100, 255) for pixel in rgba.get_flattened_data()) == 81
+    assert action["frame_count"] == 1

--- a/tests/tools/test_magenta_cleanup_contract.py
+++ b/tests/tools/test_magenta_cleanup_contract.py
@@ -9,12 +9,19 @@ sys.path.insert(0, str(TOOLS_DIR))
 
 from asset_action_process import process_action_sheet  # noqa: E402
 from asset_image_finalize import finalize_image_asset  # noqa: E402
-from asset_sheet_process import process_sheet  # noqa: E402
+from asset_sheet_process import _color_distance, process_sheet  # noqa: E402
 
 
 def _fixture(path: Path) -> None:
-    image = Image.new("RGBA", (24, 24), (245, 2, 243, 255))
+    image = Image.new("RGBA", (24, 24), (255, 0, 255, 255))
     draw = ImageDraw.Draw(image)
+    # A locally smooth backdrop reaches well beyond the strict-key radius.
+    # Every entry point must remove it through the shared cleanup contract.
+    for left, colour in zip(
+        range(0, 24, 4),
+        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (205, 20, 205), (195, 24, 195)],
+    ):
+        draw.rectangle((left, 0, left + 3, 23), fill=colour)
     draw.rectangle((7, 6, 15, 14), fill=(100, 200, 100, 255))
     # The outline is a real 50% composite of the green foreground and key.
     draw.rectangle((6, 5, 16, 15), outline=(178, 100, 178, 255))
@@ -59,6 +66,10 @@ def test_sheet_finalize_and_action_share_the_magenta_cleanup_contract(tmp_path):
 
     with Image.open(tmp_path / "sheet.png") as sheet, Image.open(tmp_path / "final.png") as final:
         assert list(sheet.convert("RGBA").get_flattened_data()) == list(final.convert("RGBA").get_flattened_data())
+        assert all(
+            pixel[3] < 255 or _color_distance(pixel[:3]) > 120
+            for pixel in sheet.convert("RGBA").get_flattened_data()
+        )
         expected = _visible_counter(sheet)
     with Image.open(tmp_path / "action" / "candidates" / "fixture.png") as candidate:
         assert _visible_counter(candidate) == expected

--- a/tests/tools/test_magenta_cleanup_contract.py
+++ b/tests/tools/test_magenta_cleanup_contract.py
@@ -2,7 +2,7 @@ from collections import Counter
 import sys
 from pathlib import Path
 
-from PIL import Image, ImageDraw
+from PIL import Image, ImageDraw, ImageFilter
 
 TOOLS_DIR = Path(__file__).resolve().parents[2] / "tools"
 sys.path.insert(0, str(TOOLS_DIR))
@@ -12,23 +12,28 @@ from asset_image_finalize import finalize_image_asset  # noqa: E402
 from asset_sheet_process import _color_distance, process_sheet  # noqa: E402
 
 
-def _fixture(path: Path) -> None:
-    image = Image.new("RGBA", (24, 24), (255, 0, 255, 255))
+def _fixture(path: Path) -> int:
+    image = Image.new("RGBA", (48, 48), (255, 0, 255, 255))
     draw = ImageDraw.Draw(image)
-    # A locally smooth backdrop reaches well beyond the strict-key radius.
-    # Every entry point must remove it through the shared cleanup contract.
+    # Every entry point must remove non-exact near-key backdrop pixels through
+    # the shared strict cleanup contract without using path expansion.
     for left, colour in zip(
-        range(0, 24, 4),
-        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (205, 20, 205), (195, 24, 195)],
+        range(0, 48, 8),
+        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (220, 15, 220), (218, 18, 218)],
     ):
-        draw.rectangle((left, 0, left + 3, 23), fill=colour)
+        draw.rectangle((left, 0, left + 7, 47), fill=colour)
     draw.rectangle((7, 6, 15, 14), fill=(100, 200, 100, 255))
     # The outline is a real 50% composite of the green foreground and key.
     draw.rectangle((6, 5, 16, 15), outline=(178, 100, 178, 255))
     # Independent foreground details must not be mistaken for that composite.
     draw.line((2, 19, 21, 19), fill=(130, 20, 185, 255), width=1)
     draw.line((2, 21, 21, 21), fill=(90, 30, 175, 255), width=1)
+    violet = (150, 10, 200)
+    soft_violet = Image.new("RGBA", image.size, (0, 0, 0, 0))
+    ImageDraw.Draw(soft_violet).rectangle((27, 27, 42, 42), fill=violet + (255,))
+    image.alpha_composite(soft_violet.filter(ImageFilter.GaussianBlur(radius=2)))
     image.save(path)
+    return sum(pixel == violet + (255,) for pixel in image.get_flattened_data())
 
 
 def _visible_counter(image: Image.Image) -> Counter[tuple[int, int, int, int]]:
@@ -37,7 +42,8 @@ def _visible_counter(image: Image.Image) -> Counter[tuple[int, int, int, int]]:
 
 def test_sheet_finalize_and_action_share_the_magenta_cleanup_contract(tmp_path):
     source = tmp_path / "provider-fixture.png"
-    _fixture(source)
+    source_violet_count = _fixture(source)
+    assert source_violet_count > 0
 
     process_sheet(
         source,
@@ -67,9 +73,10 @@ def test_sheet_finalize_and_action_share_the_magenta_cleanup_contract(tmp_path):
     with Image.open(tmp_path / "sheet.png") as sheet, Image.open(tmp_path / "final.png") as final:
         assert list(sheet.convert("RGBA").get_flattened_data()) == list(final.convert("RGBA").get_flattened_data())
         assert all(
-            pixel[3] < 255 or _color_distance(pixel[:3]) > 120
+            pixel[3] < 255 or _color_distance(pixel[:3]) > 60
             for pixel in sheet.convert("RGBA").get_flattened_data()
         )
+        assert sum(pixel == (150, 10, 200, 255) for pixel in sheet.convert("RGBA").get_flattened_data()) == source_violet_count
         expected = _visible_counter(sheet)
     with Image.open(tmp_path / "action" / "candidates" / "fixture.png") as candidate:
         assert _visible_counter(candidate) == expected
@@ -77,4 +84,5 @@ def test_sheet_finalize_and_action_share_the_magenta_cleanup_contract(tmp_path):
         assert sum(pixel == (130, 20, 185, 255) for pixel in rgba.get_flattened_data()) == 20
         assert sum(pixel == (90, 30, 175, 255) for pixel in rgba.get_flattened_data()) == 20
         assert sum(pixel == (100, 200, 100, 255) for pixel in rgba.get_flattened_data()) == 81
+        assert sum(pixel == (150, 10, 200, 255) for pixel in rgba.get_flattened_data()) == source_violet_count
     assert action["frame_count"] == 1

--- a/tests/tools/test_magenta_cleanup_contract.py
+++ b/tests/tools/test_magenta_cleanup_contract.py
@@ -86,3 +86,56 @@ def test_sheet_finalize_and_action_share_the_magenta_cleanup_contract(tmp_path):
         assert sum(pixel == (100, 200, 100, 255) for pixel in rgba.get_flattened_data()) == 81
         assert sum(pixel == (150, 10, 200, 255) for pixel in rgba.get_flattened_data()) == source_violet_count
     assert action["frame_count"] == 1
+
+
+def test_sheet_finalize_and_action_clear_a_configured_wider_key_radius(tmp_path):
+    """All entry points honour an explicit strict radius beyond the default."""
+    source = tmp_path / "wider-key-radius.png"
+    image = Image.new("RGBA", (30, 20), (255, 0, 255, 255))
+    draw = ImageDraw.Draw(image)
+    for left, colour in zip(
+        range(0, 30, 5),
+        [(255, 0, 255), (245, 4, 245), (235, 8, 235), (225, 12, 225), (205, 20, 205), (195, 24, 195)],
+    ):
+        draw.rectangle((left, 0, left + 4, 19), fill=colour)
+    draw.rectangle((11, 6, 18, 13), fill=(100, 200, 100, 255))
+    image.save(source)
+
+    process_sheet(
+        source,
+        tmp_path / "sheet-candidates",
+        grid="1x1",
+        snap_mode="grid",
+        names="fixture",
+        background="magenta",
+        magenta_threshold=120,
+        preserve_cell_bounds=True,
+        processed_out=tmp_path / "sheet.png",
+    )
+    finalize_image_asset(source, tmp_path / "final.png", background="magenta", magenta_threshold=120)
+    action = process_action_sheet(
+        source,
+        tmp_path / "action",
+        grid="1x1",
+        names="fixture",
+        asset_id="fixture",
+        component_mode="all",
+        component_padding=0,
+        action_name="idle",
+        fps=8,
+        loop=False,
+        frame_durations=[1],
+        magenta_threshold=120,
+    )
+
+    with Image.open(tmp_path / "sheet.png") as sheet, Image.open(tmp_path / "final.png") as final:
+        sheet_rgba = sheet.convert("RGBA")
+        assert list(sheet_rgba.get_flattened_data()) == list(final.convert("RGBA").get_flattened_data())
+        assert all(
+            pixel[3] < 255 or _color_distance(pixel[:3]) > 120
+            for pixel in sheet_rgba.get_flattened_data()
+        )
+        expected = _visible_counter(sheet_rgba)
+    with Image.open(tmp_path / "action" / "candidates" / "fixture.png") as candidate:
+        assert _visible_counter(candidate) == expected
+    assert action["frame_count"] == 1

--- a/tools/asset_action_process.py
+++ b/tools/asset_action_process.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any
 
 from asset_sheet_process import (
-    MAGENTA_RGB,
     SheetProcessError,
     _autoslice_rects,
     _remove_magenta_background,
@@ -547,8 +546,8 @@ def _write_recovered_action_source(
         if background == "magenta":
             scan_image, cleanup = _remove_magenta_background(
                 image,
-                threshold=100,
-                edge_threshold=120,
+                threshold=40,
+                edge_threshold=220,
             )
         elif background == "transparent":
             scan_image = image.copy()
@@ -591,8 +590,7 @@ def _write_recovered_action_source(
         cell_w = max(original_cell_w, max_crop_w + padding * 2)
         cell_h = max(original_cell_h, max_crop_h + padding * 2)
 
-        canvas_color = MAGENTA_RGB + (255,) if background == "magenta" else (0, 0, 0, 0)
-        recovered = Image.new("RGBA", (cell_w * cols, cell_h * rows), canvas_color)
+        recovered = Image.new("RGBA", (cell_w * cols, cell_h * rows), (0, 0, 0, 0))
         placements: list[dict[str, object]] = []
         for index, (name, rect, assignment) in enumerate(
             zip(frame_names, rects, assignment_diagnostics)
@@ -605,7 +603,11 @@ def _write_recovered_action_source(
                 y = row * cell_h + cell_h - crop.height - padding
             else:
                 y = row * cell_h + (cell_h - crop.height) // 2
-            recovered.paste(crop, (x, y), crop)
+            # The destination is transparent and components do not overlap.
+            # Copy RGBA directly so a semitransparent antialiased source edge
+            # keeps its original colour and alpha instead of being composited
+            # against the old magenta recovery canvas.
+            recovered.paste(crop, (x, y))
             placements.append(
                 {
                     "name": name,
@@ -716,6 +718,7 @@ def process_action_sheet(
     curation_report = output_dir / "curation-report.json"
     initial_curation_report = output_dir / "curation-report.initial-grid.json"
     source_recovery: dict[str, object] | None = None
+    recovered_background = background
 
     try:
         curation = process_sheet(
@@ -755,6 +758,9 @@ def process_action_sheet(
                 align=align,
                 timestamp=recovery_timestamp,
             )
+            # Recovery writes an already-clean transparent source.  Running
+            # magenta cleanup again would double-matte semitransparent edges.
+            recovered_background = "transparent"
         except ActionRegenerationRequired as exc:
             diagnostic = {
                 **exc.result,
@@ -775,7 +781,7 @@ def process_action_sheet(
                 names=names,
                 asset_id=asset_id,
                 tag=tag,
-                background=background,
+                background=recovered_background,
                 snap_mode="grid",
                 component_mode=component_mode,
                 component_padding=component_padding,

--- a/tools/asset_action_process.py
+++ b/tools/asset_action_process.py
@@ -524,6 +524,8 @@ def _write_recovered_action_source(
     grid: str,
     frame_names: list[str],
     background: str,
+    magenta_threshold: int = 60,
+    magenta_edge_threshold: int = 220,
     align: str,
     timestamp: str | None,
 ) -> dict[str, object]:
@@ -546,8 +548,8 @@ def _write_recovered_action_source(
         if background == "magenta":
             scan_image, cleanup = _remove_magenta_background(
                 image,
-                threshold=60,
-                edge_threshold=220,
+                threshold=magenta_threshold,
+                edge_threshold=magenta_edge_threshold,
             )
         elif background == "transparent":
             scan_image = image.copy()
@@ -666,6 +668,8 @@ def process_action_sheet(
     asset_id: str | None = None,
     tag: str | None = None,
     background: str = "magenta",
+    magenta_threshold: int = 60,
+    magenta_edge_threshold: int = 220,
     component_mode: str = "largest",
     component_padding: int = 8,
     min_component_area: int = 100,
@@ -729,6 +733,8 @@ def process_action_sheet(
             asset_id=asset_id,
             tag=tag,
             background=background,
+            magenta_threshold=magenta_threshold,
+            magenta_edge_threshold=magenta_edge_threshold,
             snap_mode="grid",
             component_mode=component_mode,
             component_padding=component_padding,
@@ -755,6 +761,8 @@ def process_action_sheet(
                 grid=grid,
                 frame_names=frame_names,
                 background=background,
+                magenta_threshold=magenta_threshold,
+                magenta_edge_threshold=magenta_edge_threshold,
                 align=align,
                 timestamp=recovery_timestamp,
             )
@@ -782,6 +790,8 @@ def process_action_sheet(
                 asset_id=asset_id,
                 tag=tag,
                 background=recovered_background,
+                magenta_threshold=magenta_threshold,
+                magenta_edge_threshold=magenta_edge_threshold,
                 snap_mode="grid",
                 component_mode=component_mode,
                 component_padding=component_padding,
@@ -922,6 +932,8 @@ def _main() -> int:
     parser.add_argument("--asset-id")
     parser.add_argument("--tag")
     parser.add_argument("--background", choices=["transparent", "magenta"], default="magenta")
+    parser.add_argument("--magenta-threshold", type=int, default=60)
+    parser.add_argument("--magenta-edge-threshold", type=int, default=220)
     parser.add_argument(
         "--cell-size",
         type=int,
@@ -958,6 +970,8 @@ def _main() -> int:
             asset_id=args.asset_id,
             tag=args.tag,
             background=args.background,
+            magenta_threshold=args.magenta_threshold,
+            magenta_edge_threshold=args.magenta_edge_threshold,
             cell_size=args.cell_size,
             component_mode=component_mode,
             align=align,

--- a/tools/asset_action_process.py
+++ b/tools/asset_action_process.py
@@ -548,7 +548,7 @@ def _write_recovered_action_source(
             scan_image, cleanup = _remove_magenta_background(
                 image,
                 threshold=100,
-                edge_threshold=150,
+                edge_threshold=120,
             )
         elif background == "transparent":
             scan_image = image.copy()

--- a/tools/asset_action_process.py
+++ b/tools/asset_action_process.py
@@ -546,7 +546,7 @@ def _write_recovered_action_source(
         if background == "magenta":
             scan_image, cleanup = _remove_magenta_background(
                 image,
-                threshold=40,
+                threshold=60,
                 edge_threshold=220,
             )
         elif background == "transparent":

--- a/tools/asset_image_finalize.py
+++ b/tools/asset_image_finalize.py
@@ -11,15 +11,13 @@ import json
 import shutil
 import sys
 import tempfile
-from collections import deque
 from pathlib import Path
+
+from asset_sheet_process import SheetProcessError, _remove_magenta_background
 
 
 class ImageFinalizeError(Exception):
     """Raised when an image cannot be finalized."""
-
-
-MAGENTA_RGB = (255, 0, 255)
 
 
 def _parse_size(value: str | None) -> tuple[int, int] | None:
@@ -76,60 +74,6 @@ def _load_image(path: Path):
         return image
     except Exception as exc:
         raise ImageFinalizeError(f"Source is not a readable image: {path}") from exc
-
-
-def _color_distance(rgb: tuple[int, int, int], target: tuple[int, int, int] = MAGENTA_RGB) -> float:
-    red, green, blue = rgb
-    target_red, target_green, target_blue = target
-    return (
-        (red - target_red) ** 2
-        + (green - target_green) ** 2
-        + (blue - target_blue) ** 2
-    ) ** 0.5
-
-
-def _remove_magenta_background(
-    image,
-    *,
-    edge_threshold: int,
-) -> tuple[object, dict[str, int]]:
-    if edge_threshold < 0:
-        raise ImageFinalizeError("--magenta-edge-threshold must be zero or positive")
-    converted = image.convert("RGBA")
-    pixels = converted.load()
-    removed = 0
-    width, height = converted.size
-
-    visited: set[tuple[int, int]] = set()
-    queue: deque[tuple[int, int]] = deque()
-    for x in range(width):
-        queue.append((x, 0))
-        queue.append((x, height - 1))
-    for y in range(height):
-        queue.append((0, y))
-        queue.append((width - 1, y))
-
-    while queue:
-        x, y = queue.popleft()
-        if (x, y) in visited or x < 0 or x >= width or y < 0 or y >= height:
-            continue
-        visited.add((x, y))
-        red, green, blue, alpha = pixels[x, y]
-        should_expand = alpha == 0
-        if alpha > 0 and _color_distance((red, green, blue)) < edge_threshold:
-            pixels[x, y] = (0, 0, 0, 0)
-            removed += 1
-            should_expand = True
-        if should_expand:
-            for dx in (-1, 0, 1):
-                for dy in (-1, 0, 1):
-                    if dx == 0 and dy == 0:
-                        continue
-                    next_pixel = (x + dx, y + dy)
-                    if next_pixel not in visited:
-                        queue.append(next_pixel)
-
-    return converted, {"removed_pixels": removed}
 
 
 def _atomic_save(image, output: Path, image_format: str) -> None:
@@ -218,7 +162,7 @@ def finalize_image_asset(
     label: str | None = None,
     archive_original: bool = True,
     background: str = "none",
-    magenta_edge_threshold: int = 150,
+    magenta_edge_threshold: int = 120,
 ) -> dict[str, object]:
     """Copy or transform a generated source image into its final path."""
     source = Path(source)
@@ -271,10 +215,14 @@ def finalize_image_asset(
             _atomic_save(origin_image, origin_path, "png")
             origin_saved = str(origin_path)
         if background == "magenta":
-            image, background_cleanup = _remove_magenta_background(
-                image,
-                edge_threshold=magenta_edge_threshold,
-            )
+            try:
+                image, background_cleanup = _remove_magenta_background(
+                    image,
+                    threshold=100,
+                    edge_threshold=magenta_edge_threshold,
+                )
+            except SheetProcessError as exc:
+                raise ImageFinalizeError(str(exc)) from exc
         if requested_size is not None:
             image = _fit_with_padding(image, requested_size)
         if image_format.lower() == "png" and image.mode not in {"RGB", "RGBA"}:
@@ -356,7 +304,7 @@ def _main() -> int:
     parser.add_argument(
         "--magenta-edge-threshold",
         type=int,
-        default=150,
+        default=120,
         help="RGB distance threshold for edge-connected magenta cleanup",
     )
     parser.add_argument(

--- a/tools/asset_image_finalize.py
+++ b/tools/asset_image_finalize.py
@@ -162,7 +162,7 @@ def finalize_image_asset(
     label: str | None = None,
     archive_original: bool = True,
     background: str = "none",
-    magenta_threshold: int = 40,
+    magenta_threshold: int = 60,
     magenta_edge_threshold: int = 220,
 ) -> dict[str, object]:
     """Copy or transform a generated source image into its final path."""
@@ -305,8 +305,8 @@ def _main() -> int:
     parser.add_argument(
         "--magenta-threshold",
         type=int,
-        default=40,
-        help="Global RGB distance for exact and enclosed #FF00FF background cleanup",
+        default=60,
+        help="Global RGB distance for strict and enclosed #FF00FF background cleanup",
     )
     parser.add_argument(
         "--magenta-edge-threshold",

--- a/tools/asset_image_finalize.py
+++ b/tools/asset_image_finalize.py
@@ -162,7 +162,8 @@ def finalize_image_asset(
     label: str | None = None,
     archive_original: bool = True,
     background: str = "none",
-    magenta_edge_threshold: int = 120,
+    magenta_threshold: int = 40,
+    magenta_edge_threshold: int = 220,
 ) -> dict[str, object]:
     """Copy or transform a generated source image into its final path."""
     source = Path(source)
@@ -218,7 +219,7 @@ def finalize_image_asset(
             try:
                 image, background_cleanup = _remove_magenta_background(
                     image,
-                    threshold=100,
+                    threshold=magenta_threshold,
                     edge_threshold=magenta_edge_threshold,
                 )
             except SheetProcessError as exc:
@@ -302,10 +303,16 @@ def _main() -> int:
         help="Optional source background cleanup mode",
     )
     parser.add_argument(
+        "--magenta-threshold",
+        type=int,
+        default=40,
+        help="Global RGB distance for exact and enclosed #FF00FF background cleanup",
+    )
+    parser.add_argument(
         "--magenta-edge-threshold",
         type=int,
-        default=120,
-        help="RGB distance threshold for edge-connected magenta cleanup",
+        default=220,
+        help="Maximum RGB distance for locally validated magenta spill cleanup",
     )
     parser.add_argument(
         "--no-origin",
@@ -326,6 +333,7 @@ def _main() -> int:
             label=args.label,
             archive_original=args.archive_original,
             background=args.background,
+            magenta_threshold=args.magenta_threshold,
             magenta_edge_threshold=args.magenta_edge_threshold,
         )
     except ImageFinalizeError as exc:

--- a/tools/asset_sheet_process.py
+++ b/tools/asset_sheet_process.py
@@ -97,10 +97,14 @@ def _remove_magenta_background(
     edge_removed = 0
     width, height = converted.size
 
+    # Pixels inside the strict key-distance threshold are deterministic
+    # backdrop, including enclosed gaps such as the opening in a signboard.
+    # This is deliberately a colour-distance test only: it does not use the
+    # previous red/blue-channel dominance rule that erased real purple art.
     for x in range(width):
         for y in range(height):
             red, green, blue, alpha = pixels[x, y]
-            if alpha > 0 and _color_distance((red, green, blue)) < threshold:
+            if alpha > 0 and _color_distance((red, green, blue)) <= threshold:
                 pixels[x, y] = (0, 0, 0, 0)
                 removed += 1
 
@@ -119,10 +123,19 @@ def _remove_magenta_background(
             continue
         visited.add((x, y))
         red, green, blue, alpha = pixels[x, y]
+        distance = _color_distance((red, green, blue))
+        # Transparency present in the original input and key-coloured pixels
+        # on the canvas perimeter are both safe routes through the background.
+        # Crucially, the flood fill is edge-seeded, so a red or blue-purple
+        # foreground detail is preserved unless it is actually part of the
+        # contiguous magenta backdrop.
         should_expand = alpha == 0
-        if alpha > 0 and _color_distance((red, green, blue)) < edge_threshold:
+        if alpha > 0 and distance <= edge_threshold:
             pixels[x, y] = (0, 0, 0, 0)
-            edge_removed += 1
+            if distance < threshold:
+                removed += 1
+            else:
+                edge_removed += 1
             should_expand = True
         if should_expand:
             for dx in (-1, 0, 1):
@@ -133,87 +146,37 @@ def _remove_magenta_background(
                     if next_pixel not in visited:
                         queue.append(next_pixel)
 
-    return converted, {"removed_pixels": removed, "edge_removed_pixels": edge_removed}
-
-
-def _smoothstep(value: float) -> float:
-    value = max(0.0, min(1.0, value))
-    return value * value * (3.0 - 2.0 * value)
-
-
-def _magenta_soft_alpha(rgb: tuple[int, int, int]) -> int:
-    """Estimate alpha for an #FF00FF-composited source pixel.
-
-    A generated sheet often contains antialiased foreground pixels blended with
-    the requested magenta background. Euclidean key removal leaves those
-    purple fringes opaque; this matte uses both red/blue key-channel dominance
-    and a soft distance ramp to retain the real foreground edge.
-    """
-    red, green, blue = rgb
-    distance = max(abs(red - 255), green, abs(blue - 255))
-    dominance = min(red, blue) - green
-    key_like = distance <= 32 or dominance >= 16
-    if not key_like:
-        return 255
-
-    if distance <= 32:
-        distance_alpha = 0
-    elif distance >= 180:
-        distance_alpha = 255
-    else:
-        ratio = (distance - 32) / (180 - 32)
-        distance_alpha = round(255 * _smoothstep(ratio))
-
-    if dominance <= 0:
-        dominance_alpha = 255
-    else:
-        denominator = max(1, 255 - green)
-        dominance_alpha = round(255 * (1 - min(1, dominance / denominator)))
-    return min(distance_alpha, dominance_alpha)
-
-
-def _remove_magenta_soft_matte(image) -> tuple[object, dict[str, int]]:
-    """Remove magenta and its blended spill while preserving antialiased edges."""
-    try:
-        from PIL import ImageFilter
-    except ImportError as exc:
-        raise SheetProcessError("Pillow is required to process asset sheets") from exc
-
-    converted = image.convert("RGBA")
-    pixels = converted.load()
-    matte_pixels = 0
-    partial_pixels = 0
-    width, height = converted.size
+    # A single exterior shell catches the visibly purple one-pixel halo that
+    # image generators often leave just beyond an otherwise opaque contour.
+    # Limit it to pixels already touching transparent background and apply it
+    # simultaneously, so it cannot eat into a real purple foreground region.
+    edge_spill: list[tuple[int, int]] = []
     for x in range(width):
         for y in range(height):
             red, green, blue, alpha = pixels[x, y]
-            matte_alpha = _magenta_soft_alpha((red, green, blue))
-            output_alpha = round(matte_alpha * (alpha / 255))
-            if output_alpha != alpha:
-                matte_pixels += 1
-            if output_alpha == 0:
-                pixels[x, y] = (0, 0, 0, 0)
+            if (
+                alpha == 0
+                or green > 40
+                or min(red, blue) < 90
+                or abs(red - blue) > 100
+            ):
                 continue
-            if output_alpha < 252:
-                # Once alpha is lowered, cap both key channels at the green
-                # channel so the translucent edge cannot retain purple spill.
-                cap = max(0, green - 1)
-                red = min(red, cap)
-                blue = min(blue, cap)
-                partial_pixels += 1
-            pixels[x, y] = (red, green, blue, output_alpha)
+            if any(
+                0 <= x + dx < width
+                and 0 <= y + dy < height
+                and pixels[x + dx, y + dy][3] == 0
+                for dx in (-1, 0, 1)
+                for dy in (-1, 0, 1)
+                if dx or dy
+            ):
+                edge_spill.append((x, y))
+    for x, y in edge_spill:
+        pixels[x, y] = (0, 0, 0, 0)
 
-    # Contract one alpha pixel to avoid an opaque keyed fringe surviving at a
-    # source boundary. This mirrors the fixed deterministic cleanup used by
-    # the compact prop production path.
-    alpha = converted.getchannel("A").filter(ImageFilter.MinFilter(3))
-    converted.putalpha(alpha)
     return converted, {
-        "removed_pixels": matte_pixels - partial_pixels,
-        "edge_removed_pixels": 0,
-        "soft_matte_pixels": matte_pixels,
-        "soft_matte_partial_pixels": partial_pixels,
-        "soft_matte_edge_contract": 1,
+        "removed_pixels": removed,
+        "edge_removed_pixels": edge_removed,
+        "edge_spill_pixels": len(edge_spill),
     }
 
 
@@ -489,7 +452,7 @@ def process_sheet(
     reject_edge_touch: bool = False,
     background: str = "transparent",
     magenta_threshold: int = 100,
-    magenta_edge_threshold: int = 150,
+    magenta_edge_threshold: int = 120,
     magenta_soft_matte: bool = False,
     component_mode: str = "all",
     component_padding: int | None = None,
@@ -561,14 +524,15 @@ def process_sheet(
             "edge_removed_pixels": 0,
         }
         if background == "magenta":
-            if magenta_soft_matte:
-                image, cleanup_counts = _remove_magenta_soft_matte(image)
-            else:
-                image, cleanup_counts = _remove_magenta_background(
-                    image,
-                    threshold=magenta_threshold,
-                    edge_threshold=magenta_edge_threshold,
-                )
+            # ``--magenta-soft-matte`` remains accepted for compatibility,
+            # but deliberately uses the same topology-aware contract.  The
+            # previous full-image channel-dominance matte deleted legitimate
+            # red and purple foreground pixels.
+            image, cleanup_counts = _remove_magenta_background(
+                image,
+                threshold=magenta_threshold,
+                edge_threshold=magenta_edge_threshold,
+            )
             cleanup.update(cleanup_counts)
         width, height = image.size
         if not _has_transparent_pixels(image):
@@ -849,7 +813,7 @@ def _main() -> int:
     parser.add_argument(
         "--magenta-edge-threshold",
         type=int,
-        default=150,
+        default=120,
         help="Euclidean RGB distance for edge-connected #FF00FF fringe cleanup",
     )
     parser.add_argument(

--- a/tools/asset_sheet_process.py
+++ b/tools/asset_sheet_process.py
@@ -20,6 +20,9 @@ SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 MAGENTA_RGB = (255, 0, 255)
 COMPONENT_MODES = {"all", "largest"}
 SNAP_MODES = {"grid", "autoslice"}
+MAGENTA_BACKGROUND_STEP = 48
+MAGENTA_MATTE_MAX_PASSES = 8
+MAGENTA_COMPOSITE_RESIDUAL = 6
 
 
 def _parse_grid(value: str) -> tuple[int, int]:
@@ -96,61 +99,87 @@ def _remove_magenta_background(
     removed = 0
     edge_removed = 0
     width, height = converted.size
+    original = list(converted.get_flattened_data())
 
-    visited: set[tuple[int, int]] = set()
-    queue: deque[tuple[int, int]] = deque()
-    for x in range(width):
-        queue.append((x, 0))
-        queue.append((x, height - 1))
+    # Strict matching is allowed globally so callers can deliberately remove
+    # enclosed key-colour holes.  The broader edge threshold is different: it
+    # can travel only through a locally smooth colour path that began at a
+    # strict-key or transparent pixel.  That removes generated backdrop
+    # gradients without treating a hard-edged purple foreground shape as a
+    # background merely because it is near the key in RGB space.
+    background = bytearray(width * height)
+    queue: deque[tuple[int, int, tuple[int, int, int] | None]] = deque()
     for y in range(height):
-        queue.append((0, y))
-        queue.append((width - 1, y))
+        for x in range(width):
+            red, green, blue, alpha = original[y * width + x]
+            if alpha == 0 or _color_distance((red, green, blue)) <= threshold:
+                queue.append((x, y, None))
 
     while queue:
-        x, y = queue.popleft()
-        if (x, y) in visited or x < 0 or x >= width or y < 0 or y >= height:
+        x, y, parent = queue.popleft()
+        if x < 0 or x >= width or y < 0 or y >= height:
             continue
-        visited.add((x, y))
-        red, green, blue, alpha = pixels[x, y]
-        distance = _color_distance((red, green, blue))
-        # The flood fill is edge-seeded and uses the strict key threshold.
-        # ``edge_threshold`` is intentionally not a deletion threshold: it
-        # only bounds the later, locally validated spill-matte candidates.
-        should_expand = alpha == 0
-        if alpha > 0 and distance <= threshold:
-            pixels[x, y] = (0, 0, 0, 0)
-            edge_removed += 1
-            should_expand = True
-        if should_expand:
-            for dx in (-1, 0, 1):
-                for dy in (-1, 0, 1):
-                    if dx == 0 and dy == 0:
-                        continue
-                    next_pixel = (x + dx, y + dy)
-                    if next_pixel not in visited:
-                        queue.append(next_pixel)
+        index = y * width + x
+        if background[index]:
+            continue
+        red, green, blue, alpha = original[index]
+        rgb = (red, green, blue)
+        strict_key = alpha > 0 and _color_distance(rgb) <= threshold
+        is_background = alpha == 0 or strict_key
+        if not is_background and parent is not None:
+            is_background = (
+                _color_distance(rgb) <= edge_threshold
+                and _color_distance(rgb, parent) <= MAGENTA_BACKGROUND_STEP
+            )
+        if not is_background:
+            continue
+        background[index] = 1
+        for dx in (-1, 0, 1):
+            for dy in (-1, 0, 1):
+                if dx or dy:
+                    queue.append((x + dx, y + dy, rgb))
 
-    # Only after the edge-connected backdrop is removed do we clear any
-    # remaining strict-key holes.  Keeping this as a separate pass makes the
-    # report distinguish ordinary backdrop cleanup from enclosed holes.
-    for x in range(width):
-        for y in range(height):
-            red, green, blue, alpha = pixels[x, y]
-            if alpha > 0 and _color_distance((red, green, blue)) <= threshold:
-                pixels[x, y] = (0, 0, 0, 0)
+    for y in range(height):
+        for x in range(width):
+            index = y * width + x
+            if not background[index]:
+                continue
+            red, green, blue, alpha = original[index]
+            if alpha == 0:
+                continue
+            if _color_distance((red, green, blue)) <= threshold:
                 removed += 1
+            else:
+                edge_removed += 1
+            pixels[x, y] = (0, 0, 0, 0)
 
-    # A candidate spill pixel must be explainable as a compositing result of
-    # the key colour and an adjacent, more foreground-like pixel.  This is the
-    # deterministic boundary missing from a simple RGB-distance or
-    # channel-dominance test: a real purple line beside transparency has only
-    # same-colour neighbours and therefore estimates alpha ~= 1, so it stays.
-    edge_spill: list[tuple[int, int, tuple[int, int, int], float]] = []
-    for x in range(width):
-        for y in range(height):
-            red, green, blue, alpha = pixels[x, y]
+    # Decontaminate soft edges from the outside in.  Every pass observes the
+    # previous pass's reduced alpha, allowing a two- or three-pixel composite
+    # ramp to expose the real foreground colour before the outer layer is
+    # revisited.  Fits always use the original input pixel, so alpha is not
+    # compounded between passes.
+    edge_spill_pixels: set[tuple[int, int]] = set()
+    frontier: set[tuple[int, int]] = set()
+    for y in range(height):
+        for x in range(width):
+            if pixels[x, y][3] == 0:
+                continue
+            if any(
+                pixels[x + dx, y + dy][3] < pixels[x, y][3]
+                for dx in (-1, 0, 1)
+                for dy in (-1, 0, 1)
+                if (dx or dy) and 0 <= x + dx < width and 0 <= y + dy < height
+            ):
+                frontier.add((x, y))
+
+    for _ in range(MAGENTA_MATTE_MAX_PASSES):
+        updates: list[tuple[int, int, tuple[int, int, int], int]] = []
+        for x, y in frontier:
+            index = y * width + x
+            red, green, blue, original_alpha = original[index]
+            current_alpha = pixels[x, y][3]
             distance = _color_distance((red, green, blue))
-            if alpha == 0 or distance > edge_threshold:
+            if original_alpha == 0 or current_alpha == 0 or distance > edge_threshold:
                 continue
             neighbours = [
                 pixels[x + dx, y + dy]
@@ -158,9 +187,9 @@ def _remove_magenta_background(
                 for dy in (-1, 0, 1)
                 if (dx or dy) and 0 <= x + dx < width and 0 <= y + dy < height
             ]
-            if not any(item[3] == 0 for item in neighbours):
+            if not any(item[3] < current_alpha for item in neighbours):
                 continue
-            best: tuple[tuple[int, int, int], float, float] | None = None
+            best: tuple[tuple[int, int, int], int, float] | None = None
             for neighbour_red, neighbour_green, neighbour_blue, neighbour_alpha in neighbours:
                 foreground = (neighbour_red, neighbour_green, neighbour_blue)
                 if neighbour_alpha == 0 or _color_distance(foreground) <= distance + 8:
@@ -171,19 +200,34 @@ def _remove_magenta_background(
                 residual = _magenta_composite_residual(
                     (red, green, blue), foreground, matte_alpha
                 )
-                if best is None or residual < best[2]:
-                    best = (foreground, matte_alpha, residual)
+                if residual > MAGENTA_COMPOSITE_RESIDUAL:
+                    continue
+                output_alpha = round(original_alpha * matte_alpha)
+                if output_alpha >= current_alpha:
+                    continue
+                if best is None or output_alpha < best[1] or (
+                    output_alpha == best[1] and residual < best[2]
+                ):
+                    best = (foreground, output_alpha, residual)
             if best is not None:
-                foreground, matte_alpha, _ = best
-                edge_spill.append((x, y, foreground, matte_alpha))
-    for x, y, foreground, matte_alpha in edge_spill:
-        red, green, blue, alpha = pixels[x, y]
-        pixels[x, y] = (*foreground, round(alpha * matte_alpha))
+                foreground, output_alpha, _ = best
+                updates.append((x, y, foreground, output_alpha))
+        if not updates:
+            break
+        frontier = set()
+        for x, y, foreground, output_alpha in updates:
+            pixels[x, y] = (*foreground, output_alpha)
+            edge_spill_pixels.add((x, y))
+            for dx in (-1, 0, 1):
+                for dy in (-1, 0, 1):
+                    next_x, next_y = x + dx, y + dy
+                    if 0 <= next_x < width and 0 <= next_y < height:
+                        frontier.add((next_x, next_y))
 
     return converted, {
         "removed_pixels": removed,
         "edge_removed_pixels": edge_removed,
-        "edge_spill_pixels": len(edge_spill),
+        "edge_spill_pixels": len(edge_spill_pixels),
     }
 
 
@@ -196,10 +240,12 @@ def _magenta_composite_alpha(
         denominator = foreground_value - key_value
         if abs(denominator) >= 8:
             ratios.append((value - key_value) / denominator)
-    if len(ratios) < 2:
+    if not ratios:
         return None
     coverage = sum(ratios) / len(ratios)
-    if not 0.05 <= coverage <= 0.95 or max(ratios) - min(ratios) > 0.08:
+    if not 0.05 <= coverage <= 0.95:
+        return None
+    if len(ratios) > 1 and max(ratios) - min(ratios) > 0.08:
         return None
     return coverage
 
@@ -484,7 +530,7 @@ def process_sheet(
     padding: int = 0,
     reject_edge_touch: bool = False,
     background: str = "transparent",
-    magenta_threshold: int = 40,
+    magenta_threshold: int = 60,
     magenta_edge_threshold: int = 220,
     component_mode: str = "all",
     component_padding: int | None = None,
@@ -833,8 +879,8 @@ def _main() -> int:
     parser.add_argument(
         "--magenta-threshold",
         type=int,
-        default=40,
-        help="Global RGB distance for exact and enclosed #FF00FF background cleanup",
+        default=60,
+        help="Global RGB distance for strict and enclosed #FF00FF background cleanup",
     )
     parser.add_argument(
         "--magenta-edge-threshold",

--- a/tools/asset_sheet_process.py
+++ b/tools/asset_sheet_process.py
@@ -21,7 +21,9 @@ MAGENTA_RGB = (255, 0, 255)
 COMPONENT_MODES = {"all", "largest"}
 SNAP_MODES = {"grid", "autoslice"}
 MAGENTA_MATTE_MAX_PASSES = 8
-MAGENTA_COMPOSITE_RESIDUAL = 6
+MAGENTA_MATTE_SEARCH_RADIUS = 3
+MAGENTA_COMPOSITE_RESIDUAL = 12
+MAGENTA_COMPOSITE_RATIO_SPREAD = 0.16
 
 
 def _parse_grid(value: str) -> tuple[int, int]:
@@ -139,10 +141,7 @@ def _remove_magenta_background(
             red, green, blue, alpha = original[index]
             if alpha == 0:
                 continue
-            if _color_distance((red, green, blue)) <= threshold:
-                removed += 1
-            else:
-                edge_removed += 1
+            edge_removed += 1
             pixels[x, y] = (0, 0, 0, 0)
 
     # Enclosed strict-key holes are intentionally removed, but never become
@@ -188,8 +187,8 @@ def _remove_magenta_background(
                 continue
             neighbours = [
                 pixels[x + dx, y + dy]
-                for dx in (-1, 0, 1)
-                for dy in (-1, 0, 1)
+                for dx in range(-MAGENTA_MATTE_SEARCH_RADIUS, MAGENTA_MATTE_SEARCH_RADIUS + 1)
+                for dy in range(-MAGENTA_MATTE_SEARCH_RADIUS, MAGENTA_MATTE_SEARCH_RADIUS + 1)
                 if (dx or dy) and 0 <= x + dx < width and 0 <= y + dy < height
             ]
             if not any(item[3] < current_alpha for item in neighbours):
@@ -250,7 +249,7 @@ def _magenta_composite_alpha(
     coverage = sum(ratios) / len(ratios)
     if not 0.05 <= coverage <= 0.95:
         return None
-    if len(ratios) > 1 and max(ratios) - min(ratios) > 0.08:
+    if len(ratios) > 1 and max(ratios) - min(ratios) > MAGENTA_COMPOSITE_RATIO_SPREAD:
         return None
     return coverage
 

--- a/tools/asset_sheet_process.py
+++ b/tools/asset_sheet_process.py
@@ -20,7 +20,6 @@ SAFE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]*$")
 MAGENTA_RGB = (255, 0, 255)
 COMPONENT_MODES = {"all", "largest"}
 SNAP_MODES = {"grid", "autoslice"}
-MAGENTA_BACKGROUND_STEP = 48
 MAGENTA_MATTE_MAX_PASSES = 8
 MAGENTA_COMPOSITE_RESIDUAL = 6
 
@@ -101,22 +100,22 @@ def _remove_magenta_background(
     width, height = converted.size
     original = list(converted.get_flattened_data())
 
-    # Strict matching is allowed globally so callers can deliberately remove
-    # enclosed key-colour holes.  The broader edge threshold is different: it
-    # can travel only through a locally smooth colour path that began at a
-    # strict-key or transparent pixel.  That removes generated backdrop
-    # gradients without treating a hard-edged purple foreground shape as a
-    # background merely because it is near the key in RGB space.
+    # A colour-distance test can safely clear only the strict key radius.  Do
+    # not extend an exterior fill through a locally smooth path: a blurred
+    # violet foreground creates the same path and would be erased wholesale.
+    # The broader edge threshold is reserved exclusively for the compositing
+    # validation below, where an actual foreground colour is available.
     background = bytearray(width * height)
-    queue: deque[tuple[int, int, tuple[int, int, int] | None]] = deque()
+    queue: deque[tuple[int, int]] = deque()
+    for x in range(width):
+        queue.append((x, 0))
+        queue.append((x, height - 1))
     for y in range(height):
-        for x in range(width):
-            red, green, blue, alpha = original[y * width + x]
-            if alpha == 0 or _color_distance((red, green, blue)) <= threshold:
-                queue.append((x, y, None))
+        queue.append((0, y))
+        queue.append((width - 1, y))
 
     while queue:
-        x, y, parent = queue.popleft()
+        x, y = queue.popleft()
         if x < 0 or x >= width or y < 0 or y >= height:
             continue
         index = y * width + x
@@ -124,20 +123,13 @@ def _remove_magenta_background(
             continue
         red, green, blue, alpha = original[index]
         rgb = (red, green, blue)
-        strict_key = alpha > 0 and _color_distance(rgb) <= threshold
-        is_background = alpha == 0 or strict_key
-        if not is_background and parent is not None:
-            is_background = (
-                _color_distance(rgb) <= edge_threshold
-                and _color_distance(rgb, parent) <= MAGENTA_BACKGROUND_STEP
-            )
-        if not is_background:
+        if alpha > 0 and _color_distance(rgb) > threshold:
             continue
         background[index] = 1
         for dx in (-1, 0, 1):
             for dy in (-1, 0, 1):
                 if dx or dy:
-                    queue.append((x + dx, y + dy, rgb))
+                    queue.append((x + dx, y + dy))
 
     for y in range(height):
         for x in range(width):
@@ -152,6 +144,19 @@ def _remove_magenta_background(
             else:
                 edge_removed += 1
             pixels[x, y] = (0, 0, 0, 0)
+
+    # Enclosed strict-key holes are intentionally removed, but never become
+    # flood-fill seeds.  This keeps a magenta window transparent without
+    # letting its neighbourhood consume a soft-edged foreground.
+    for y in range(height):
+        for x in range(width):
+            index = y * width + x
+            if background[index]:
+                continue
+            red, green, blue, alpha = original[index]
+            if alpha > 0 and _color_distance((red, green, blue)) <= threshold:
+                pixels[x, y] = (0, 0, 0, 0)
+                removed += 1
 
     # Decontaminate soft edges from the outside in.  Every pass observes the
     # previous pass's reduced alpha, allowing a two- or three-pixel composite

--- a/tools/asset_sheet_process.py
+++ b/tools/asset_sheet_process.py
@@ -97,17 +97,6 @@ def _remove_magenta_background(
     edge_removed = 0
     width, height = converted.size
 
-    # Pixels inside the strict key-distance threshold are deterministic
-    # backdrop, including enclosed gaps such as the opening in a signboard.
-    # This is deliberately a colour-distance test only: it does not use the
-    # previous red/blue-channel dominance rule that erased real purple art.
-    for x in range(width):
-        for y in range(height):
-            red, green, blue, alpha = pixels[x, y]
-            if alpha > 0 and _color_distance((red, green, blue)) <= threshold:
-                pixels[x, y] = (0, 0, 0, 0)
-                removed += 1
-
     visited: set[tuple[int, int]] = set()
     queue: deque[tuple[int, int]] = deque()
     for x in range(width):
@@ -124,18 +113,13 @@ def _remove_magenta_background(
         visited.add((x, y))
         red, green, blue, alpha = pixels[x, y]
         distance = _color_distance((red, green, blue))
-        # Transparency present in the original input and key-coloured pixels
-        # on the canvas perimeter are both safe routes through the background.
-        # Crucially, the flood fill is edge-seeded, so a red or blue-purple
-        # foreground detail is preserved unless it is actually part of the
-        # contiguous magenta backdrop.
+        # The flood fill is edge-seeded and uses the strict key threshold.
+        # ``edge_threshold`` is intentionally not a deletion threshold: it
+        # only bounds the later, locally validated spill-matte candidates.
         should_expand = alpha == 0
-        if alpha > 0 and distance <= edge_threshold:
+        if alpha > 0 and distance <= threshold:
             pixels[x, y] = (0, 0, 0, 0)
-            if distance < threshold:
-                removed += 1
-            else:
-                edge_removed += 1
+            edge_removed += 1
             should_expand = True
         if should_expand:
             for dx in (-1, 0, 1):
@@ -146,38 +130,87 @@ def _remove_magenta_background(
                     if next_pixel not in visited:
                         queue.append(next_pixel)
 
-    # A single exterior shell catches the visibly purple one-pixel halo that
-    # image generators often leave just beyond an otherwise opaque contour.
-    # Limit it to pixels already touching transparent background and apply it
-    # simultaneously, so it cannot eat into a real purple foreground region.
-    edge_spill: list[tuple[int, int]] = []
+    # Only after the edge-connected backdrop is removed do we clear any
+    # remaining strict-key holes.  Keeping this as a separate pass makes the
+    # report distinguish ordinary backdrop cleanup from enclosed holes.
     for x in range(width):
         for y in range(height):
             red, green, blue, alpha = pixels[x, y]
-            if (
-                alpha == 0
-                or green > 40
-                or min(red, blue) < 90
-                or abs(red - blue) > 100
-            ):
+            if alpha > 0 and _color_distance((red, green, blue)) <= threshold:
+                pixels[x, y] = (0, 0, 0, 0)
+                removed += 1
+
+    # A candidate spill pixel must be explainable as a compositing result of
+    # the key colour and an adjacent, more foreground-like pixel.  This is the
+    # deterministic boundary missing from a simple RGB-distance or
+    # channel-dominance test: a real purple line beside transparency has only
+    # same-colour neighbours and therefore estimates alpha ~= 1, so it stays.
+    edge_spill: list[tuple[int, int, tuple[int, int, int], float]] = []
+    for x in range(width):
+        for y in range(height):
+            red, green, blue, alpha = pixels[x, y]
+            distance = _color_distance((red, green, blue))
+            if alpha == 0 or distance > edge_threshold:
                 continue
-            if any(
-                0 <= x + dx < width
-                and 0 <= y + dy < height
-                and pixels[x + dx, y + dy][3] == 0
+            neighbours = [
+                pixels[x + dx, y + dy]
                 for dx in (-1, 0, 1)
                 for dy in (-1, 0, 1)
-                if dx or dy
-            ):
-                edge_spill.append((x, y))
-    for x, y in edge_spill:
-        pixels[x, y] = (0, 0, 0, 0)
+                if (dx or dy) and 0 <= x + dx < width and 0 <= y + dy < height
+            ]
+            if not any(item[3] == 0 for item in neighbours):
+                continue
+            best: tuple[tuple[int, int, int], float, float] | None = None
+            for neighbour_red, neighbour_green, neighbour_blue, neighbour_alpha in neighbours:
+                foreground = (neighbour_red, neighbour_green, neighbour_blue)
+                if neighbour_alpha == 0 or _color_distance(foreground) <= distance + 8:
+                    continue
+                matte_alpha = _magenta_composite_alpha((red, green, blue), foreground)
+                if matte_alpha is None:
+                    continue
+                residual = _magenta_composite_residual(
+                    (red, green, blue), foreground, matte_alpha
+                )
+                if best is None or residual < best[2]:
+                    best = (foreground, matte_alpha, residual)
+            if best is not None:
+                foreground, matte_alpha, _ = best
+                edge_spill.append((x, y, foreground, matte_alpha))
+    for x, y, foreground, matte_alpha in edge_spill:
+        red, green, blue, alpha = pixels[x, y]
+        pixels[x, y] = (*foreground, round(alpha * matte_alpha))
 
     return converted, {
         "removed_pixels": removed,
         "edge_removed_pixels": edge_removed,
         "edge_spill_pixels": len(edge_spill),
     }
+
+
+def _magenta_composite_alpha(
+    pixel: tuple[int, int, int], foreground: tuple[int, int, int]
+) -> float | None:
+    """Return a consistent foreground coverage for ``pixel`` over magenta."""
+    ratios: list[float] = []
+    for value, foreground_value, key_value in zip(pixel, foreground, MAGENTA_RGB):
+        denominator = foreground_value - key_value
+        if abs(denominator) >= 8:
+            ratios.append((value - key_value) / denominator)
+    if len(ratios) < 2:
+        return None
+    coverage = sum(ratios) / len(ratios)
+    if not 0.05 <= coverage <= 0.95 or max(ratios) - min(ratios) > 0.08:
+        return None
+    return coverage
+
+
+def _magenta_composite_residual(
+    pixel: tuple[int, int, int], foreground: tuple[int, int, int], coverage: float
+) -> float:
+    return max(
+        abs(value - round(key_value + coverage * (foreground_value - key_value)))
+        for value, foreground_value, key_value in zip(pixel, foreground, MAGENTA_RGB)
+    )
 
 
 def _trim_border(image, *, pixels: int):
@@ -451,9 +484,8 @@ def process_sheet(
     padding: int = 0,
     reject_edge_touch: bool = False,
     background: str = "transparent",
-    magenta_threshold: int = 100,
-    magenta_edge_threshold: int = 120,
-    magenta_soft_matte: bool = False,
+    magenta_threshold: int = 40,
+    magenta_edge_threshold: int = 220,
     component_mode: str = "all",
     component_padding: int | None = None,
     min_component_area: int = 1,
@@ -481,8 +513,6 @@ def process_sheet(
 
     if background not in {"transparent", "magenta"}:
         raise SheetProcessError("--background must be transparent or magenta")
-    if magenta_soft_matte and background != "magenta":
-        raise SheetProcessError("--magenta-soft-matte requires --background magenta")
     if snap_mode not in SNAP_MODES:
         raise SheetProcessError("--snap-mode must be grid or autoslice")
     if snap_mode == "grid" and grid is None:
@@ -519,15 +549,11 @@ def process_sheet(
             "background": background,
             "magenta_threshold": magenta_threshold if background == "magenta" else None,
             "magenta_edge_threshold": magenta_edge_threshold if background == "magenta" else None,
-            "magenta_soft_matte": magenta_soft_matte,
             "removed_pixels": 0,
             "edge_removed_pixels": 0,
+            "edge_spill_pixels": 0,
         }
         if background == "magenta":
-            # ``--magenta-soft-matte`` remains accepted for compatibility,
-            # but deliberately uses the same topology-aware contract.  The
-            # previous full-image channel-dominance matte deleted legitimate
-            # red and purple foreground pixels.
             image, cleanup_counts = _remove_magenta_background(
                 image,
                 threshold=magenta_threshold,
@@ -807,19 +833,14 @@ def _main() -> int:
     parser.add_argument(
         "--magenta-threshold",
         type=int,
-        default=100,
-        help="Euclidean RGB distance for #FF00FF cleanup",
+        default=40,
+        help="Global RGB distance for exact and enclosed #FF00FF background cleanup",
     )
     parser.add_argument(
         "--magenta-edge-threshold",
         type=int,
-        default=120,
-        help="Euclidean RGB distance for edge-connected #FF00FF fringe cleanup",
-    )
-    parser.add_argument(
-        "--magenta-soft-matte",
-        action="store_true",
-        help="Use a fixed soft matte and spill cleanup for #FF00FF-composited source edges",
+        default=220,
+        help="Maximum RGB distance for locally validated magenta spill cleanup",
     )
     parser.add_argument(
         "--snap-mode",
@@ -889,7 +910,6 @@ def _main() -> int:
             background=args.background,
             magenta_threshold=args.magenta_threshold,
             magenta_edge_threshold=args.magenta_edge_threshold,
-            magenta_soft_matte=args.magenta_soft_matte,
             snap_mode=args.snap_mode,
             component_mode=args.component_mode,
             component_padding=args.component_padding,


### PR DESCRIPTION
## Summary

Replace unsafe global magenta cleanup with a shared topology-aware cleanup contract across sheet, image-finalize, and action-processing paths.

## Motivation

Prevent magenta and purple background spill while retaining genuine red, purple, blue-purple, and antialiased foreground details.

## Changes

- [x] Share deterministic magenta cleanup behavior across all three processing entry points.
- [x] Add noisy composite, wide-threshold, foreground-preservation, and action-recovery regression coverage.
- [x] Update asset-tool and compact-prop-pack documentation to reflect the cleanup contract.

## Testing

- [x] New or updated tests pass (`python -m pytest -q`: 2241 passed, 7 skipped).
- [x] Gitleaks passes or no secret-bearing files were touched (Secret Scan passed in CI).
- [x] Manual testing completed, if applicable (real provider fixture produced 16 autoslice candidates; zero opaque exact `#FF00FF` pixels after cleanup).

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
N/A — not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>` (N/A — no migration)
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"` (N/A — no migration)
- [ ] Post-upgrade on-disk state was inspected and matches expectations (N/A — no migration)
- [ ] Re-running `tools/publish.py` produces no further migration changes (N/A — no migration)
- [ ] Result attached or summarized below (N/A — no migration)

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (N/A — no ECS changes)
- [x] No hardcoded secrets or API keys
- [ ] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR (N/A — maintenance behavior correction; relevant tool documentation was updated)
