### PR TITLE
Give workers the TileMap authoring boundary

### DIFF
--- a/agents/worker.md
+++ b/agents/worker.md
@@ -144,8 +144,8 @@ write a repair record, run a revalidation pass, or author a new skill.
   substitute the physical atlas image behind it.
 - `Texture2D` → the node's texture. `StyleBoxTexture` → the Theme or StyleBox
   slot it belongs to. `Theme` → `Control.theme`. `TileSet` →
-  `TileMapLayer.tile_set`. Author map layout, layers, and gameplay structure
-  yourself.
+  `TileMapLayer.tile_set`, then author the map yourself — see **TileMap
+  Authoring** below.
 - For temporary projectile, impact, pickup, slash, aura, or feedback FX, wire
   the effect lifecycle so it disappears or clears after playback.
 - **Art production is never yours.** Do not draw, generate, synthesize, or
@@ -161,6 +161,41 @@ write a repair record, run a revalidation pass, or author a new skill.
   freshly drawn stand-ins.
 - If the snapshot is empty for a visual task, or a listed artifact path does not
   exist, report `PARTIAL` or `FAILED` with the missing path. Do not invent one.
+
+## TileMap Authoring
+
+A `TileSet` is a tile library, not a map. Nobody upstream decided where a tile
+goes, so when your brief binds one, the map is yours.
+
+- **Design from the game requirement, not from the tiles.** Read the brief's
+  `Game Mechanic Function`, `Scene Layout Reference`, and listed Input Files
+  first: they say what the player must walk on, be blocked by, enter, leave, and
+  trigger. The atlas only tells you what art exists — never what the level is.
+- **Separate art from gameplay structure.** Painted cells are terrain art plus
+  the tile semantics the `TileSet` already declares. Spawns, exits, pickups,
+  hazards, doors, enemies, and interactables are gameplay objects: author them
+  as nodes or entities, not as cells the game has to reverse-engineer.
+- **You decide the structure.** Layer count and order, cell placement, gameplay
+  object placement, triggers and zones, camera limits, and the scene tree that
+  holds them are all yours. No brief, manifest, or artifact hands them to you,
+  and no asset skill guesses them for you.
+- **Use the ready `TileSet` as it is.** Paint with the terrain sets, physics
+  layers, navigation, and custom data it already declares — read them off the
+  loaded resource. Do not add sources, re-slice the atlas, or hand-edit the
+  `.tres` to invent semantics it does not have. If a semantic the map genuinely
+  needs is absent, say so in Notes instead of painting around it.
+- **Read the tilemap gotchas before painting.** `.claude/skills/tilemap/gotchas.md`
+  covers the failures that cost the most rework here: terrain painting order,
+  collision polygon snagging, y-sort layering, and stale navigation meshes.
+- **Run the map, do not just build it.** A tilemap that compiles is not a
+  tilemap that plays. Drive the real traversal path from your unit tests —
+  blocked cells block, walkable cells are walkable, every trigger and exit you
+  placed fires — and when the brief includes `Visual Self-Check`, look at the
+  map on screen too.
+- **Fix the concrete failure the run showed.** Repair the specific gap in a
+  wall, snagging corner, unreachable exit, stale nav mesh, or camera that leaves
+  the map, then re-run. Do not redesign the layout on a hunch, and do not report
+  DONE on a map you never ran.
 
 ## Error Handling
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -46,6 +46,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Changed
 
+- Workers now own TileMap layout, layers, cell and gameplay object placement, triggers, camera limits, and scene structure, binding a ready `TileSet` as a tile library and repairing what running the map actually shows.
+
 - Reworked `ui-kit` around a flat-first Godot Theme: one fixed eight-patch
   surface atlas expands into reusable button, panel, popup, tooltip, and tab
   StyleBoxTextures, while native StyleBoxFlat/StyleBoxEmpty resources own form,

--- a/skills/core/_shared/worker-dispatch.md
+++ b/skills/core/_shared/worker-dispatch.md
@@ -43,6 +43,7 @@ Agent({
 - [ ] Load every `Asset Runtime Snapshot` `godot_artifact.path` and bind it as its declared `godot_artifact.type`; do not rebuild it from `source_layout`
 - [ ] If runtime assets include a `SpriteFrames` artifact: wire animation playback from that resource, not one static frame
 - [ ] If runtime assets include temporary animated FX: implement end-of-life behavior (animation finished, timer, tween completion, or equivalent state clear)
+- [ ] If runtime assets include a `TileSet` artifact: decide the layer count, cell placement, gameplay object placement, triggers, camera limits, and scene structure yourself, then run the map and fix the concrete failures the run shows
 - [ ] Run headless-build and confirm compilation
 - [ ] Run unit tests and include pass/fail output
 - [ ] If `Visual Self-Check` is present: capture screenshot(s), run visual-qa, include output
@@ -166,6 +167,20 @@ record, a revalidation pass, or a worker-authored skill; accept a note in the
 report. Do not let a worker produce art. Never write a `Scope Boundaries` or
 `Prohibited Actions` line that cancels this exception.
 25. **Fixgap visual tasks require worker self-check output.** Fill `Visual Self-Check` for blocking findings from `evaluation.json.visual_checks` or visual critical/major issues. Use `reports/fixgap-visual/{task_id}/`, not `e2e/` or `.godotmaker/`.
+26. **A `TileSet` artifact carries no map.** When the snapshot lists one, state
+the map's gameplay requirement in `Game Mechanic Function` — what blocks the
+player, what is walkable, where they enter and leave, what must trigger — and
+leave layer count, cell placement, gameplay object placement, triggers, camera
+limits, and scene structure to the worker. Do not paste a cell grid or a layer
+list, and never ask an asset skill to design the map: a tile library is art plus
+declared tile semantics, and the layout depends on the concrete game
+requirement.
+27. **A TileMap task is not done until it ran.** Require unit tests that drive
+the real traversal path — blocked cells block, walkable cells are walkable, each
+placed trigger and exit fires — and fill `Visual Self-Check` when the map's
+appearance is part of the finding. Then require the worker to fix the concrete
+failures the run exposed. A green headless build is not evidence that the map
+plays.
 
 ## Worker Utility Convention
 

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -428,6 +428,176 @@ def test_worker_binds_the_compiled_artifact_instead_of_rebuilding_it():
     assert "`TileMapLayer.tile_set`" in worker
 
 
+def test_worker_owns_tilemap_layout_and_gameplay_structure():
+    """A `TileSet` is art plus declared tile semantics. The map is neither.
+
+    Which cell goes where, how many layers there are, where the player spawns
+    and exits, what triggers, and how far the camera may travel all follow from
+    the concrete game requirement — nothing upstream of the worker knows it. A
+    decision this prompt does not claim reads as somebody else's, and the worker
+    paints a decorative map with no gameplay structure in it.
+    """
+    worker = _read("agents/worker.md")
+    dispatch = _read("skills/core/_shared/worker-dispatch.md")
+    flat_worker = _flat(worker)
+    flat_dispatch = _flat(dispatch)
+
+    assert "## TileMap Authoring" in worker
+    assert "A `TileSet` is a tile library, not a map." in flat_worker
+    assert "**A `TileSet` artifact carries no map.**" in flat_dispatch
+
+    # Both sides enumerate the owned decisions. Naming only "layout" leaves a
+    # brief free to keep triggers or camera bounds and hand down a dressed map.
+    for decision in (
+        "Layer count and order",
+        "cell placement",
+        "gameplay object placement",
+        "triggers and zones",
+        "camera limits",
+        "the scene tree that holds them",
+    ):
+        assert decision in flat_worker, f"worker.md stopped claiming {decision}"
+    # On the dispatch side the enumeration has to be in both places: the rule is
+    # what the manager reads, the Deliverables checkbox is what actually reaches
+    # the worker. Matching the file as a whole would let either one drop it.
+    rule = flat_dispatch.split("**A `TileSet` artifact carries no map.**", 1)[1]
+    rule = rule.split("27. **", 1)[0]
+    deliverable = next(
+        (
+            line
+            for line in dispatch.splitlines()
+            if line.startswith("- [ ] If runtime assets include a `TileSet` artifact:")
+        ),
+        "",
+    )
+    assert deliverable, "the brief template lost its `TileSet` deliverable"
+    for decision in (
+        "layer count",
+        "cell placement",
+        "gameplay object placement",
+        "triggers",
+        "camera limits",
+        "scene structure",
+    ):
+        assert decision in rule, (
+            f"the dispatch rule stopped leaving {decision} to the worker"
+        )
+        assert decision in deliverable, (
+            f"the `TileSet` deliverable stopped naming {decision}"
+        )
+
+    # The layout comes from the game requirement, never from the atlas.
+    assert "**Design from the game requirement, not from the tiles.**" in flat_worker
+    assert "never what the level is" in flat_worker
+    assert "the layout depends on the concrete game requirement" in flat_dispatch
+
+    # Art and gameplay structure stay separated, or the gameplay objects end up
+    # painted into cells the runtime then has to guess back out.
+    assert "**Separate art from gameplay structure.**" in flat_worker
+    assert (
+        "author them as nodes or entities, not as cells the game has to "
+        "reverse-engineer" in flat_worker
+    )
+
+    # A pasted grid is how a manager takes the decision back without saying so.
+    assert "Do not paste a cell grid or a layer list" in flat_dispatch
+
+
+def test_worker_paints_with_the_tileset_semantics_it_was_given():
+    """Terrain sets, physics, navigation, and custom data ship compiled in.
+
+    A worker that hand-edits the `.tres` to add the semantic it wants has
+    rebuilt the artifact with none of its L0-L4 evidence; a worker that quietly
+    paints around a missing one hides the gap from whoever owns the art. Both
+    end with a map that looks right and behaves wrong.
+    """
+    flat_worker = _flat(_read("agents/worker.md"))
+
+    assert "**Use the ready `TileSet` as it is.**" in flat_worker
+    assert (
+        "Paint with the terrain sets, physics layers, navigation, and custom "
+        "data it already declares" in flat_worker
+    )
+    assert (
+        "Do not add sources, re-slice the atlas, or hand-edit the `.tres` to "
+        "invent semantics it does not have." in flat_worker
+    )
+    assert "say so in Notes instead of painting around it" in flat_worker
+    # The known-pitfall reference, so terrain order and nav staleness are not
+    # rediscovered one review cycle at a time.
+    assert ".claude/skills/tilemap/gotchas.md" in flat_worker
+
+
+def test_tilemap_work_is_verified_by_running_the_map():
+    """A compiled `TileMapLayer` proves nothing about whether the map plays.
+
+    A wall that does not block, an exit nothing can reach, a stale navigation
+    mesh, and a camera that slides off the map all survive a green headless
+    build. The prompt has to demand the run and then tie the fix to what the run
+    showed, or the worker reports DONE on a map it never played.
+    """
+    flat_worker = _flat(_read("agents/worker.md"))
+    flat_dispatch = _flat(_read("skills/core/_shared/worker-dispatch.md"))
+
+    assert "**Run the map, do not just build it.**" in flat_worker
+    assert "A tilemap that compiles is not a tilemap that plays." in flat_worker
+    assert "do not report DONE on a map you never ran" in flat_worker
+
+    # The repair follows the observed failure instead of a redesign on a hunch.
+    assert "**Fix the concrete failure the run showed.**" in flat_worker
+    assert "Do not redesign the layout on a hunch" in flat_worker
+
+    assert "**A TileMap task is not done until it ran.**" in flat_dispatch
+    assert "blocked cells block, walkable cells are walkable" in flat_dispatch
+    assert "fix the concrete failures the run exposed" in flat_dispatch
+    assert "A green headless build is not evidence that the map plays." in flat_dispatch
+
+
+def test_map_authoring_never_flows_back_into_an_asset_skill():
+    """Asset production stops at the tile library.
+
+    An asset skill that starts placing cells is guessing the level from the art
+    it just made — the one thing the pixels cannot tell it — and the guess
+    arrives as a compiled resource with L0-L4 evidence attached, which reads
+    downstream as a decision somebody verified. Stating the boundary in prose is
+    not enough; the scan is what catches a later edit crossing it.
+    """
+    flat_tileset = _flat(_read("skills/assets/tileset/SKILL.md"))
+    assert "never for designing a TileMap" in flat_tileset
+    assert (
+        "A TileSet is a reusable tile library; creating or painting a `TileMap` "
+        "is outside this skill." in flat_tileset
+    )
+
+    # A map-authoring API inside a production document is the concrete symptom.
+    authoring_api = re.compile(
+        r"TileMapLayer|set_cells?_terrain|\bset_cell\b|\berase_cell\b", re.IGNORECASE
+    )
+    offenders = []
+    scanned = 0
+    for root in ("skills/assets", "skills/core/gm-asset"):
+        directory = REPO_ROOT / root
+        assert directory.is_dir(), f"scan root disappeared: {root}"
+        for path in sorted(directory.glob("**/*.md")):
+            scanned += 1
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines, start=1):
+                if authoring_api.search(line):
+                    relative = str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+                    offenders.append(f"{relative}:{index}: {line.strip()}")
+    assert scanned, "the asset production docs disappeared"
+    assert not offenders, (
+        "these asset production docs author a TileMap instead of a tile library: "
+        + "; ".join(offenders)
+    )
+
+    # And both worker-side prompts say out loud that nobody upstream will do it.
+    assert "no asset skill guesses them for you" in _flat(_read("agents/worker.md"))
+    assert "never ask an asset skill to design the map" in _flat(
+        _read("skills/core/_shared/worker-dispatch.md")
+    )
+
+
 def test_a_missing_artifact_fails_closed_instead_of_reaching_a_worker():
     """No artifact means no visual dispatch — not an invented path.
 


### PR DESCRIPTION
## Summary

Clarifies the TileMap authoring boundary for workers and adds contract coverage that keeps map-layout decisions out of asset skills.

## Motivation

Workers need explicit ownership of map layers, placement, gameplay objects, triggers, camera limits, and scene structure while reusing the existing TileSet semantics. No public GitHub issue.

## Changes

- [x] Documented TileMap authoring responsibilities and the use of ready TileSets.
- [x] Added dispatch guidance and contract tests that protect the responsibility boundary.

## Testing

- [x] New or updated tests pass (`python -m pytest`; 2236 passed, 7 skipped)
- [x] Gitleaks passes or no secret-bearing files were touched (no secret-bearing files were touched)
- [x] Manual testing completed, if applicable (documentation and contract-test change; not applicable)

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [x] Not applicable; no migration script was added or modified.
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable (not applicable)
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
