### PR TITLE
fix(asset): close the background-map ready registration chain

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -86,6 +86,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- A validated background-map now registers as a ready `single -> Texture2D` stable entry through its own finalize builder, instead of stopping at `source_ready` with no way to reach a worker.
+
 - Replaced legacy magenta edge cleanup with PyMatting using a fixed validated trimap.
 
 - Compact prop packs now generate one provider-authored source sheet, normalize each curated prop into its declared atlas slot, and publish independently addressable AtlasTexture resources with repaired L0-L4 validation.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -86,7 +86,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
-- A validated background-map now registers as a ready `single -> Texture2D` stable entry through its own finalize builder, instead of stopping at `source_ready` with no way to reach a worker.
+- A validated background-map now registers as a ready `single -> Texture2D` stable entry through its own finalize builder, instead of stopping at `source_ready` with no way to reach a worker; registration binds to the image bytes its L0-L4 run recorded, so regenerating onto the same stable path fails closed.
 
 - Replaced legacy magenta edge cleanup with PyMatting using a fixed validated trimap.
 

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -247,6 +247,15 @@ python tools/asset_finalize_entry_draft.py \
   --out .godotmaker/asset-generation/work/entries/<asset_id>.json
 ```
 
+Adding `--result <result.json>` switches the same builder to `background-map`
+ready mode. It binds that passing result's one `Texture2D` runtime output and
+its one `single` source to the exact PNG the finalize report published, requires
+all of L0-L4, runs the registered `single -> Texture2D` route, and writes the
+`ready` entry from the artifact that route returned. Godot's default import is
+already that `Texture2D`, so `source_layout.path` and `godot_artifact.path` are
+the same PNG and no `.tres` is produced. Without `--result` the entry stops at
+`source_ready`.
+
 ## asset_output_path.py
 
 `asset_output_path.py` is the authority for the stable output directory

--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -256,6 +256,13 @@ already that `Texture2D`, so `source_layout.path` and `godot_artifact.path` are
 the same PNG and no `.tres` is produced. Without `--result` the entry stops at
 `source_ready`.
 
+Because a result names paths and not bytes, and the stable path is derived from
+the asset id, that mode also requires the validation record the family's
+standalone runner wrote for the image it examined
+(`.godotmaker/asset-generation/reports/<asset_id>_validation.json`) and
+recomputes it from disk. Overwriting the PNG after validation — which a normal
+retry does, in place — fails closed until the Skill revalidates.
+
 ## asset_output_path.py
 
 `asset_output_path.py` is the authority for the stable output directory

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -197,6 +197,8 @@ python tools/asset_finalize_entry_draft.py \
 
 追加 `--result <result.json>` 会把同一个 builder 切换到 `background-map` 的 ready 模式：它把通过校验的 result 中唯一的 `Texture2D` runtime output 和唯一的 `single` source 绑定到 finalize 报告实际发布的那张 PNG，要求 L0-L4 全部通过，运行已注册的 `single -> Texture2D` 路由，并用该路由返回的 artifact 写出 `ready` entry。Godot 的默认导入本身就是那个 `Texture2D`，因此 `source_layout.path` 与 `godot_artifact.path` 是同一张 PNG，不会产生 `.tres`。不带 `--result` 时 entry 停在 `source_ready`。
 
+由于 result 只声明路径不声明字节，而稳定路径由 asset id 派生，该模式还要求 family 的 standalone 验证运行器为其检查过的图片写下的 validation record（`.godotmaker/asset-generation/reports/<asset_id>_validation.json`），并从磁盘重新计算比对。验证之后再覆盖这张 PNG（正常重试就是原位覆盖）会 fail closed，必须重新走一次 Skill 验证。
+
 ## asset_output_path.py
 
 `asset_output_path.py` 是稳定输出目录 `assets/generated/<production_family>/<asset_id>/` 的唯一权威。一个素材所有可被 worker 消费的文件都放在这里，因此重新生成会就地覆盖，不会漂移到带时间戳或 `v2` 的路径。

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -195,6 +195,8 @@ python tools/asset_finalize_entry_draft.py \
   --out .godotmaker/asset-generation/work/entries/<asset_id>.json
 ```
 
+追加 `--result <result.json>` 会把同一个 builder 切换到 `background-map` 的 ready 模式：它把通过校验的 result 中唯一的 `Texture2D` runtime output 和唯一的 `single` source 绑定到 finalize 报告实际发布的那张 PNG，要求 L0-L4 全部通过，运行已注册的 `single -> Texture2D` 路由，并用该路由返回的 artifact 写出 `ready` entry。Godot 的默认导入本身就是那个 `Texture2D`，因此 `source_layout.path` 与 `godot_artifact.path` 是同一张 PNG，不会产生 `.tres`。不带 `--result` 时 entry 停在 `source_ready`。
+
 ## asset_output_path.py
 
 `asset_output_path.py` 是稳定输出目录 `assets/generated/<production_family>/<asset_id>/` 的唯一权威。一个素材所有可被 worker 消费的文件都放在这里，因此重新生成会就地覆盖，不会漂移到带时间戳或 `v2` 的路径。

--- a/skills/assets/background-map/SKILL.md
+++ b/skills/assets/background-map/SKILL.md
@@ -75,6 +75,11 @@ For every attempt, retain these project-local records under
    the runtime exposes it, real reference attachments with roles, source path,
    and provider trace or failure.
 4. `reports/<asset_id>_finalize.json`, the deterministic finalization report.
+5. `reports/<asset_id>_validation.json`, written by the validation runner itself
+   on a fully passing ladder. It fingerprints the PNG that ladder examined, so
+   registration can tell it apart from whatever a later retry leaves at the same
+   identity-derived path. Keep it beside the other records and do not edit it;
+   regenerating the image means running validation again.
 
 The visual source may only be a selected provider output or a user-provided
 source/reference. Never create art with Pillow, System.Drawing, ImageMagick,

--- a/skills/assets/background-map/SKILL.md
+++ b/skills/assets/background-map/SKILL.md
@@ -75,11 +75,9 @@ For every attempt, retain these project-local records under
    the runtime exposes it, real reference attachments with roles, source path,
    and provider trace or failure.
 4. `reports/<asset_id>_finalize.json`, the deterministic finalization report.
-5. `reports/<asset_id>_validation.json`, written by the validation runner itself
-   on a fully passing ladder. It fingerprints the PNG that ladder examined, so
-   registration can tell it apart from whatever a later retry leaves at the same
-   identity-derived path. Keep it beside the other records and do not edit it;
-   regenerating the image means running validation again.
+5. `reports/<asset_id>_validation.json`, written by the validation runner on a
+   fully passing ladder. Do not edit it; run validation again after any
+   regeneration.
 
 The visual source may only be a selected provider output or a user-provided
 source/reference. Never create art with Pillow, System.Drawing, ImageMagick,

--- a/skills/assets/background-map/standalone_validation.py
+++ b/skills/assets/background-map/standalone_validation.py
@@ -41,13 +41,35 @@ def _runtime() -> None:
 
 
 _runtime()
+from asset_build_record import write_validation_record  # noqa: E402
 from missing_family_standalone_validation import (  # noqa: E402
     MissingFamilySkillError,
     compile_and_validate as _compile_and_validate,
 )
 
+_LEVELS = ("L0", "L1", "L2", "L3", "L4")
+
 
 def compile_and_validate(request, result, *, project_root, godot_path):
-    return _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="background-map")
+    """Run the family ladder and record the PNG a fully passing run examined.
+
+    The stable output path is derived from ``asset_id``, so a regeneration
+    overwrites the very file an older passing result names, and comparing paths
+    at registration would prove nothing about which bytes are there. The record
+    this leaves is what registration recomputes from disk, so only a PNG that
+    actually passed L0-L4 can become a ``ready`` entry.
+    """
+    validated = _compile_and_validate(request, result, project_root=project_root, godot_path=godot_path, expected_family="background-map")
+    levels = validated["validation"]["levels"]
+    if not all(levels.get(level) is True for level in _LEVELS):
+        return validated
+    runtime = [item for item in validated["outputs"] if item.get("role") == "runtime"]
+    write_validation_record(
+        project_root,
+        production_family="background-map",
+        asset_id=request["asset_id"],
+        artifact_path=runtime[0]["path"],
+    )
+    return validated
 
 __all__ = ("MissingFamilySkillError", "compile_and_validate")

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -205,6 +205,12 @@ Brief shape:
 - One Skill call may return several logical outputs. Exactly one runtime output
   per logical asset becomes a stable entry; every other output is reported as a
   reference. Never draft a second entry or a `godot_artifact` for a reference.
+- For `background-map`, pass the finalize report and the passing result to
+  `tools/asset_finalize_entry_draft.py --result`. It writes one ready `single ->
+  Texture2D` entry whose source and artifact are the same finalized PNG, because
+  Godot's default import already produces that `Texture2D`. Do not wrap it in a
+  `.tres`. Without `--result` the entry stops at `source_ready` and never
+  reaches a worker.
 - For `character-bundle`, pass the Skill's archived resolved request, one
   action processing report per required action, and its validated result to
   `tools/asset_action_entry_draft.py` bundle mode. It registers exactly one
@@ -289,7 +295,8 @@ does not register a generic result directly.
 3. Confirm every entry draft came from a deterministic builder —
    `tools/asset_action_entry_draft.py` for processed action output,
    `tools/asset_curation_entry_draft.py` for a selected curation candidate,
-   `tools/asset_finalize_entry_draft.py` for a finalized screen reference,
+   `tools/asset_finalize_entry_draft.py` for a finalized screen reference or,
+   with `--result`, a validated `background-map`,
    `tools/asset_compact_prop_pack_entry_draft.py` for a fully ready compact
    prop atlas bundle,
    `tools/asset_scene_prop_set_entry_draft.py` for a compiled scene prop atlas,

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -209,7 +209,9 @@ Brief shape:
   `tools/asset_finalize_entry_draft.py --result`. It writes one ready `single ->
   Texture2D` entry whose source and artifact are the same finalized PNG, because
   Godot's default import already produces that `Texture2D`. Do not wrap it in a
-  `.tres`. Without `--result` the entry stops at `source_ready` and never
+  `.tres`. It registers only the image the Skill's validation record
+  fingerprinted, so a regeneration after validation fails closed until the Skill
+  revalidates. Without `--result` the entry stops at `source_ready` and never
   reaches a worker.
 - For `character-bundle`, pass the Skill's archived resolved request, one
   action processing report per required action, and its validated result to

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -207,12 +207,10 @@ Brief shape:
   reference. Never draft a second entry or a `godot_artifact` for a reference.
 - For `background-map`, pass the finalize report and the passing result to
   `tools/asset_finalize_entry_draft.py --result`. It writes one ready `single ->
-  Texture2D` entry whose source and artifact are the same finalized PNG, because
-  Godot's default import already produces that `Texture2D`. Do not wrap it in a
-  `.tres`. It registers only the image the Skill's validation record
-  fingerprinted, so a regeneration after validation fails closed until the Skill
-  revalidates. Without `--result` the entry stops at `source_ready` and never
-  reaches a worker.
+  Texture2D` entry using the finalized PNG as both source and artifact. Do not
+  create a `.tres`. That run requires the Skill's validation record; revalidate
+  a regenerated image before registering it. Without `--result` the entry stops
+  at `source_ready`.
 - For `character-bundle`, pass the Skill's archived resolved request, one
   action processing report per required action, and its validated result to
   `tools/asset_action_entry_draft.py` bundle mode. It registers exactly one

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -112,8 +112,9 @@ entry to `ready` only after its own L0-L4 loop passes. Both do that promotion by
 handing the evidence back to the same deterministic builder, which binds the
 promotion to the recorded build fingerprint instead of to the stable path.
 A first-class Skill that already holds a passing result
-when it drafts — `compact-prop-pack`, `scene-prop-set`, `ui-kit`, `card-kit`,
-and `tileset` — writes `ready` directly. Nothing else may write `ready`.
+when it drafts — `background-map`, `compact-prop-pack`, `scene-prop-set`,
+`ui-kit`, `card-kit`, and `tileset` — writes `ready` directly.
+Nothing else may write `ready`.
 
 ## Stable Entry Contract
 
@@ -160,10 +161,13 @@ Rules:
    where an animation was promised. There is no generic compiler that makes
    every source layout runtime-ready: a family without its own compiler and
    validation path stays at `source_ready` with no `godot_artifact`. A family
-   with both paths — `character-bundle`, `fx-bundle`, `compact-prop-pack`,
-   `scene-prop-set`, `ui-kit`, `card-kit`, and `tileset` — follows its explicit
-   contract instead, and every one of them has a deterministic builder that
-   registers what it compiled.
+   with both paths — `background-map`, `character-bundle`, `fx-bundle`,
+   `compact-prop-pack`, `scene-prop-set`, `ui-kit`, `card-kit`, and `tileset` —
+   follows its explicit contract instead, and every one of them has a
+   deterministic builder that registers what it compiled. The `single ->
+   Texture2D` route is the one case where the artifact is the source image
+   itself: Godot's default import already produces the `Texture2D`, so both
+   paths name the same PNG and no `.tres` wraps it.
 5. A `reference` layout carries no `godot_artifact` and keeps its `references/`
    location.
 6. Detailed runtime metadata (region rects, frame lists) is a support file beside
@@ -311,6 +315,25 @@ requires that run to have succeeded with `--require-aspect` inside tolerance and
 `--label <asset_id>`. It derives the layout from the family — `reference` pinned
 to `references/` for `screen-reference`, `single` pinned to the stable output
 directory for every other family.
+
+Ready background map (`background-map`):
+
+```bash
+python tools/asset_finalize_entry_draft.py \
+  --finalize-report <finalize_report.json> --result <result.json> \
+  --asset-id <asset_id> --tag <tag> --production-family background-map \
+  --project-root . \
+  --out .godotmaker/asset-generation/work/entries/<asset_id>.json
+```
+
+`--result` is the same builder in one shot, not a second promotion run: the
+Skill already holds its passing L0-L4 result when it drafts. It binds that
+result's one `Texture2D` runtime output and its one `single` source to the exact
+PNG this finalize report published, requires all of L0-L4, runs the registered
+`single -> Texture2D` route, and writes the `ready` entry from the artifact that
+route returned. Source and artifact are the same PNG — do not wrap it in a
+`.tres`. Without `--result` the entry stops at `source_ready` and no worker sees
+it.
 
 Ready compact prop atlas bundle:
 

--- a/skills/core/gm-asset/references/asset-runtime-pipeline.md
+++ b/skills/core/gm-asset/references/asset-runtime-pipeline.md
@@ -335,6 +335,13 @@ route returned. Source and artifact are the same PNG — do not wrap it in a
 `.tres`. Without `--result` the entry stops at `source_ready` and no worker sees
 it.
 
+A result names paths, never bytes, and the stable path is derived from the asset
+id, so a retry's finalize run overwrites the exact PNG an older passing result
+names. The builder therefore also requires the validation record the family's
+standalone runner wrote for the image it examined, and recomputes it from disk.
+Regenerate after validating and registration fails closed: rerun the Skill's
+validation on the new image before registering it.
+
 Ready compact prop atlas bundle:
 
 ```bash

--- a/tests/assets/test_missing_family_standalone_validation.py
+++ b/tests/assets/test_missing_family_standalone_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import importlib.util
 import struct
@@ -600,6 +601,102 @@ def test_background_executes_l2_to_l4_with_a_real_png_and_probe(monkeypatch, tmp
     assert actual["validation"]["levels"] == {
         level: True for level in ("L0", "L1", "L2", "L3", "L4")
     }
+
+
+class _PassingTexture2DProbe:
+    def __init__(self, _path):
+        pass
+
+    def probe(self, _root, requests):
+        return ProbeReport(
+            "fake",
+            (
+                ProbeResult(
+                    requests[0].res_path,
+                    "Texture2D",
+                    True,
+                    "CompressedTexture2D",
+                    True,
+                    structure={"texture2d": {"width": 2, "height": 3}},
+                ),
+            ),
+        )
+
+
+def test_background_records_the_bytes_a_passing_ladder_examined(monkeypatch, tmp_path):
+    """Registration has no other way to tell the validated build from a retry's.
+
+    The stable path is derived from `asset_id`, so a regeneration overwrites the
+    exact PNG a passing result names. The record is what the entry builder
+    recomputes from disk before it writes `ready`.
+    """
+    source = tmp_path / "assets/generated/background-map/sky/sky.png"
+    source.parent.mkdir(parents=True)
+    Image.new("RGBA", (2, 3), (1, 2, 3, 255)).save(source)
+    monkeypatch.setattr(runner, "GodotProbe", _PassingTexture2DProbe)
+
+    actual = _source_adapter("background-map").compile_and_validate(
+        {"asset_type": "background-map", "asset_id": "sky", "brief": "A blue sky."},
+        _background_result(),
+        project_root=tmp_path,
+        godot_path="fake",
+    )
+
+    assert actual["validation"]["passed"] is True
+    record = json.loads(
+        (
+            tmp_path / ".godotmaker/asset-generation/reports/sky_validation.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert record == {
+        "version": 1,
+        "production_family": "background-map",
+        "asset_id": "sky",
+        "artifact": {
+            "path": "res://assets/generated/background-map/sky/sky.png",
+            "sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
+        },
+    }
+
+
+def test_background_records_nothing_when_the_ladder_does_not_pass(monkeypatch, tmp_path):
+    """A failed run must not leave a record that would let the bytes register."""
+    source = tmp_path / "assets/generated/background-map/sky/sky.png"
+    source.parent.mkdir(parents=True)
+    Image.new("RGBA", (2, 3), (1, 2, 3, 255)).save(source)
+
+    class Probe:
+        def __init__(self, _path):
+            pass
+
+        def probe(self, _root, requests):
+            return ProbeReport(
+                "fake",
+                (
+                    ProbeResult(
+                        requests[0].res_path,
+                        "Texture2D",
+                        False,
+                        None,
+                        False,
+                        error="Godot could not import the image",
+                    ),
+                ),
+            )
+
+    monkeypatch.setattr(runner, "GodotProbe", Probe)
+
+    actual = _source_adapter("background-map").compile_and_validate(
+        {"asset_type": "background-map", "asset_id": "sky", "brief": "A blue sky."},
+        _background_result(),
+        project_root=tmp_path,
+        godot_path="fake",
+    )
+
+    assert actual["validation"]["passed"] is False
+    assert not (
+        tmp_path / ".godotmaker/asset-generation/reports/sky_validation.json"
+    ).exists()
 
 
 def test_standalone_validation_prefers_the_pinned_eval_godot(monkeypatch, tmp_path):

--- a/tests/tools/test_asset_finalize_entry_draft.py
+++ b/tests/tools/test_asset_finalize_entry_draft.py
@@ -225,6 +225,209 @@ def test_runtime_family_path_must_be_in_the_stable_directory(tmp_path, path):
         )
 
 
+def make_runtime_result(**overrides):
+    """The background-map Skill result for the image the report finalized."""
+    res_path = f"res://{RUNTIME_PATH}"
+    result = {
+        "asset_type": RUNTIME_FAMILY,
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": RUNTIME_ASSET_ID,
+                "path": res_path,
+                "godot_type": "Texture2D",
+            }
+        ],
+        "sources": [{"path": res_path, "layout": "single"}],
+        "previews": [],
+        "validation": {
+            "passed": True,
+            "levels": {level: True for level in ("L0", "L1", "L2", "L3", "L4")},
+        },
+    }
+    result.update(overrides)
+    return result
+
+
+def write_runtime_result(project_root: Path, result) -> Path:
+    path = project_root / ".godotmaker/asset-generation/sky-result.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result), encoding="utf-8")
+    return path
+
+
+def build_runtime(project_root: Path, result, *, report=None):
+    report = report if report is not None else make_report(
+        path=RUNTIME_PATH, label=RUNTIME_ASSET_ID, asset_id=RUNTIME_ASSET_ID
+    )
+    return build(
+        project_root,
+        write_report(project_root, report),
+        asset_id=RUNTIME_ASSET_ID,
+        production_family=RUNTIME_FAMILY,
+        result_path=write_runtime_result(project_root, result),
+    )
+
+
+def test_a_validated_background_map_becomes_a_ready_texture2d_entry(tmp_path):
+    """The PNG is the Texture2D Godot imports; no .tres wraps it."""
+    touch(tmp_path, RUNTIME_PATH)
+
+    entry = build_runtime(tmp_path, make_runtime_result())
+
+    assert entry["source_layout"] == {"type": "single", "path": f"res://{RUNTIME_PATH}"}
+    assert entry["godot_artifact"] == {
+        "type": "Texture2D",
+        "path": f"res://{RUNTIME_PATH}",
+    }
+    assert entry["processing_status"] == "ready"
+    validate_entry(entry, project_root=tmp_path, check_files=True)
+
+
+def test_a_failed_ladder_never_reaches_ready(tmp_path):
+    touch(tmp_path, RUNTIME_PATH)
+    result = make_runtime_result()
+    result["validation"] = {
+        "passed": False,
+        "levels": {"L0": True, "L1": True, "L2": True, "L3": False, "L4": False},
+    }
+
+    with pytest.raises(FinalizeEntryDraftError, match="not passing: L3, L4"):
+        build_runtime(tmp_path, result)
+
+
+def test_a_result_without_levels_never_reaches_ready(tmp_path):
+    """`passed: true` alone is a claim; the levels are the evidence."""
+    touch(tmp_path, RUNTIME_PATH)
+    result = make_runtime_result()
+    del result["validation"]["levels"]
+
+    with pytest.raises(FinalizeEntryDraftError, match="no explicit validation levels"):
+        build_runtime(tmp_path, result)
+
+
+def test_a_self_declared_failure_never_reaches_ready(tmp_path):
+    """An all-true ladder plus `passed: false` is still a refused delivery."""
+    touch(tmp_path, RUNTIME_PATH)
+    result = make_runtime_result()
+    result["validation"]["passed"] = False
+    result["validation"]["notes"] = "the horizon line drifts under the viewport"
+
+    with pytest.raises(FinalizeEntryDraftError, match="validation.passed is not true"):
+        build_runtime(tmp_path, result)
+
+
+def test_a_result_about_another_image_cannot_register_this_one(tmp_path):
+    touch(tmp_path, RUNTIME_PATH)
+    result = make_runtime_result()
+    result["outputs"][0]["path"] = "res://assets/generated/background-map/dusk/dusk.png"
+
+    with pytest.raises(FinalizeEntryDraftError, match="must be the finalized stable"):
+        build_runtime(tmp_path, result)
+
+
+def test_a_result_sourced_from_another_image_cannot_register_this_one(tmp_path):
+    """The runtime output alone never says which file carried the layout."""
+    touch(tmp_path, RUNTIME_PATH)
+    result = make_runtime_result()
+    result["sources"] = [
+        {"path": "res://assets/generated/background-map/dusk/dusk.png", "layout": "single"}
+    ]
+
+    with pytest.raises(FinalizeEntryDraftError, match="single source must be"):
+        build_runtime(tmp_path, result)
+
+
+def test_a_result_for_another_family_is_rejected(tmp_path):
+    touch(tmp_path, RUNTIME_PATH)
+
+    with pytest.raises(FinalizeEntryDraftError, match="must be a background-map result"):
+        build_runtime(tmp_path, make_runtime_result(asset_type="fx-bundle"))
+
+
+def test_a_second_runtime_output_is_rejected(tmp_path):
+    # One scenic image is one texture; a second would reach the worker as a
+    # rival background for the same asset.
+    touch(tmp_path, RUNTIME_PATH)
+    result = make_runtime_result()
+    result["outputs"].append(
+        {
+            "role": "runtime",
+            "path": f"res://{stable_output_dir(RUNTIME_FAMILY, RUNTIME_ASSET_ID)}/extra.png",
+            "godot_type": "Texture2D",
+        }
+    )
+
+    with pytest.raises(FinalizeEntryDraftError, match="exactly one runtime output"):
+        build_runtime(tmp_path, result)
+
+
+def test_a_result_declaring_a_wrong_artifact_type_is_rejected(tmp_path):
+    touch(tmp_path, RUNTIME_PATH)
+    result = make_runtime_result()
+    result["outputs"][0]["godot_type"] = "SpriteFrames"
+
+    with pytest.raises(FinalizeEntryDraftError, match="must be the finalized stable"):
+        build_runtime(tmp_path, result)
+
+
+def test_a_drifted_finalized_name_never_reaches_ready(tmp_path):
+    """The stable PNG is `<asset_id>.png`; a `_v2` sibling is drift, not an asset."""
+    drifted = f"{stable_output_dir(RUNTIME_FAMILY, RUNTIME_ASSET_ID)}/{RUNTIME_ASSET_ID}_v2.png"
+    touch(tmp_path, drifted)
+    report = make_report(
+        path=drifted, label=RUNTIME_ASSET_ID, asset_id=RUNTIME_ASSET_ID
+    )
+
+    with pytest.raises(FinalizeEntryDraftError, match="must finalize into its stable"):
+        build_runtime(tmp_path, make_runtime_result(), report=report)
+
+
+def test_a_missing_finalized_image_never_reaches_ready(tmp_path):
+    with pytest.raises(FinalizeEntryDraftError, match="finalized file not found"):
+        build_runtime(tmp_path, make_runtime_result())
+
+
+def test_a_reference_family_cannot_be_promoted_with_a_result(tmp_path):
+    """`--result` compiles a native artifact; a reference never has one."""
+    touch(tmp_path, REFERENCE)
+    result = make_runtime_result(asset_type="screen-reference")
+
+    with pytest.raises(FinalizeEntryDraftError, match="only supported for background-map"):
+        build(
+            tmp_path,
+            write_report(tmp_path, make_report()),
+            result_path=write_runtime_result(tmp_path, result),
+        )
+
+
+def test_a_rejected_promotion_leaves_no_draft_behind(tmp_path):
+    """A partial registration is worse than none: nothing may be written."""
+    touch(tmp_path, RUNTIME_PATH)
+    result = make_runtime_result()
+    result["validation"]["levels"]["L4"] = False
+    result["validation"]["passed"] = False
+    out = tmp_path / ".godotmaker/asset-generation/work/entries/sky.json"
+
+    with pytest.raises(FinalizeEntryDraftError):
+        write_finalize_entry_draft(
+            write_report(
+                tmp_path,
+                make_report(
+                    path=RUNTIME_PATH, label=RUNTIME_ASSET_ID, asset_id=RUNTIME_ASSET_ID
+                ),
+            ),
+            asset_id=RUNTIME_ASSET_ID,
+            tag=TAG,
+            production_family=RUNTIME_FAMILY,
+            project_root=tmp_path,
+            out=out,
+            result_path=write_runtime_result(tmp_path, result),
+        )
+
+    assert not out.exists()
+
+
 def test_unknown_production_family_is_rejected(tmp_path):
     touch(tmp_path, REFERENCE)
 

--- a/tests/tools/test_asset_finalize_entry_draft.py
+++ b/tests/tools/test_asset_finalize_entry_draft.py
@@ -13,6 +13,10 @@ from asset_finalize_entry_draft import (  # noqa: E402
     build_finalize_entry_draft,
     write_finalize_entry_draft,
 )
+from asset_build_record import (  # noqa: E402
+    validation_record_path,
+    write_validation_record,
+)
 from asset_stable_entry import stable_output_dir, validate_entry  # noqa: E402
 
 DRAFT_TOOL = TOOLS_DIR / "asset_finalize_entry_draft.py"
@@ -256,6 +260,17 @@ def write_runtime_result(project_root: Path, result) -> Path:
     return path
 
 
+def record_validation(project_root: Path, *, path: str = RUNTIME_PATH, **overrides):
+    """Leave the record the family's validation runner writes when L0-L4 pass."""
+    params = {
+        "production_family": RUNTIME_FAMILY,
+        "asset_id": RUNTIME_ASSET_ID,
+        "artifact_path": f"res://{path}",
+    }
+    params.update(overrides)
+    return write_validation_record(project_root, **params)
+
+
 def build_runtime(project_root: Path, result, *, report=None):
     report = report if report is not None else make_report(
         path=RUNTIME_PATH, label=RUNTIME_ASSET_ID, asset_id=RUNTIME_ASSET_ID
@@ -272,6 +287,7 @@ def build_runtime(project_root: Path, result, *, report=None):
 def test_a_validated_background_map_becomes_a_ready_texture2d_entry(tmp_path):
     """The PNG is the Texture2D Godot imports; no .tres wraps it."""
     touch(tmp_path, RUNTIME_PATH)
+    record_validation(tmp_path)
 
     entry = build_runtime(tmp_path, make_runtime_result())
 
@@ -385,6 +401,55 @@ def test_a_drifted_finalized_name_never_reaches_ready(tmp_path):
 
 def test_a_missing_finalized_image_never_reaches_ready(tmp_path):
     with pytest.raises(FinalizeEntryDraftError, match="finalized file not found"):
+        build_runtime(tmp_path, make_runtime_result())
+
+
+def test_regenerating_the_same_stable_png_after_validation_is_refused(tmp_path):
+    """The regression this guard exists for.
+
+    The stable path is derived from `asset_id`, so a retry's finalize run
+    overwrites the exact PNG the passing result names. Every path still matches
+    and the non-writing Texture2D route happily re-binds the new file, so only
+    the recorded bytes tell the validated build from whatever landed after it.
+    """
+    touch(tmp_path, RUNTIME_PATH)
+    record_validation(tmp_path)
+    (tmp_path / RUNTIME_PATH).write_bytes(b"regenerated png")
+
+    with pytest.raises(FinalizeEntryDraftError, match="changed since it passed L0-L4"):
+        build_runtime(tmp_path, make_runtime_result())
+
+
+def test_an_unvalidated_background_map_cannot_register(tmp_path):
+    """No record means no ladder ran on these bytes in this project."""
+    touch(tmp_path, RUNTIME_PATH)
+
+    with pytest.raises(FinalizeEntryDraftError, match="no validation record"):
+        build_runtime(tmp_path, make_runtime_result())
+
+
+def test_a_record_from_another_asset_cannot_register_this_one(tmp_path):
+    touch(tmp_path, RUNTIME_PATH)
+    record_validation(tmp_path)
+    record = json.loads(
+        validation_record_path(tmp_path, RUNTIME_ASSET_ID).read_text(encoding="utf-8")
+    )
+    record["asset_id"] = "dusk"
+    validation_record_path(tmp_path, RUNTIME_ASSET_ID).write_text(
+        json.dumps(record), encoding="utf-8"
+    )
+
+    with pytest.raises(FinalizeEntryDraftError, match="is not a v1 background-map"):
+        build_runtime(tmp_path, make_runtime_result())
+
+
+def test_a_record_for_another_artifact_cannot_register_this_one(tmp_path):
+    touch(tmp_path, RUNTIME_PATH)
+    other = f"{stable_output_dir(RUNTIME_FAMILY, RUNTIME_ASSET_ID)}/{RUNTIME_ASSET_ID}_alt.png"
+    touch(tmp_path, other)
+    record_validation(tmp_path, path=other)
+
+    with pytest.raises(FinalizeEntryDraftError, match="describes another artifact"):
         build_runtime(tmp_path, make_runtime_result())
 
 

--- a/tests/tools/test_asset_registration_closure.py
+++ b/tests/tools/test_asset_registration_closure.py
@@ -32,6 +32,7 @@ from asset_assets_md_update import (  # noqa: E402
     update_assets_md,
     update_assets_md_from_bundle,
 )
+from asset_build_record import write_validation_record  # noqa: E402
 from asset_bundle_manifest import (  # noqa: E402
     AssetBundleManifestError,
     write_bundle_manifest,
@@ -822,6 +823,16 @@ def _background_result(relative: str) -> dict:
     }
 
 
+def _validate_background(project_root: Path, relative: str) -> None:
+    """Stand in for the passing L0-L4 run: record the bytes it examined."""
+    write_validation_record(
+        project_root,
+        production_family="background-map",
+        asset_id=BACKGROUND_ID,
+        artifact_path=f"res://{relative}",
+    )
+
+
 def _draft_background(project_root: Path, report_path, result_path=None):
     return build_finalize_entry_draft(
         report_path,
@@ -835,6 +846,7 @@ def _draft_background(project_root: Path, report_path, result_path=None):
 
 def test_background_map_reaches_a_worker_snapshot_from_a_validated_delivery(tmp_path):
     report_path, relative = _background_inputs(tmp_path)
+    _validate_background(tmp_path, relative)
     result_path = _write_json(
         tmp_path / "background-result.json", _background_result(relative)
     )
@@ -893,6 +905,43 @@ def test_background_map_registration_fails_closed_on_a_deleted_image(tmp_path):
     (tmp_path / relative).unlink()
 
     with pytest.raises(FinalizeEntryDraftError, match="finalized file not found"):
+        _draft_background(tmp_path, report_path, result_path)
+
+
+def test_a_regenerated_background_map_cannot_register_against_the_old_result(tmp_path):
+    """Validate, regenerate onto the same stable PNG, then try to register.
+
+    Every declared path still matches and the `single -> Texture2D` route
+    re-binds whatever file is there, so path comparison alone would hand a
+    worker bytes no ladder ever loaded.
+    """
+    report_path, relative = _background_inputs(tmp_path)
+    _validate_background(tmp_path, relative)
+    result_path = _write_json(
+        tmp_path / "background-result.json", _background_result(relative)
+    )
+    validated = (tmp_path / relative).read_bytes()
+    assets_md = _assets_md(tmp_path, [BACKGROUND_ID])
+    # A retry's finalize run overwrites in place; the path is identity-derived.
+    Image.new("RGBA", (8, 8), (9, 9, 9, 255)).save(tmp_path / relative)
+    assert (tmp_path / relative).read_bytes() != validated
+
+    with pytest.raises(FinalizeEntryDraftError, match="changed since it passed L0-L4"):
+        _draft_background(tmp_path, report_path, result_path)
+
+    assert not (tmp_path / entry_relative_path(TAG, BACKGROUND_ID)).exists()
+    assert "MISSING" in assets_md.read_text(encoding="utf-8")
+    with pytest.raises(AssetRuntimeResolverError):
+        _snapshot(tmp_path, BACKGROUND_ID)
+
+
+def test_background_map_registration_needs_a_validation_record(tmp_path):
+    report_path, relative = _background_inputs(tmp_path)
+    result_path = _write_json(
+        tmp_path / "background-result.json", _background_result(relative)
+    )
+
+    with pytest.raises(FinalizeEntryDraftError, match="no validation record"):
         _draft_background(tmp_path, report_path, result_path)
 
 
@@ -1001,6 +1050,7 @@ def test_tileset_cli_writes_the_ready_draft(tmp_path):
 
 def test_background_map_cli_writes_the_ready_draft(tmp_path):
     report_path, relative = _background_inputs(tmp_path)
+    _validate_background(tmp_path, relative)
     result_path = _write_json(
         tmp_path / "background-result.json", _background_result(relative)
     )

--- a/tests/tools/test_asset_registration_closure.py
+++ b/tests/tools/test_asset_registration_closure.py
@@ -40,6 +40,10 @@ from asset_curation_entry_draft import (  # noqa: E402
     CurationEntryDraftError,
     write_fx_static_entry_draft,
 )
+from asset_finalize_entry_draft import (  # noqa: E402
+    FinalizeEntryDraftError,
+    build_finalize_entry_draft,
+)
 from asset_generation_index import check_index, update_index  # noqa: E402
 from asset_runtime_resolver import (  # noqa: E402
     AssetRuntimeResolverError,
@@ -767,6 +771,154 @@ def test_static_fx_promotion_rejects_a_result_about_another_image(tmp_path):
 
 
 # --------------------------------------------------------------------------
+# background-map -> Texture2D
+# --------------------------------------------------------------------------
+
+BACKGROUND_ID = "sky_dome"
+
+
+def _background_inputs(project_root: Path, *, name: str = BACKGROUND_ID):
+    relative = f"assets/generated/background-map/{BACKGROUND_ID}/{name}.png"
+    _touch(project_root, f"res://{relative}")
+    report = {
+        "ok": True,
+        "source": f".godotmaker/asset-generation/sources/{BACKGROUND_ID}_source.png",
+        "path": relative,
+        "width": 1920,
+        "height": 1080,
+        "required_aspect": "16:9",
+        "aspect_delta": 0.0,
+        "aspect_tolerance": 0.03,
+        "label": BACKGROUND_ID,
+        "asset_id": BACKGROUND_ID,
+    }
+    return (
+        _write_json(
+            project_root
+            / f".godotmaker/asset-generation/reports/{BACKGROUND_ID}_finalize.json",
+            report,
+        ),
+        relative,
+    )
+
+
+def _background_result(relative: str) -> dict:
+    return {
+        "asset_type": "background-map",
+        "outputs": [
+            {
+                "role": "runtime",
+                "name": BACKGROUND_ID,
+                "path": f"res://{relative}",
+                "godot_type": "Texture2D",
+            }
+        ],
+        "sources": [{"path": f"res://{relative}", "layout": "single"}],
+        "previews": [],
+        "validation": {
+            "passed": True,
+            "levels": {level: True for level in LEVELS_PASSED},
+        },
+    }
+
+
+def _draft_background(project_root: Path, report_path, result_path=None):
+    return build_finalize_entry_draft(
+        report_path,
+        asset_id=BACKGROUND_ID,
+        tag=TAG,
+        production_family="background-map",
+        project_root=project_root,
+        result_path=result_path,
+    )
+
+
+def test_background_map_reaches_a_worker_snapshot_from_a_validated_delivery(tmp_path):
+    report_path, relative = _background_inputs(tmp_path)
+    result_path = _write_json(
+        tmp_path / "background-result.json", _background_result(relative)
+    )
+    assets_md = _assets_md(tmp_path, [BACKGROUND_ID])
+
+    entry = _draft_background(tmp_path, report_path, result_path)
+    _register(tmp_path, [entry])
+    update_assets_md(assets_md, [tmp_path / entry_relative_path(TAG, BACKGROUND_ID)])
+
+    # The PNG is the Texture2D Godot imports, so source and artifact are one
+    # file and no .tres wraps it.
+    assert _snapshot(tmp_path, BACKGROUND_ID) == {
+        "asset_id": BACKGROUND_ID,
+        "production_family": "background-map",
+        "source_layout": {"type": "single", "path": f"res://{relative}"},
+        "godot_artifact": {"type": "Texture2D", "path": f"res://{relative}"},
+    }
+    assert not list((tmp_path / relative).parent.glob("*.tres"))
+
+
+def test_a_background_map_without_a_result_stays_out_of_the_worker_handoff(tmp_path):
+    """The gap this closed: a validated background stuck at source_ready."""
+    report_path, _ = _background_inputs(tmp_path)
+    assets_md = _assets_md(tmp_path, [BACKGROUND_ID])
+
+    entry = _draft_background(tmp_path, report_path)
+    assert entry["processing_status"] == "source_ready"
+    _register(tmp_path, [entry])
+
+    with pytest.raises(AssetsMdUpdateError, match="only a ready runtime entry"):
+        update_assets_md(
+            assets_md, [tmp_path / entry_relative_path(TAG, BACKGROUND_ID)]
+        )
+    with pytest.raises(AssetRuntimeResolverError):
+        _snapshot(tmp_path, BACKGROUND_ID)
+
+
+def test_background_map_without_a_passing_ladder_never_registers(tmp_path):
+    report_path, relative = _background_inputs(tmp_path)
+    result = _background_result(relative)
+    result["validation"] = {
+        "passed": False,
+        "levels": {"L0": True, "L1": True, "L2": True, "L3": False, "L4": False},
+    }
+    result_path = _write_json(tmp_path / "background-result.json", result)
+
+    with pytest.raises(FinalizeEntryDraftError, match="passed L0-L4"):
+        _draft_background(tmp_path, report_path, result_path)
+
+
+def test_background_map_registration_fails_closed_on_a_deleted_image(tmp_path):
+    report_path, relative = _background_inputs(tmp_path)
+    result_path = _write_json(
+        tmp_path / "background-result.json", _background_result(relative)
+    )
+    (tmp_path / relative).unlink()
+
+    with pytest.raises(FinalizeEntryDraftError, match="finalized file not found"):
+        _draft_background(tmp_path, report_path, result_path)
+
+
+def test_background_map_rejects_a_result_about_another_asset(tmp_path):
+    report_path, relative = _background_inputs(tmp_path)
+    result = _background_result(relative)
+    result["outputs"][0]["path"] = (
+        "res://assets/generated/background-map/dusk_dome/dusk_dome.png"
+    )
+    result_path = _write_json(tmp_path / "background-result.json", result)
+
+    with pytest.raises(FinalizeEntryDraftError):
+        _draft_background(tmp_path, report_path, result_path)
+
+
+def test_background_map_rejects_a_drifted_finalized_path(tmp_path):
+    report_path, relative = _background_inputs(tmp_path, name=f"{BACKGROUND_ID}_final")
+    result_path = _write_json(
+        tmp_path / "background-result.json", _background_result(relative)
+    )
+
+    with pytest.raises(FinalizeEntryDraftError, match="must finalize into its stable"):
+        _draft_background(tmp_path, report_path, result_path)
+
+
+# --------------------------------------------------------------------------
 # CLI wiring: the documented command is what /gm-asset actually runs.
 # --------------------------------------------------------------------------
 
@@ -844,6 +996,30 @@ def test_tileset_cli_writes_the_ready_draft(tmp_path):
     assert completed.returncode == 0, completed.stdout + completed.stderr
     entry = json.loads(out.read_text(encoding="utf-8"))
     assert entry["godot_artifact"]["type"] == "TileSet"
+    assert entry["processing_status"] == "ready"
+
+
+def test_background_map_cli_writes_the_ready_draft(tmp_path):
+    report_path, relative = _background_inputs(tmp_path)
+    result_path = _write_json(
+        tmp_path / "background-result.json", _background_result(relative)
+    )
+    out = tmp_path / ".godotmaker/asset-generation/work/entries/sky_dome.json"
+
+    completed = _run(
+        "asset_finalize_entry_draft.py",
+        "--finalize-report", str(report_path),
+        "--result", str(result_path),
+        "--asset-id", BACKGROUND_ID,
+        "--tag", TAG,
+        "--production-family", "background-map",
+        "--project-root", str(tmp_path),
+        "--out", str(out),
+    )
+
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    entry = json.loads(out.read_text(encoding="utf-8"))
+    assert entry["godot_artifact"] == {"type": "Texture2D", "path": f"res://{relative}"}
     assert entry["processing_status"] == "ready"
 
 

--- a/tests/tools/test_published_layout_asset_tools.py
+++ b/tests/tools/test_published_layout_asset_tools.py
@@ -38,6 +38,7 @@ ASSET_TOOLS = (
     "asset_bundle_manifest",
     "asset_compact_prop_pack_entry_draft",
     "asset_curation_entry_draft",
+    "asset_finalize_entry_draft",
     "asset_generation_index",
     "asset_runtime_resolver",
     "asset_scene_prop_set_entry_draft",

--- a/tools/asset_build_record.py
+++ b/tools/asset_build_record.py
@@ -24,6 +24,23 @@ refreshes the record, after which a stale result promotes a never-validated
 build. Closing that needs a build id in the record that the Skill result echoes
 back; until the result contract carries one, treat this as drift detection
 between compile and promote, not as proof of validation.
+
+The validation record
+---------------------
+
+A *validation* record closes exactly that remaining gap for a family whose
+Skill validates the artifact it will register. It is written by the family's
+standalone validation runner, only after a fully passing ladder, and it
+fingerprints the artifact the ladder actually examined. Registration recomputes
+that fingerprint from disk and requires an exact match, so an asset regenerated
+after validation cannot be registered against the older passing result: the
+bytes on disk no longer hash to the ones L0-L4 saw.
+
+The result contract still carries no build identity, so this does not tie a
+*particular* result document to those bytes. It does prove the stronger thing a
+worker depends on — the bytes being registered passed L0-L4 in this project.
+Like every record here it is an ordinary project file, so it detects drift and
+mistakes, not a producer determined to forge one.
 """
 from __future__ import annotations
 
@@ -33,6 +50,7 @@ from pathlib import Path
 from typing import Any
 
 BUILD_RECORD_VERSION = 1
+VALIDATION_RECORD_VERSION = 1
 
 RES_PREFIX = "res://"
 
@@ -89,6 +107,95 @@ def read_recorded_build(
             "entry and revalidate it before promoting"
         )
     return recorded
+
+
+def validation_record_path(project_root: Path | str, asset_id: str) -> Path:
+    """Return the fixed validation-record path for one asset.
+
+    It sits with the family's other provenance under generation scratch, never
+    beside the artifact: a ``single -> Texture2D`` asset has no support file,
+    and nothing registered may point into ``.godotmaker/``.
+    """
+    return (
+        Path(project_root)
+        / ".godotmaker"
+        / "asset-generation"
+        / "reports"
+        / f"{asset_id}_validation.json"
+    )
+
+
+def write_validation_record(
+    project_root: Path | str,
+    *,
+    production_family: str,
+    asset_id: str,
+    artifact_path: str,
+) -> dict[str, Any]:
+    """Record the artifact bytes one fully passing L0-L4 run examined."""
+    record = {
+        "version": VALIDATION_RECORD_VERSION,
+        "production_family": production_family,
+        "asset_id": asset_id,
+        "artifact": {
+            "path": artifact_path,
+            "sha256": digest(
+                resolve_res(project_root, artifact_path), "validated artifact"
+            ),
+        },
+    }
+    path = validation_record_path(project_root, asset_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(record, indent=2) + "\n", encoding="utf-8")
+    return record
+
+
+def read_validation_record(
+    project_root: Path | str, *, production_family: str, asset_id: str
+) -> dict[str, Any]:
+    """Load the record this asset's last passing validation run wrote."""
+    path = validation_record_path(project_root, asset_id)
+    if not path.is_file():
+        raise BuildRecordError(
+            "no validation record to register against: run this family's "
+            "standalone validation on the asset and keep its record "
+            f"(missing {path})"
+        )
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise BuildRecordError(f"validation record is not valid JSON: {path}") from exc
+    if (
+        not isinstance(record, dict)
+        or record.get("version") != VALIDATION_RECORD_VERSION
+        or record.get("production_family") != production_family
+        or record.get("asset_id") != asset_id
+    ):
+        raise BuildRecordError(
+            f"{path} is not a v1 {production_family} validation record for "
+            f"{asset_id}; rerun standalone validation before registering"
+        )
+    return record
+
+
+def assert_validated_artifact(
+    record: dict[str, Any], *, project_root: Path | str, artifact_path: str
+) -> None:
+    """Fail closed unless the artifact on disk is the one that passed L0-L4."""
+    artifact = record.get("artifact")
+    if not isinstance(artifact, dict) or artifact.get("path") != artifact_path:
+        raise BuildRecordError(
+            f"the validation record describes another artifact than {artifact_path}; "
+            "rerun standalone validation before registering"
+        )
+    if digest(resolve_res(project_root, artifact_path), "validated artifact") != artifact.get(
+        "sha256"
+    ):
+        raise BuildRecordError(
+            f"{artifact_path} changed since it passed L0-L4; a regeneration "
+            "overwrites the same stable path, so rerun standalone validation "
+            "and register the build it examined"
+        )
 
 
 def assert_same_build(

--- a/tools/asset_finalize_entry_draft.py
+++ b/tools/asset_finalize_entry_draft.py
@@ -32,9 +32,14 @@ PNG *is* the ``Texture2D`` Godot imports, so the finalized image and the
 artifact are the same file and no ``.tres`` wraps it. Supplying that Skill's
 passing result with ``--result`` binds it to the image this run finalized, runs
 the declared ``single -> Texture2D`` route, and writes the ``ready`` entry from
-the compiler's own artifact. The Skill holds a passing L0-L4 result by the time
-it drafts, so there is no ``compiled`` stage to promote from and no window in
-which the registered bytes could drift from the validated ones.
+the compiler's own artifact.
+
+A result names paths, never bytes, and the stable path is derived from
+``asset_id`` — so a regeneration lands on the exact PNG an older passing result
+names, and re-running the non-writing ``Texture2D`` route over whatever now sits
+there would happily register a build no ladder ever saw. Registration therefore
+recomputes the fingerprint the family's validation runner recorded for the PNG
+it examined and requires an exact match; see ``asset_build_record``.
 """
 from __future__ import annotations
 
@@ -44,6 +49,11 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from asset_build_record import (
+    BuildRecordError,
+    assert_validated_artifact,
+    read_validation_record,
+)
 from asset_runtime_path import ensure_asset_runtime_on_path
 from asset_skill_contract_check import AssetContractError, check_result
 from asset_stable_entry import (
@@ -229,6 +239,21 @@ def _compiled_artifact(
             f"before a ready entry: {source_path}"
         )
     _check_compiled_result(result_path, source_path=source_path)
+
+    # The result proved a PNG at this path passed L0-L4; only the record proves
+    # the PNG at this path is still that one. Without this, finalizing again
+    # after validation would silently register never-validated bytes, since the
+    # non-writing Texture2D route below only re-binds whatever is on disk now.
+    try:
+        assert_validated_artifact(
+            read_validation_record(
+                project_root, production_family=COMPILED_FAMILY, asset_id=asset_id
+            ),
+            project_root=project_root,
+            artifact_path=source_path,
+        )
+    except BuildRecordError as exc:
+        raise FinalizeEntryDraftError(str(exc)) from exc
 
     # The artifact is the compiler's, not this builder's: the registry is what
     # decides a PNG really is the Texture2D Godot imports for a `single` layout.

--- a/tools/asset_finalize_entry_draft.py
+++ b/tools/asset_finalize_entry_draft.py
@@ -26,6 +26,15 @@ output directory closes that.
 The layout is derived from the production family rather than passed in: the
 schema already binds reference families and reference layouts to each other in
 both directions, so a flag could only introduce a contradiction.
+
+``background-map`` is the one family here that compiles a native artifact. Its
+PNG *is* the ``Texture2D`` Godot imports, so the finalized image and the
+artifact are the same file and no ``.tres`` wraps it. Supplying that Skill's
+passing result with ``--result`` binds it to the image this run finalized, runs
+the declared ``single -> Texture2D`` route, and writes the ``ready`` entry from
+the compiler's own artifact. The Skill holds a passing L0-L4 result by the time
+it drafts, so there is no ``compiled`` stage to promote from and no window in
+which the registered bytes could drift from the validated ones.
 """
 from __future__ import annotations
 
@@ -35,6 +44,8 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from asset_runtime_path import ensure_asset_runtime_on_path
+from asset_skill_contract_check import AssetContractError, check_result
 from asset_stable_entry import (
     GENERATED_ROOT,
     PRODUCTION_FAMILIES,
@@ -42,11 +53,25 @@ from asset_stable_entry import (
     SCHEMA_VERSION,
     StableEntryError,
     check_output_path,
+    stable_output_dir,
     validate_entry,
 )
 
+# Published projects keep this runtime at .godotmaker/asset-runtime, not under
+# skills/assets/. Resolving it by hand here breaks every published run.
+SHARED_ROOT = ensure_asset_runtime_on_path()
+from asset_compiler import CompileRequest, CompilerError, build_default_registry  # noqa: E402
+
 REFERENCES_ROOT = "references"
 DRAFT_STATUS = "source_ready"
+READY_STATUS = "ready"
+
+# The one finalize-driven family with a declared native compiler route and its
+# own L0-L4 runner. Every other family on this builder stops at source_ready.
+COMPILED_FAMILY = "background-map"
+COMPILED_LAYOUT = "single"
+COMPILED_ARTIFACT_TYPE = "Texture2D"
+LEVELS = ("L0", "L1", "L2", "L3", "L4")
 
 
 class FinalizeEntryDraftError(Exception):
@@ -126,6 +151,109 @@ def _runtime_res_path(relative: str, *, production_family: str, asset_id: str) -
         raise FinalizeEntryDraftError(str(exc)) from exc
 
 
+def _check_compiled_result(result_path: Path, *, source_path: str) -> None:
+    """Bind a passing background-map result to the image this run finalized."""
+    result = _load_object(result_path, "result")
+    try:
+        check_result(result)
+    except AssetContractError as exc:
+        raise FinalizeEntryDraftError(str(exc)) from exc
+    if result["asset_type"] != COMPILED_FAMILY:
+        raise FinalizeEntryDraftError(
+            f"--result must be a {COMPILED_FAMILY} result, not {result['asset_type']}"
+        )
+
+    # One scenic image is one runtime resource. A second output would reach a
+    # worker as a rival texture for the same asset.
+    runtime = [item for item in result["outputs"] if item.get("role") == "runtime"]
+    if len(result["outputs"]) != 1 or len(runtime) != 1:
+        raise FinalizeEntryDraftError(
+            f"{COMPILED_FAMILY} result must expose exactly one runtime output"
+        )
+    if (
+        runtime[0].get("path") != source_path
+        or runtime[0].get("godot_type") != COMPILED_ARTIFACT_TYPE
+    ):
+        raise FinalizeEntryDraftError(
+            "result runtime output must be the finalized stable "
+            f"{COMPILED_ARTIFACT_TYPE} path"
+        )
+    # The runtime output alone proves some image was validated, never which file
+    # carried the `single` layout, so a result about another asset's image would
+    # otherwise register this one.
+    if result["sources"] != [{"path": source_path, "layout": COMPILED_LAYOUT}]:
+        raise FinalizeEntryDraftError(
+            "result single source must be the finalized stable image"
+        )
+
+    # L5 is a legal level of the shared contract; require L0-L4 to have passed
+    # rather than demanding the level map contain nothing else.
+    validation = result["validation"]
+    levels = validation.get("levels")
+    if not isinstance(levels, dict):
+        raise FinalizeEntryDraftError(
+            "result must have passed L0-L4 before a ready entry is drafted; "
+            "no explicit validation levels were reported"
+        )
+    unpassed = [level for level in LEVELS if levels.get(level) is not True]
+    if unpassed:
+        raise FinalizeEntryDraftError(
+            "result must have passed L0-L4 before a ready entry is drafted; "
+            f"not passing: {', '.join(unpassed)}"
+        )
+    # A result may pass every runtime level and still declare itself failed —
+    # an L5 finding, or a note the Skill stopped on. Registering it anyway would
+    # promote a delivery its own producer refused to stand behind.
+    if validation.get("passed") is not True:
+        raise FinalizeEntryDraftError(
+            "result must have passed L0-L4 before a ready entry is drafted; "
+            "validation.passed is not true"
+        )
+
+
+def _compiled_artifact(
+    source_ready: dict[str, Any], *, result_path: Path, project_root: Path
+) -> dict[str, Any]:
+    """Return the ready entry for a validated background-map delivery."""
+    asset_id = source_ready["asset_id"]
+    if source_ready["production_family"] != COMPILED_FAMILY:
+        raise FinalizeEntryDraftError(
+            f"--result is only supported for {COMPILED_FAMILY}; "
+            f"{source_ready['production_family']} compiles no Godot artifact here"
+        )
+    source_path = source_ready["source_layout"]["path"]
+    expected = f"res://{stable_output_dir(COMPILED_FAMILY, asset_id)}/{asset_id}.png"
+    if source_path != expected:
+        raise FinalizeEntryDraftError(
+            f"{COMPILED_FAMILY} must finalize into its stable {asset_id}.png "
+            f"before a ready entry: {source_path}"
+        )
+    _check_compiled_result(result_path, source_path=source_path)
+
+    # The artifact is the compiler's, not this builder's: the registry is what
+    # decides a PNG really is the Texture2D Godot imports for a `single` layout.
+    try:
+        compiled = build_default_registry().compile(
+            CompileRequest(
+                COMPILED_FAMILY,
+                asset_id,
+                COMPILED_LAYOUT,
+                source_path,
+                COMPILED_ARTIFACT_TYPE,
+                source_path,
+                Path(project_root),
+            )
+        )
+    except (CompilerError, StableEntryError) as exc:
+        raise FinalizeEntryDraftError(str(exc)) from exc
+
+    return {
+        **source_ready,
+        "godot_artifact": compiled.godot_artifact.to_dict(),
+        "processing_status": READY_STATUS,
+    }
+
+
 def build_finalize_entry_draft(
     finalize_report: Path,
     *,
@@ -133,8 +261,14 @@ def build_finalize_entry_draft(
     tag: str,
     production_family: str,
     project_root: Path,
+    result_path: Path | None = None,
 ) -> dict[str, Any]:
-    """Validate a finalize report and return the draft stable entry."""
+    """Validate a finalize report and return the draft stable entry.
+
+    Without ``result_path`` the entry stops at ``source_ready``. Supplying the
+    ``background-map`` Skill's passing result compiles its native
+    ``single -> Texture2D`` route and returns the ``ready`` entry instead.
+    """
     if not asset_id.strip():
         raise FinalizeEntryDraftError("--asset-id must be a non-empty string")
     if not tag.strip():
@@ -198,6 +332,10 @@ def build_finalize_entry_draft(
         "source_layout": {"type": layout_type, "path": res_path},
         "processing_status": DRAFT_STATUS,
     }
+    if result_path is not None:
+        entry = _compiled_artifact(
+            entry, result_path=result_path, project_root=project_root
+        )
     try:
         validate_entry(entry, project_root=Path(project_root), check_files=True)
     except StableEntryError as exc:
@@ -213,6 +351,7 @@ def write_finalize_entry_draft(
     production_family: str,
     project_root: Path,
     out: Path,
+    result_path: Path | None = None,
 ) -> dict[str, Any]:
     entry = build_finalize_entry_draft(
         finalize_report,
@@ -220,6 +359,7 @@ def write_finalize_entry_draft(
         tag=tag,
         production_family=production_family,
         project_root=project_root,
+        result_path=result_path,
     )
     out = Path(out)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -231,6 +371,7 @@ def write_finalize_entry_draft(
         "tag": tag,
         "source_layout": entry["source_layout"]["type"],
         "path": entry["source_layout"]["path"],
+        "processing_status": entry["processing_status"],
     }
 
 
@@ -243,6 +384,14 @@ def _main() -> int:
         required=True,
         type=Path,
         help="JSON report printed by asset_image_finalize.py",
+    )
+    parser.add_argument(
+        "--result",
+        type=Path,
+        help=(
+            "Passing background-map Skill result; compiles its single -> "
+            "Texture2D route and writes a ready entry instead of source_ready"
+        ),
     )
     parser.add_argument("--asset-id", required=True)
     parser.add_argument("--tag", required=True)
@@ -259,6 +408,7 @@ def _main() -> int:
             production_family=args.production_family,
             project_root=args.project_root,
             out=args.out,
+            result_path=args.result,
         )
     except FinalizeEntryDraftError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}))


### PR DESCRIPTION
## Summary

Fix the `background-map` registration path so an L0-L4-validated PNG can produce a ready stable entry, root index pointer, ASSETS.md update, and runtime resolver handoff.

## Motivation

Generated background maps could pass validation yet remain only `source_ready`, leaving them unavailable to runtime consumers. Closes #154.

## Changes

- [x] Add the `background-map` result-to-entry path for `single -> Texture2D` assets.
- [x] Bind ready registration to a persisted validation record and PNG SHA-256, rejecting stale, missing, or mismatched records.
- [x] Add end-to-end, negative, and published-layout regression coverage; update affected documentation and release notes.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant).
- [x] Gitleaks passes or no secret-bearing files were touched.
- [ ] Manual testing completed, if applicable.

`python -m pytest tests/` passed locally (2316 passed, 7 skipped). CI passes on Ubuntu, Windows, and macOS; lint, documentation checks, and secret scanning also pass. Manual headless-Godot L3/L4 execution was not run in this environment.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [x] Result attached or summarized below

No migration is included or required for this change.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
