### PR TITLE
fix(asset): unify the asset-producer terminal outcome protocol

### DIFF
--- a/agents/asset-producer.md
+++ b/agents/asset-producer.md
@@ -157,12 +157,15 @@ When a prompt depends on an existing image:
    manager all read the terminal status from it.
 3. Every listed field is required. `outputs` accepts only the five categories
    above, and `validation.levels` only `L0`-`L4`.
-4. `status` `DONE` requires `validation.passed` true and an empty `blockers`.
-5. `status` `PARTIAL` or `FAILED` requires at least one blocker, each naming
+4. `report_type` is always `asset-producer` — the role you are running as.
+   Declaring another role is rejected; you cannot hand back another role's
+   outcome.
+5. `status` `DONE` requires `validation.passed` true and an empty `blockers`.
+6. `status` `PARTIAL` or `FAILED` requires at least one blocker, each naming
    what stopped the unit concretely enough for the manager to act on it.
-6. The block fails closed. A missing or invalid field is rejected with the
+7. The block fails closed. A missing or invalid field is rejected with the
    field name, and the attempt does not count as a terminal result — fix the
    named field and re-emit the whole report.
-7. Being released after repeated rejections is not acceptance. Without a valid
+8. Being released after repeated rejections is not acceptance. Without a valid
    block the unit has no terminal status and its outputs are not registered, so
    say so plainly instead of presenting the run as finished.

--- a/agents/asset-producer.md
+++ b/agents/asset-producer.md
@@ -163,3 +163,6 @@ When a prompt depends on an existing image:
 6. The block fails closed. A missing or invalid field is rejected with the
    field name, and the attempt does not count as a terminal result — fix the
    named field and re-emit the whole report.
+7. Being released after repeated rejections is not acceptance. Without a valid
+   block the unit has no terminal status and its outputs are not registered, so
+   say so plainly instead of presenting the run as finished.

--- a/agents/asset-producer.md
+++ b/agents/asset-producer.md
@@ -35,10 +35,9 @@ You produce one assigned visual asset production unit for `/gm-asset`.
     source or final asset path.
 19. When the configured provider fails after its allowed retries, write `FAILED` or
     `PARTIAL` and leave affected stable entry drafts unwritten.
-20. End every report with exactly one machine outcome block. It carries the
-    terminal status; the markdown sections are the human-readable summary.
-21. Never report `DONE` with a blocker or with failed validation. A run that hit
-    a blocker is `PARTIAL` or `FAILED`, and every blocker stays in the block.
+20. End every report with exactly one machine outcome block.
+21. Report `DONE` only with passing validation and no blockers. Otherwise report
+    `PARTIAL` or `FAILED` and list every blocker.
 
 ## Execution Order
 
@@ -153,19 +152,14 @@ When a prompt depends on an existing image:
 ## Machine Outcome Rules
 
 1. Emit exactly one machine outcome block, as the last thing in the report.
-2. It is a fenced JSON block, not prose. The hook, the metrics log, and the
-   manager all read the terminal status from it.
-3. Every listed field is required. `outputs` accepts only the five categories
-   above, and `validation.levels` only `L0`-`L4`.
-4. `report_type` is always `asset-producer` — the role you are running as.
-   Declaring another role is rejected; you cannot hand back another role's
-   outcome.
-5. `status` `DONE` requires `validation.passed` true and an empty `blockers`.
-6. `status` `PARTIAL` or `FAILED` requires at least one blocker, each naming
-   what stopped the unit concretely enough for the manager to act on it.
-7. The block fails closed. A missing or invalid field is rejected with the
-   field name, and the attempt does not count as a terminal result — fix the
-   named field and re-emit the whole report.
-8. Being released after repeated rejections is not acceptance. Without a valid
-   block the unit has no terminal status and its outputs are not registered, so
-   say so plainly instead of presenting the run as finished.
+2. Write it as a fenced JSON block, not prose.
+3. Fill every listed field. Use only the five `outputs` categories above, and
+   only `L0`-`L4` in `validation.levels`.
+4. Set `report_type` to `asset-producer`.
+5. Use `status` `DONE` only with `validation.passed` true and an empty
+   `blockers`.
+6. For `status` `PARTIAL` or `FAILED`, write at least one blocker naming what
+   stopped the unit.
+7. When a field is rejected, fix that field and re-emit the whole report.
+8. When you cannot produce a valid block, state that the unit is unfinished.
+   Do not present the run as complete.

--- a/agents/asset-producer.md
+++ b/agents/asset-producer.md
@@ -35,6 +35,10 @@ You produce one assigned visual asset production unit for `/gm-asset`.
     source or final asset path.
 19. When the configured provider fails after its allowed retries, write `FAILED` or
     `PARTIAL` and leave affected stable entry drafts unwritten.
+20. End every report with exactly one machine outcome block. It carries the
+    terminal status; the markdown sections are the human-readable summary.
+21. Never report `DONE` with a blocker or with failed validation. A run that hit
+    a blocker is `PARTIAL` or `FAILED`, and every blocker stays in the block.
 
 ## Execution Order
 
@@ -88,7 +92,7 @@ When a prompt depends on an existing image:
 
 ## Report Format
 
-```
+~~~
 ## Asset Producer Report: {Unit ID}
 
 ### Status: DONE | PARTIAL | FAILED
@@ -121,4 +125,41 @@ When a prompt depends on an existing image:
 
 ### Asset Skill Result
 {Validated generic result summary for a first-class Skill, or none.}
+
+### Machine Outcome
+```json
+{
+  "gm_outcome_version": 1,
+  "report_type": "asset-producer",
+  "status": "DONE | PARTIAL | FAILED",
+  "unit_id": "{unit id}",
+  "outputs": {
+    "sources": ["{paths}"],
+    "runtime": ["{paths}"],
+    "prompts": ["{paths}"],
+    "reports": ["{paths}"],
+    "entry_drafts": ["{paths}"]
+  },
+  "validation": {
+    "passed": true,
+    "levels": {"L0": true, "L1": true, "L2": true, "L3": true, "L4": true},
+    "notes": "{short notes}"
+  },
+  "blockers": []
+}
 ```
+~~~
+
+## Machine Outcome Rules
+
+1. Emit exactly one machine outcome block, as the last thing in the report.
+2. It is a fenced JSON block, not prose. The hook, the metrics log, and the
+   manager all read the terminal status from it.
+3. Every listed field is required. `outputs` accepts only the five categories
+   above, and `validation.levels` only `L0`-`L4`.
+4. `status` `DONE` requires `validation.passed` true and an empty `blockers`.
+5. `status` `PARTIAL` or `FAILED` requires at least one blocker, each naming
+   what stopped the unit concretely enough for the manager to act on it.
+6. The block fails closed. A missing or invalid field is rejected with the
+   field name, and the attempt does not count as a terminal result — fix the
+   named field and re-emit the whole report.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -250,7 +250,7 @@ mangled heading can no longer produce a `report_type: unknown` /
 | Field | Rule |
 |---|---|
 | `gm_outcome_version` | `1` |
-| `report_type` | A known role (`asset-producer`) |
+| `report_type` | Must equal the role the subagent was dispatched as |
 | `status` | `DONE`, `PARTIAL`, or `FAILED` |
 | `unit_id` | Non-empty string |
 | `outputs` | Object of path arrays, keyed only by `sources`, `runtime`, `prompts`, `reports`, `entry_drafts` |
@@ -261,6 +261,14 @@ mangled heading can no longer produce a `report_type: unknown` /
 require at least one blocker. A missing or invalid field is rejected with the
 field name, and that stop is logged as a `rejected_attempt` — or `unverified`
 if force-allow eventually released it. Neither writes an outcome event.
+
+**Role binding:** the role a subagent was dispatched as (payload `agent_type`,
+falling back to its `subagent_start` event) outranks anything the report claims
+about itself, and a block declaring a different `report_type` fails closed. A
+report cannot promote or demote its own role, so a record can never carry one
+role's `role` with another role's outcome. `log_subagent.classify_stop` re-checks
+the same equality, which covers the paths where the hook validated nothing
+(force-allow, or no active pipeline role).
 
 **Per-role required sections:**
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -176,10 +176,22 @@ Role detection order:
    4. `verifier:` / `verify:` → verifier
    5. `reviewer:` / `review:` → reviewer
 
-**handle_stop:** invoked from `on_subagent_stop.py`. Extracts report type,
-status, files changed from the assistant message. Looks up role from the
-matching start event. Records `SUBAGENT_STOP` metric plus outcome-specific
-events: `WORKER_DONE`, `VERIFIER_PASS`, etc.
+**handle_stop:** invoked from `on_subagent_stop.py`. Reads report type and
+status through `metrics.outcome.normalize_report` — the same entry point the
+report hook uses. Looks up role from the matching start event. Records
+`SUBAGENT_STOP` metric plus outcome-specific events: `WORKER_DONE`,
+`VERIFIER_PASS`, `ASSET_PRODUCER_PARTIAL`, etc.
+
+Every `SUBAGENT_STOP` carries `outcome_kind`:
+
+| `outcome_kind` | Meaning |
+|---|---|
+| `terminal` | The run's result. Writes the one outcome-specific event. |
+| `rejected_attempt` | The report hook rejected this stop. Writes no outcome event. |
+
+A rejected attempt never claims the single outcome event, so a format-only
+rejection can neither read as a producer failure nor pre-empt the retry's real
+status.
 
 ### on_subagent_stop.py
 
@@ -192,8 +204,15 @@ Claude-style subagent lifecycle hooks.
 Single dispatcher for the `SubagentStop` event. Reads stdin once and runs
 serially:
 
-1. `log_subagent.handle_stop(data)` — record metrics, save traces (never blocks)
-2. `check_worker_report.main_with_data(data)` — validate report (may block)
+1. `check_worker_report.evaluate(data)` — decide the verdict (no side effects)
+2. `log_subagent.handle_stop(data, verdict=…)` — record metrics, labelled by
+   that verdict (never blocks)
+3. `check_worker_report.apply_verdict(verdict)` — emit the decision (may block)
+
+**Why validate first:** the verdict decides whether the stop is a terminal
+record or a rejected attempt. Recording before validating wrote the rejected
+attempt as the run's result, and the duplicate-outcome guard then discarded the
+retry's real status.
 
 **Why a dispatcher:** Claude Code runs multiple `SubagentStop` hooks in
 parallel by default. Both handlers touch `metrics_current.jsonl` —
@@ -211,9 +230,33 @@ pipeline role is active. With no `.godotmaker/current_role`, ordinary
 subagent conversations are allowed and this hook does not block.
 
 **Format detection flow:**
-1. Detect `report_type` from message content (layered: exact marker → regex → fallback)
-2. If `report_type` detected → check required sections for that type
-3. If `report_type` is None but role is known (from start event) → block and demand a formatted report
+1. Resolve `report_type` and `status` through `metrics.outcome.normalize_report`
+   — the machine outcome block first, then the markdown layers (exact marker →
+   regex → fallback)
+2. If the role must carry a machine outcome block → validate it, fail closed
+3. If `report_type` detected → check required sections for that type
+4. If `report_type` is None but role is known (from start event) → block and demand a formatted report
+
+**Machine outcome block:** an `asset-producer` report must end with exactly one
+fenced JSON object carrying `gm_outcome_version`. It is the status protocol —
+the markdown headings are the human-readable summary. The hook, the metrics
+log, and the `/gm-asset` manager all read it through the same parser, so a
+mangled heading can no longer produce a `report_type: unknown` /
+`status: UNKNOWN` record beside a status the manager read correctly.
+
+| Field | Rule |
+|---|---|
+| `gm_outcome_version` | `1` |
+| `report_type` | A known role (`asset-producer`) |
+| `status` | `DONE`, `PARTIAL`, or `FAILED` |
+| `unit_id` | Non-empty string |
+| `outputs` | Object of path arrays, keyed only by `sources`, `runtime`, `prompts`, `reports`, `entry_drafts` |
+| `validation` | `{passed: bool, levels?: {L0–L4: bool}, notes?: string}` |
+| `blockers` | Array of strings; empty only when `status` is `DONE` |
+
+`DONE` additionally requires `validation.passed`; `PARTIAL` and `FAILED`
+require at least one blocker. A missing or invalid field is rejected with the
+field name, and that stop is logged as a `rejected_attempt`.
 
 **Per-role required sections:**
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -186,12 +186,15 @@ Every `SUBAGENT_STOP` carries `outcome_kind`:
 
 | `outcome_kind` | Meaning |
 |---|---|
-| `terminal` | The run's result. Writes the one outcome-specific event. |
-| `rejected_attempt` | The report hook rejected this stop. Writes no outcome event. |
+| `terminal` | The report passed validation. Writes the one outcome-specific event. |
+| `rejected_attempt` | The report hook blocked this stop. Writes no outcome event. |
+| `unverified` | Released without passing validation. Writes no outcome event. |
 
-A rejected attempt never claims the single outcome event, so a format-only
-rejection can neither read as a producer failure nor pre-empt the retry's real
-status.
+Only a `terminal` stop writes an outcome-specific event, so a report that never
+passed validation can neither read as a result nor pre-empt the retry's real
+status. `unverified` covers the two ways an agent is released without its
+report being accepted: the anti-deadloop force-allow below, and a role that
+must carry a machine outcome block reaching this point without a valid one.
 
 ### on_subagent_stop.py
 
@@ -256,7 +259,8 @@ mangled heading can no longer produce a `report_type: unknown` /
 
 `DONE` additionally requires `validation.passed`; `PARTIAL` and `FAILED`
 require at least one blocker. A missing or invalid field is rejected with the
-field name, and that stop is logged as a `rejected_attempt`.
+field name, and that stop is logged as a `rejected_attempt` — or `unverified`
+if force-allow eventually released it. Neither writes an outcome event.
 
 **Per-role required sections:**
 
@@ -281,6 +285,12 @@ have ≥50 characters of content. Prevents empty/trivial reviews.
 
 **Anti-deadloop:** `BLOCK_LIMIT = 2` per `agent_id` — after 2 blocks for the
 same subagent, force-allow with a warning rather than re-block forever.
+
+Force-allow releases the agent; it does **not** accept the report. That stop is
+logged as `unverified` and writes no outcome-specific event, so an unvalidated
+report can never claim the run's terminal status. For a role that must carry a
+machine outcome block, the warning also tells the agent the report is not a
+terminal result and its outputs must not be registered.
 
 **Gaps:**
 - Verifier reports: no check that tests were actually run (only format)

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -89,6 +89,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - An asset-producer run now reports its terminal status in a machine-readable outcome block that the report hook, metrics, and `/gm-asset` read through one parser, so a valid PARTIAL is no longer recorded as UNKNOWN.
 - A report the hook rejects on format is now recorded as a rejected attempt, so it neither reads as a production failure nor overwrites the retry's real terminal status.
 - Only a validated outcome can create a terminal record, so a report the anti-deadloop force-allow releases is recorded as unverified and produces no result event.
+- A subagent's dispatched role now outranks the role its report claims, so an outcome block declaring a different role is rejected instead of being recorded as that role's result.
 
 - Replaced legacy magenta edge cleanup with PyMatting using a fixed validated trimap.
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -86,6 +86,9 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- An asset-producer run now reports its terminal status in a machine-readable outcome block that the report hook, metrics, and `/gm-asset` read through one parser, so a valid PARTIAL is no longer recorded as UNKNOWN.
+- A report the hook rejects on format is now recorded as a rejected attempt, so it neither reads as a production failure nor overwrites the retry's real terminal status.
+
 - Replaced legacy magenta edge cleanup with PyMatting using a fixed validated trimap.
 
 - Compact prop packs now generate one provider-authored source sheet, normalize each curated prop into its declared atlas slot, and publish independently addressable AtlasTexture resources with repaired L0-L4 validation.

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -86,10 +86,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
-- An asset-producer run now reports its terminal status in a machine-readable outcome block that the report hook, metrics, and `/gm-asset` read through one parser, so a valid PARTIAL is no longer recorded as UNKNOWN.
-- A report the hook rejects on format is now recorded as a rejected attempt, so it neither reads as a production failure nor overwrites the retry's real terminal status.
-- Only a validated outcome can create a terminal record, so a report the anti-deadloop force-allow releases is recorded as unverified and produces no result event.
-- A subagent's dispatched role now outranks the role its report claims, so an outcome block declaring a different role is rejected instead of being recorded as that role's result.
+- An asset production unit now ends the asset stage with one consistent status, so a retried report no longer reads as a failure and a partial result keeps its blockers instead of being recorded as unknown.
 
 - Replaced legacy magenta edge cleanup with PyMatting using a fixed validated trimap.
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -88,6 +88,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 - An asset-producer run now reports its terminal status in a machine-readable outcome block that the report hook, metrics, and `/gm-asset` read through one parser, so a valid PARTIAL is no longer recorded as UNKNOWN.
 - A report the hook rejects on format is now recorded as a rejected attempt, so it neither reads as a production failure nor overwrites the retry's real terminal status.
+- Only a validated outcome can create a terminal record, so a report the anti-deadloop force-allow releases is recorded as unverified and produces no result event.
 
 - Replaced legacy magenta edge cleanup with PyMatting using a fixed validated trimap.
 

--- a/docs/wiki/07-contributing/writing-a-hook.md
+++ b/docs/wiki/07-contributing/writing-a-hook.md
@@ -120,7 +120,7 @@ A condensed summary. For full detail on each hook, see [../../hooks.md](../../ho
 | `check_stage_prerequisites.py` | PreToolUse (Agent) | Yes | Block `build` / `fixgap` from dispatching workers if prerequisite role did not complete |
 | `check_asset_access.py` | PreToolUse (Read) | Yes | Block the main agent from reading image files in `assets/` (forces analyst sub-agent) |
 | `log_subagent.py` | SubagentStart | No | Record sub-agent start with role detection; called again by `on_subagent_stop.py` for stop metrics |
-| `on_subagent_stop.py` | SubagentStop | Delegates | Serial dispatcher: runs `log_subagent.handle_stop` then `check_worker_report.main_with_data` to avoid a metrics file race |
+| `on_subagent_stop.py` | SubagentStop | Delegates | Serial dispatcher: runs `check_worker_report.evaluate`, then `log_subagent.handle_stop` with that verdict, then `check_worker_report.apply_verdict` — avoids a metrics file race and keeps a rejected report out of the terminal record |
 | `check_completion.py` | Stop | Yes | Final gate for `build` / `fixgap`: blocks if workers ran without verifier + reviewer |
 
 ---

--- a/docs/zh/hooks.md
+++ b/docs/zh/hooks.md
@@ -201,7 +201,7 @@ metrics 与 `/gm-asset` 管理端通过同一个 parser 读取它，因此错乱
 | 字段 | 规则 |
 |---|---|
 | `gm_outcome_version` | `1` |
-| `report_type` | 已知角色（`asset-producer`） |
+| `report_type` | 必须等于该子代理被派发时的角色 |
 | `status` | `DONE`、`PARTIAL` 或 `FAILED` |
 | `unit_id` | 非空字符串 |
 | `outputs` | 路径数组对象，键只能是 `sources`、`runtime`、`prompts`、`reports`、`entry_drafts` |
@@ -211,6 +211,12 @@ metrics 与 `/gm-asset` 管理端通过同一个 parser 读取它，因此错乱
 `DONE` 还要求 `validation.passed` 为真；`PARTIAL` 与 `FAILED` 至少需要一条 blocker。
 字段缺失或非法会带着字段名被拒绝，该次 stop 记录为 `rejected_attempt`；若最终被
 force-allow 放行，则记录为 `unverified`。两者都不会写结果事件。
+
+**角色绑定：** 子代理被派发时的角色（payload 的 `agent_type`，回退到其
+`subagent_start` 事件）优先于报告对自身的任何声明；block 声明了不同的
+`report_type` 会 fail closed。报告无法自行升格或降格，因此记录里不可能出现一个角色
+的 `role` 配另一个角色的 outcome。`log_subagent.classify_stop` 会复核同一等式，覆盖
+hook 完全没有校验的路径（force-allow，或没有活跃的流水线角色）。
 
 **每角色必需章节：**
 

--- a/docs/zh/hooks.md
+++ b/docs/zh/hooks.md
@@ -143,7 +143,20 @@ Runner 支持：仅 Claude Code / Codex。OpenCode adapter 不发出 Claude-styl
    4. `verifier:` / `verify:` → verifier
    5. `reviewer:` / `review:` → reviewer
 
-**handle_stop：** 由 `on_subagent_stop.py` 调用。从助手消息中提取报告类型、状态、变更文件。从匹配的启动事件中查找角色。记录 `SUBAGENT_STOP` 指标以及结果特定事件：`WORKER_DONE`、`VERIFIER_PASS` 等。
+**handle_stop：** 由 `on_subagent_stop.py` 调用。通过 `metrics.outcome.normalize_report`
+读取报告类型与状态——与报告 Hook 完全相同的入口。从匹配的启动事件中查找角色。记录
+`SUBAGENT_STOP` 指标以及结果特定事件：`WORKER_DONE`、`VERIFIER_PASS`、
+`ASSET_PRODUCER_PARTIAL` 等。
+
+每条 `SUBAGENT_STOP` 都带 `outcome_kind`：
+
+| `outcome_kind` | 含义 |
+|---|---|
+| `terminal` | 本次运行的终态，写入唯一的结果特定事件 |
+| `rejected_attempt` | 报告 Hook 拒绝了这次 stop，不写结果事件 |
+
+被拒绝的尝试永远不会占用那唯一的结果事件，因此纯格式拒绝既不会被读成 producer
+失败，也不会抢先覆盖重试的真实终态。
 
 ### on_subagent_stop.py
 
@@ -155,8 +168,12 @@ Runner 支持：仅 Claude Code / Codex。OpenCode adapter 不发出 Claude-styl
 
 `SubagentStop` 事件的单一分发器。读取一次 stdin 后串行运行：
 
-1. `log_subagent.handle_stop(data)` — 记录指标，保存追踪（从不阻止）
-2. `check_worker_report.main_with_data(data)` — 验证报告（可能阻止）
+1. `check_worker_report.evaluate(data)` — 判定结论（无副作用）
+2. `log_subagent.handle_stop(data, verdict=…)` — 按该结论标记并记录指标（从不阻止）
+3. `check_worker_report.apply_verdict(verdict)` — 输出决定（可能阻止）
+
+**为什么先验证：** 结论决定这次 stop 是终态记录还是被拒绝的尝试。先记录再验证会把被
+拒绝的尝试写成本次运行的结果，随后去重保护会丢弃重试的真实状态。
 
 **为什么使用分发器：** Claude Code 默认并行运行多个 `SubagentStop` Hook。两个处理程序都会操作 `metrics_current.jsonl`——`log_subagent` 读取，`check_worker_report` 写入——这会导致间歇性的 `JSONDecodeError` 崩溃。在单个进程内串行执行消除了竞态条件。
 
@@ -168,9 +185,29 @@ Runner 支持：仅 Claude Code / Codex。OpenCode adapter 不发出 Claude-styl
 仅在 `/gm-*` 流水线角色活跃时验证子代理角色的报告格式和内容。没有 `.godotmaker/current_role` 时，普通子代理对话被允许，该 Hook 不阻止。
 
 **格式检测流程：**
-1. 从消息内容检测 `report_type`（分层：精确标记 → 正则 → 回退）
-2. 若检测到 `report_type` → 检查该类型所需的章节
-3. 若 `report_type` 为 None 但从启动事件得知角色 → 阻止并要求提交格式化报告
+1. 通过 `metrics.outcome.normalize_report` 解析 `report_type` 与 `status`——先读
+   machine outcome 块，再走 Markdown 分层（精确标记 → 正则 → 回退）
+2. 若该角色必须携带 machine outcome 块 → 校验该块，fail closed
+3. 若检测到 `report_type` → 检查该类型所需的章节
+4. 若 `report_type` 为 None 但从启动事件得知角色 → 阻止并要求提交格式化报告
+
+**Machine outcome 块：** `asset-producer` 报告必须以恰好一个带 `gm_outcome_version`
+的 fenced JSON 对象结尾。它才是状态协议，Markdown 标题只是人类可读摘要。Hook、
+metrics 与 `/gm-asset` 管理端通过同一个 parser 读取它，因此错乱的标题不会再产生
+`report_type: unknown` / `status: UNKNOWN` 记录，同时管理端却读到了正确状态。
+
+| 字段 | 规则 |
+|---|---|
+| `gm_outcome_version` | `1` |
+| `report_type` | 已知角色（`asset-producer`） |
+| `status` | `DONE`、`PARTIAL` 或 `FAILED` |
+| `unit_id` | 非空字符串 |
+| `outputs` | 路径数组对象，键只能是 `sources`、`runtime`、`prompts`、`reports`、`entry_drafts` |
+| `validation` | `{passed: bool, levels?: {L0–L4: bool}, notes?: string}` |
+| `blockers` | 字符串数组；只有 `status` 为 `DONE` 时才可为空 |
+
+`DONE` 还要求 `validation.passed` 为真；`PARTIAL` 与 `FAILED` 至少需要一条 blocker。
+字段缺失或非法会带着字段名被拒绝，该次 stop 记录为 `rejected_attempt`。
 
 **每角色必需章节：**
 

--- a/docs/zh/hooks.md
+++ b/docs/zh/hooks.md
@@ -152,11 +152,13 @@ Runner 支持：仅 Claude Code / Codex。OpenCode adapter 不发出 Claude-styl
 
 | `outcome_kind` | 含义 |
 |---|---|
-| `terminal` | 本次运行的终态，写入唯一的结果特定事件 |
-| `rejected_attempt` | 报告 Hook 拒绝了这次 stop，不写结果事件 |
+| `terminal` | 报告通过校验，写入唯一的结果特定事件 |
+| `rejected_attempt` | 报告 Hook 拦截了这次 stop，不写结果事件 |
+| `unverified` | 未通过校验即被放行，不写结果事件 |
 
-被拒绝的尝试永远不会占用那唯一的结果事件，因此纯格式拒绝既不会被读成 producer
-失败，也不会抢先覆盖重试的真实终态。
+只有 `terminal` 才写结果特定事件，因此未通过校验的报告既不会被读成结果，也不会
+抢先覆盖重试的真实终态。`unverified` 覆盖两种「放行但未接受报告」的情况：下文的
+防死锁 force-allow，以及必须携带 machine outcome 块的角色在没有合法块时走到这一步。
 
 ### on_subagent_stop.py
 
@@ -207,7 +209,8 @@ metrics 与 `/gm-asset` 管理端通过同一个 parser 读取它，因此错乱
 | `blockers` | 字符串数组；只有 `status` 为 `DONE` 时才可为空 |
 
 `DONE` 还要求 `validation.passed` 为真；`PARTIAL` 与 `FAILED` 至少需要一条 blocker。
-字段缺失或非法会带着字段名被拒绝，该次 stop 记录为 `rejected_attempt`。
+字段缺失或非法会带着字段名被拒绝，该次 stop 记录为 `rejected_attempt`；若最终被
+force-allow 放行，则记录为 `unverified`。两者都不会写结果事件。
 
 **每角色必需章节：**
 
@@ -229,6 +232,11 @@ metrics 与 `/gm-asset` 管理端通过同一个 parser 读取它，因此错乱
 **Reviewer 内容检查：** ECS Review 和 Issues Found 章节各自必须有至少 50 个字符的内容，防止空洞或走过场的审查。
 
 **防死锁：** `BLOCK_LIMIT = 2`，每个 `agent_id` 最多 2 次拦截——超过 2 次后强制放行并给出警告，而不是永远阻止。
+
+Force-allow 只解除对 agent 的阻塞，**并不**表示接受该报告。这次 stop 记为
+`unverified` 且不写任何结果特定事件，未通过校验的报告因此永远无法占据本次运行的
+终态。对必须携带 machine outcome 块的角色，警告还会明确告知该报告不是终态、其产物
+不得被注册。
 
 **已知缺口：**
 - Verifier 报告：没有 Hook 验证 Verifier 确实运行了测试（仅检查格式）

--- a/docs/zh/wiki/07-contributing/writing-a-hook.md
+++ b/docs/zh/wiki/07-contributing/writing-a-hook.md
@@ -116,7 +116,7 @@ Claude Code / Codex，或提供显式的 OpenCode fallback。
 | `check_stage_prerequisites.py` | PreToolUse (Agent) | 是 | 前置角色未完成时，阻止 `build` / `fixgap` 分发 worker |
 | `check_asset_access.py` | PreToolUse (Read) | 是 | 阻止主 Agent 直接读取 `assets/` 中的图片文件（强制使用分析师子 Agent） |
 | `log_subagent.py` | SubagentStart | 否 | 记录子 Agent 启动及角色信息；由 `on_subagent_stop.py` 再次调用以记录停止 metrics |
-| `on_subagent_stop.py` | SubagentStop | 委托执行 | 串行调度器：在同一进程中依次运行 `log_subagent.handle_stop` 和 `check_worker_report.main_with_data`，避免 metrics 文件竞争条件 |
+| `on_subagent_stop.py` | SubagentStop | 委托执行 | 串行调度器：依次运行 `check_worker_report.evaluate`、带该结论的 `log_subagent.handle_stop`、`check_worker_report.apply_verdict`，避免 metrics 文件竞争条件，并让被拒绝的报告不进入终态记录 |
 | `check_completion.py` | Stop | 是 | `build` / `fixgap` 的最终门禁：若 worker 运行后未经过验证器 + 审查员则拦截 |
 
 ---

--- a/hooks/check_worker_report.py
+++ b/hooks/check_worker_report.py
@@ -57,11 +57,20 @@ class ReportVerdict:
     state_key: str | None = None
     agent_id: str = ""
     block_count: int = 0
+    outcome_verified: bool = False
     event_extra: dict = field(default_factory=dict)
 
     @property
     def rejected(self) -> bool:
         return self.action == ACTION_BLOCK
+
+    @property
+    def force_allowed(self) -> bool:
+        """The deadloop escape hatch fired: the agent is released without its
+        report being validated. Release is not acceptance — see
+        `log_subagent.classify_stop`, which refuses to call such a stop terminal.
+        """
+        return self.action == ACTION_FORCE_ALLOW
 
 
 WORKER_TEST_SUBSTANCE = [
@@ -253,13 +262,20 @@ def evaluate(data: dict) -> ReportVerdict:
     if not get_current_role():
         return ReportVerdict(ACTION_SKIP)
 
-    # Anti-deadloop: per-agent block counter
     agent_id = data.get("agent_id") or ""
+    agent_type = data.get("agent_type") or ""
+    report = normalize_report(message)
+
+    # Anti-deadloop: per-agent block counter. Resolved before the counter check
+    # so the escape hatch can name the role it is releasing unvalidated.
     state_key = f"worker_report_block:{agent_id}" if agent_id else "worker_report_block:main"
     block_count = state.get(state_key, 0)
     if block_count >= BLOCK_LIMIT:
+        released = agent_type if agent_type in KNOWN_ROLES else report.report_type
         return ReportVerdict(
             ACTION_FORCE_ALLOW, agent_id=agent_id, block_count=block_count,
+            report_type=released if released in KNOWN_ROLES else None,
+            outcome_verified=report.outcome is not None,
         )
 
     def block(reason: str, **extra) -> ReportVerdict:
@@ -270,7 +286,6 @@ def evaluate(data: dict) -> ReportVerdict:
     # Compute worktree directories once to avoid repeated glob calls in _resolve_file
     worktree_dirs = globmod.glob(os.path.join(".claude", "worktrees", "agent-*"))
 
-    report = normalize_report(message)
     report_type = report.report_type if report.report_type in KNOWN_ROLES else None
 
     if report_type is None:
@@ -366,13 +381,22 @@ def apply_verdict(verdict: ReportVerdict) -> None:
                      result="force_allow",
                      reason=(f"Agent {verdict.agent_id} blocked "
                              f"{verdict.block_count} times, force-allowing"),
-                     agent_id=verdict.agent_id)
+                     agent_id=verdict.agent_id,
+                     report_type=verdict.report_type,
+                     outcome_verified=verdict.outcome_verified)
         warning = (
             f"Force-allowing after {verdict.block_count} failed attempts. "
             f"Your report for agent {verdict.agent_id} did not pass validation. "
             f"You MUST inform the user that this report has unresolved quality issues "
             f"and may need manual review. Do NOT silently proceed as if everything passed."
         )
+        if verdict.report_type in OUTCOME_REQUIRED_ROLES and not verdict.outcome_verified:
+            warning += (
+                f" This {verdict.report_type} report has NO validated machine outcome, "
+                f"so it is not a terminal result: it is recorded as unverified and "
+                f"produces no outcome event. Do not register its outputs — re-run the "
+                f"production unit or escalate."
+            )
         print(json.dumps({"decision": "allow", "reason": warning}), file=sys.stderr)
         return
 

--- a/hooks/check_worker_report.py
+++ b/hooks/check_worker_report.py
@@ -6,9 +6,18 @@ results), Build, Memory Entry.
 
 Verifier reports MUST have: Overall, Results, Adversarial Probes.
 
+Asset-producer reports MUST additionally carry a machine-readable outcome
+block (see `metrics/outcome.py`); markdown headings are the human-readable
+presentation, the block is the status protocol.
+
 Blocks (JSON decision: "block") if required sections are missing. When no
 current_role is set, no /gm-* pipeline role is active and regular subagent
 conversations are allowed without report-format enforcement.
+
+Validation is split in two: `evaluate()` is pure and returns a verdict,
+`apply_verdict()` performs the side effects. `on_subagent_stop.py` runs
+`evaluate()` first so the metrics logger can label a rejected attempt as an
+attempt instead of writing a contradictory terminal record.
 
 Anti-deadloop: if a specific agent has been blocked BLOCK_LIMIT times,
 force-allow with a warning to prevent infinite retry loops.
@@ -18,16 +27,42 @@ import json
 import os
 import re
 import sys
+from dataclasses import dataclass, field
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from metrics import (
     record_event, read_current_events, EventType,
-    detect_report_type, event_has_role,
+    event_has_role, normalize_report,
     REPORT_REQUIRED_SECTIONS, REPORT_FORMAT_HINTS, REPORT_REQUIRED_LABELS,
+    OUTCOME_REQUIRED_ROLES, OUTCOME_TEMPLATE,
+    KNOWN_ROLES, ROLE_UNKNOWN,
     get_current_role, state,
 )
 
 BLOCK_LIMIT = 2  # Max blocks per subagent before force-allowing
+
+# Verdict actions
+ACTION_SKIP = "skip"          # hook not applicable — no message, no active role
+ACTION_ALLOW = "allow"        # report validated
+ACTION_BLOCK = "block"        # report rejected — this stop is an attempt, not a result
+ACTION_FORCE_ALLOW = "force_allow"  # deadloop escape hatch
+
+
+@dataclass
+class ReportVerdict:
+    """Outcome of report validation, decided before any side effect runs."""
+    action: str
+    reason: str = ""
+    report_type: str | None = None
+    state_key: str | None = None
+    agent_id: str = ""
+    block_count: int = 0
+    event_extra: dict = field(default_factory=dict)
+
+    @property
+    def rejected(self) -> bool:
+        return self.action == ACTION_BLOCK
+
 
 WORKER_TEST_SUBSTANCE = [
     r"test[_/].*\.gd",
@@ -75,15 +110,6 @@ def _extract_section(message: str, heading: str) -> str | None:
         message, re.DOTALL | re.IGNORECASE,
     )
     return match.group(1).strip() if match else None
-
-
-def _block(reason: str, state_key: str | None = None, **extra) -> None:
-    """Record block event, increment deadloop counter, print decision JSON, and exit."""
-    if state_key:
-        state.increment(state_key)
-    record_event(EventType.HOOK_BLOCK, hook="check_worker_report", reason=reason, **extra)
-    print(json.dumps({"decision": "block", "reason": reason}))
-    sys.exit(0)
 
 
 def check_sections(message: str, required: list[tuple[str, str]]) -> list[str]:
@@ -211,53 +237,76 @@ def main():
 
 def main_with_data(data: dict) -> None:
     """Validate a worker/verifier report. Called from on_subagent_stop.py dispatcher."""
+    apply_verdict(evaluate(data))
+
+
+def evaluate(data: dict) -> ReportVerdict:
+    """Decide whether a report passes validation. No side effects.
+
+    Separated from `apply_verdict` so the metrics logger can learn the verdict
+    before it records the stop, and label a rejected attempt accordingly.
+    """
     message = data.get("last_assistant_message") or ""
     if not message:
-        sys.exit(0)
+        return ReportVerdict(ACTION_SKIP)
 
     if not get_current_role():
-        sys.exit(0)
+        return ReportVerdict(ACTION_SKIP)
 
     # Anti-deadloop: per-agent block counter
     agent_id = data.get("agent_id") or ""
     state_key = f"worker_report_block:{agent_id}" if agent_id else "worker_report_block:main"
     block_count = state.get(state_key, 0)
     if block_count >= BLOCK_LIMIT:
-        record_event(EventType.GATE_CHECK, gate="worker_report",
-                     result="force_allow",
-                     reason=f"Agent {agent_id} blocked {block_count} times, force-allowing",
-                     agent_id=agent_id)
-        warning = (
-            f"Force-allowing after {block_count} failed attempts. "
-            f"Your report for agent {agent_id} did not pass validation. "
-            f"You MUST inform the user that this report has unresolved quality issues "
-            f"and may need manual review. Do NOT silently proceed as if everything passed."
+        return ReportVerdict(
+            ACTION_FORCE_ALLOW, agent_id=agent_id, block_count=block_count,
         )
-        print(json.dumps({"decision": "allow", "reason": warning}), file=sys.stderr)
-        sys.exit(0)
+
+    def block(reason: str, **extra) -> ReportVerdict:
+        return ReportVerdict(ACTION_BLOCK, reason=reason, report_type=report_type,
+                             state_key=state_key, agent_id=agent_id,
+                             event_extra=extra)
 
     # Compute worktree directories once to avoid repeated glob calls in _resolve_file
     worktree_dirs = globmod.glob(os.path.join(".claude", "worktrees", "agent-*"))
 
-    report_type = detect_report_type(message)
+    report = normalize_report(message)
+    report_type = report.report_type if report.report_type in KNOWN_ROLES else None
 
     if report_type is None:
         # Check if this agent was dispatched with a known role (worker/verifier/reviewer)
         # If so, it MUST output a report in the required format — block and demand it.
         from log_subagent import lookup_role_from_events
-        role = lookup_role_from_events(agent_id) if agent_id else "unknown"
+        role = lookup_role_from_events(agent_id) if agent_id else ROLE_UNKNOWN
 
         if role in REPORT_FORMAT_HINTS:
             reason = (
                 f"You are a {role} but your output does not contain a properly formatted report. "
                 f"You MUST end your response with a report in this format:\n\n"
                 f"{REPORT_FORMAT_HINTS[role]}\n\n"
-                f"Re-output your report now."
             )
-            _block(reason, state_key=state_key, agent_id=agent_id, role=role)
+            if role in OUTCOME_REQUIRED_ROLES:
+                reason += f"followed by the machine outcome block:\n\n{OUTCOME_TEMPLATE}\n\n"
+            if report.outcome_error:
+                reason += f"Your outcome block was also rejected: {report.outcome_error}\n\n"
+            reason += "Re-output your report now."
+            return block(reason, role=role, outcome_error=report.outcome_error)
 
         # Unknown role and no report format — not a worker/verifier/reviewer, allow
-        sys.exit(0)
+        return ReportVerdict(ACTION_SKIP)
+
+    # The machine outcome block is the status protocol for the roles that carry
+    # one. Reject it before the markdown gate so the diagnostic names the field.
+    if report_type in OUTCOME_REQUIRED_ROLES and report.outcome is None:
+        detail = report.outcome_error or "No machine outcome block found."
+        reason = (
+            f"{report_type} report has no valid machine-readable outcome block: {detail}\n"
+            f"End your report with exactly one fenced JSON block in this shape:\n\n"
+            f"{OUTCOME_TEMPLATE}\n\n"
+            f"The markdown sections stay as the human-readable summary; this block "
+            f"is what the hook, metrics, and the manager read the status from."
+        )
+        return block(reason, outcome_error=report.outcome_error)
 
     if report_type in REPORT_REQUIRED_SECTIONS:
         sections = REPORT_REQUIRED_SECTIONS[report_type]
@@ -270,12 +319,12 @@ def main_with_data(data: dict) -> None:
                 f"Add each missing section as a ### heading with content underneath. "
                 f"Refer to the report format in your agent definition for the exact template."
             )
-            _block(reason, state_key=state_key, missing=missing)
+            return block(reason, missing=missing)
 
     if report_type == "worker":
         test_issue = check_test_substance(message)
         if test_issue:
-            _block(test_issue, state_key=state_key)
+            return block(test_issue)
 
         if os.path.exists("project.godot"):
             files = extract_files_changed(message)
@@ -292,19 +341,52 @@ def main_with_data(data: dict) -> None:
 
             res_issue = check_resource_paths(gd_contents, worktree_dirs)
             if res_issue:
-                _block(res_issue, state_key=state_key)
+                return block(res_issue)
 
             classname_issue = check_classname_conflicts(gd_contents)
             if classname_issue:
-                _block(classname_issue, state_key=state_key)
+                return block(classname_issue)
 
     if report_type == "reviewer":
         reviewer_issue = check_reviewer_substance(message)
         if reviewer_issue:
-            _block(reviewer_issue, state_key=state_key)
+            return block(reviewer_issue)
+
+    return ReportVerdict(ACTION_ALLOW, report_type=report_type,
+                         state_key=state_key, agent_id=agent_id)
+
+
+def apply_verdict(verdict: ReportVerdict) -> None:
+    """Record the verdict's events and emit the hook decision."""
+    if verdict.action == ACTION_SKIP:
+        return
+
+    if verdict.action == ACTION_FORCE_ALLOW:
+        record_event(EventType.GATE_CHECK, gate="worker_report",
+                     result="force_allow",
+                     reason=(f"Agent {verdict.agent_id} blocked "
+                             f"{verdict.block_count} times, force-allowing"),
+                     agent_id=verdict.agent_id)
+        warning = (
+            f"Force-allowing after {verdict.block_count} failed attempts. "
+            f"Your report for agent {verdict.agent_id} did not pass validation. "
+            f"You MUST inform the user that this report has unresolved quality issues "
+            f"and may need manual review. Do NOT silently proceed as if everything passed."
+        )
+        print(json.dumps({"decision": "allow", "reason": warning}), file=sys.stderr)
+        return
+
+    if verdict.action == ACTION_BLOCK:
+        if verdict.state_key:
+            state.increment(verdict.state_key)
+        record_event(EventType.HOOK_BLOCK, hook="check_worker_report",
+                     reason=verdict.reason, agent_id=verdict.agent_id,
+                     **verdict.event_extra)
+        print(json.dumps({"decision": "block", "reason": verdict.reason}))
+        return
 
     record_event(EventType.HOOK_ALLOW, hook="check_worker_report",
-                 report_type=report_type)
+                 report_type=verdict.report_type)
 
     # Inject progress reminder on successful validation
     reminder = build_progress_reminder()

--- a/hooks/check_worker_report.py
+++ b/hooks/check_worker_report.py
@@ -32,10 +32,10 @@ from dataclasses import dataclass, field
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from metrics import (
     record_event, read_current_events, EventType,
-    event_has_role, normalize_report,
+    event_has_role, normalize_report, outcome_matches_role,
     REPORT_REQUIRED_SECTIONS, REPORT_FORMAT_HINTS, REPORT_REQUIRED_LABELS,
     OUTCOME_REQUIRED_ROLES, OUTCOME_TEMPLATE,
-    KNOWN_ROLES, ROLE_UNKNOWN,
+    KNOWN_ROLES,
     get_current_role, state,
 )
 
@@ -249,6 +249,26 @@ def main_with_data(data: dict) -> None:
     apply_verdict(evaluate(data))
 
 
+def resolve_runtime_role(data: dict) -> str | None:
+    """The role this subagent was dispatched as, or None if not a known role.
+
+    The payload's `agent_type` is authoritative when it names a known role; the
+    recorded SubagentStart event is the fallback for generic dispatches. This is
+    the same resolution `log_subagent.handle_stop` uses, so the hook and the
+    metrics logger can never disagree about whose report this is.
+    """
+    agent_type = data.get("agent_type") or ""
+    if agent_type in KNOWN_ROLES:
+        return agent_type
+    agent_id = data.get("agent_id") or ""
+    if agent_id:
+        from log_subagent import lookup_role_from_events
+        role = lookup_role_from_events(agent_id)
+        if role in KNOWN_ROLES:
+            return role
+    return None
+
+
 def evaluate(data: dict) -> ReportVerdict:
     """Decide whether a report passes validation. No side effects.
 
@@ -263,19 +283,23 @@ def evaluate(data: dict) -> ReportVerdict:
         return ReportVerdict(ACTION_SKIP)
 
     agent_id = data.get("agent_id") or ""
-    agent_type = data.get("agent_type") or ""
     report = normalize_report(message)
 
-    # Anti-deadloop: per-agent block counter. Resolved before the counter check
-    # so the escape hatch can name the role it is releasing unvalidated.
+    # The role this subagent was dispatched as outranks anything the report
+    # claims about itself. A report cannot promote or demote its own role.
+    runtime_role = resolve_runtime_role(data)
+    declared = report.report_type if report.report_type in KNOWN_ROLES else None
+    report_type = runtime_role or declared
+
+    # Anti-deadloop: per-agent block counter. The role and block are resolved
+    # first so the escape hatch can name the role it releases unvalidated.
     state_key = f"worker_report_block:{agent_id}" if agent_id else "worker_report_block:main"
     block_count = state.get(state_key, 0)
     if block_count >= BLOCK_LIMIT:
-        released = agent_type if agent_type in KNOWN_ROLES else report.report_type
         return ReportVerdict(
             ACTION_FORCE_ALLOW, agent_id=agent_id, block_count=block_count,
-            report_type=released if released in KNOWN_ROLES else None,
-            outcome_verified=report.outcome is not None,
+            report_type=report_type,
+            outcome_verified=outcome_matches_role(report, report_type),
         )
 
     def block(reason: str, **extra) -> ReportVerdict:
@@ -286,29 +310,39 @@ def evaluate(data: dict) -> ReportVerdict:
     # Compute worktree directories once to avoid repeated glob calls in _resolve_file
     worktree_dirs = globmod.glob(os.path.join(".claude", "worktrees", "agent-*"))
 
-    report_type = report.report_type if report.report_type in KNOWN_ROLES else None
-
-    if report_type is None:
-        # Check if this agent was dispatched with a known role (worker/verifier/reviewer)
-        # If so, it MUST output a report in the required format — block and demand it.
-        from log_subagent import lookup_role_from_events
-        role = lookup_role_from_events(agent_id) if agent_id else ROLE_UNKNOWN
-
-        if role in REPORT_FORMAT_HINTS:
+    if declared is None:
+        # No recognizable report at all. If this agent was dispatched with a
+        # known role it MUST output one — block and demand the format.
+        if report_type in REPORT_FORMAT_HINTS:
             reason = (
-                f"You are a {role} but your output does not contain a properly formatted report. "
+                f"You are a {report_type} but your output does not contain a properly "
+                f"formatted report. "
                 f"You MUST end your response with a report in this format:\n\n"
-                f"{REPORT_FORMAT_HINTS[role]}\n\n"
+                f"{REPORT_FORMAT_HINTS[report_type]}\n\n"
             )
-            if role in OUTCOME_REQUIRED_ROLES:
+            if report_type in OUTCOME_REQUIRED_ROLES:
                 reason += f"followed by the machine outcome block:\n\n{OUTCOME_TEMPLATE}\n\n"
             if report.outcome_error:
                 reason += f"Your outcome block was also rejected: {report.outcome_error}\n\n"
             reason += "Re-output your report now."
-            return block(reason, role=role, outcome_error=report.outcome_error)
+            return block(reason, role=report_type, outcome_error=report.outcome_error)
 
         # Unknown role and no report format — not a worker/verifier/reviewer, allow
         return ReportVerdict(ACTION_SKIP)
+
+    # An outcome block is an explicit structured claim about which role produced
+    # this run. If it contradicts the dispatched role, fail closed: otherwise the
+    # record carries one role with another role's outcome, and the manager cannot
+    # tell whose handoff it is holding.
+    if report.outcome is not None and not outcome_matches_role(report, report_type):
+        reason = (
+            f"Your machine outcome block declares report_type "
+            f"'{report.outcome['report_type']}', but you were dispatched as "
+            f"{report_type}. The block must declare the role you are running as.\n"
+            f"Set \"report_type\": \"{report_type}\" and re-output your report."
+        )
+        return block(reason, declared_report_type=report.outcome["report_type"],
+                     runtime_role=report_type)
 
     # The machine outcome block is the status protocol for the roles that carry
     # one. Reject it before the markdown gate so the diagnostic names the field.

--- a/hooks/log_subagent.py
+++ b/hooks/log_subagent.py
@@ -16,7 +16,8 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from metrics import (
-    record_event, EventType, normalize_report, OUTCOME_REQUIRED_ROLES,
+    record_event, EventType, normalize_report, outcome_matches_role,
+    OUTCOME_REQUIRED_ROLES,
     ROLE_WORKER, ROLE_VERIFIER, ROLE_REVIEWER, ROLE_ANALYST,
     ROLE_ASSET_PRODUCER, ROLE_UNKNOWN,
     KNOWN_ROLES,
@@ -188,10 +189,17 @@ def classify_stop(verdict, report, effective_role: str) -> str:
     if verdict is not None and getattr(verdict, "rejected", False):
         return OUTCOME_REJECTED_ATTEMPT
 
+    # A block declaring a different role than the one this subagent was
+    # dispatched as verifies nothing here. The hook already fails closed on the
+    # mismatch; re-checking the equality closes the paths where it never ran
+    # (force-allow, or no active pipeline role), which would otherwise let a
+    # worker block write an asset_producer_* result.
+    if report.outcome is not None and not outcome_matches_role(report, effective_role):
+        return OUTCOME_UNVERIFIED
+
     # For a role that carries a machine outcome, that block IS the verification,
-    # so it alone decides — including on paths where the hook validated nothing
-    # (force-allow, or no active pipeline role). A valid block still counts; a
-    # missing or malformed one has no terminal status to claim.
+    # so it alone decides. A valid block still counts even when the hook was
+    # bypassed; a missing one has no terminal status to claim.
     if effective_role in OUTCOME_REQUIRED_ROLES:
         return OUTCOME_TERMINAL if report.outcome is not None else OUTCOME_UNVERIFIED
 

--- a/hooks/log_subagent.py
+++ b/hooks/log_subagent.py
@@ -16,18 +16,19 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from metrics import (
-    record_event, EventType, normalize_report,
+    record_event, EventType, normalize_report, OUTCOME_REQUIRED_ROLES,
     ROLE_WORKER, ROLE_VERIFIER, ROLE_REVIEWER, ROLE_ANALYST,
     ROLE_ASSET_PRODUCER, ROLE_UNKNOWN,
     KNOWN_ROLES,
 )
 from check_worker_report import extract_files_changed
 
-# A stop the report hook rejected is an attempt, not a result. Labelling it
-# keeps a format-only rejection from reading as a terminal producer failure,
-# and keeps it from claiming the one terminal outcome event.
+# How a stop relates to the run's terminal status. Only `terminal` writes an
+# outcome-specific event, so a report that never passed validation can neither
+# read as a result nor claim the one terminal outcome.
 OUTCOME_TERMINAL = "terminal"
-OUTCOME_REJECTED_ATTEMPT = "rejected_attempt"
+OUTCOME_REJECTED_ATTEMPT = "rejected_attempt"  # the hook blocked this stop
+OUTCOME_UNVERIFIED = "unverified"              # released without passing validation
 
 # Debug logging: always on. Writes to .godotmaker/traces/hook_debug.log.
 _DEBUG_LOG = os.path.join(".godotmaker", "traces", "hook_debug.log")
@@ -175,14 +176,39 @@ def main():
     sys.exit(0)  # Never block
 
 
+def classify_stop(verdict, report, effective_role: str) -> str:
+    """Decide whether this stop is the run's terminal result.
+
+    Only a report that actually passed validation may become `terminal`, and
+    only a `terminal` stop writes an outcome-specific event. The hook can
+    release an agent without accepting its report — it blocks, or its deadloop
+    escape hatch force-allows — and treating either as a result is how an
+    unvalidated report claimed the single terminal outcome.
+    """
+    if verdict is not None and getattr(verdict, "rejected", False):
+        return OUTCOME_REJECTED_ATTEMPT
+
+    # For a role that carries a machine outcome, that block IS the verification,
+    # so it alone decides — including on paths where the hook validated nothing
+    # (force-allow, or no active pipeline role). A valid block still counts; a
+    # missing or malformed one has no terminal status to claim.
+    if effective_role in OUTCOME_REQUIRED_ROLES:
+        return OUTCOME_TERMINAL if report.outcome is not None else OUTCOME_UNVERIFIED
+
+    # Other roles are verified only by the markdown gate, which force-allow skips.
+    if verdict is not None and getattr(verdict, "force_allowed", False):
+        return OUTCOME_UNVERIFIED
+    return OUTCOME_TERMINAL
+
+
 def handle_stop(data: dict, verdict=None) -> None:
     """Handle SubagentStop event. Called from the on_subagent_stop dispatcher.
 
     `verdict` is the report hook's `ReportVerdict` for this same stop, computed
-    before this call. When the hook rejected the report, the stop is recorded as
-    a rejected attempt and writes no terminal outcome event, so a format-only
-    rejection can neither read as a producer failure nor pre-empt the retry's
-    real result.
+    before this call. `classify_stop` turns it into an `outcome_kind`; only a
+    `terminal` stop writes an outcome event, so neither a format rejection nor
+    a force-allowed report can read as a producer result or pre-empt the
+    retry's real one.
     """
     agent_id = data.get("agent_id") or ""
     agent_type = data.get("agent_type") or ""
@@ -205,8 +231,10 @@ def handle_stop(data: dict, verdict=None) -> None:
     # Final-output capture moved to log_agent_tool.py PostToolUse — see
     # this file's header for rationale.
 
-    rejected = bool(verdict is not None and getattr(verdict, "rejected", False))
+    # Role for outcome purposes: the dispatched role first, report type second.
+    effective_role = role if role != ROLE_UNKNOWN else report_type
     outcome = report.outcome or {}
+    kind = classify_stop(verdict, report, effective_role)
 
     record_event(
         EventType.SUBAGENT_STOP,
@@ -216,19 +244,18 @@ def handle_stop(data: dict, verdict=None) -> None:
         report_type=report_type,
         status=status,
         files_changed=files,
-        outcome_kind=OUTCOME_REJECTED_ATTEMPT if rejected else OUTCOME_TERMINAL,
+        outcome_kind=kind,
         unit_id=outcome.get("unit_id"),
         blockers=outcome.get("blockers", []),
         outcome_error=report.outcome_error,
     )
 
-    if rejected:
+    if kind != OUTCOME_TERMINAL:
         return
 
     # Record outcome-specific event based on role (primary) or report_type (fallback).
     # Only record once per agent_id to avoid duplicates when check_worker_report
     # blocks and the SubagentStop hook fires multiple times on retries.
-    effective_role = role if role != ROLE_UNKNOWN else report_type
     outcome_map = _OUTCOME_MAPS.get(effective_role)
     if outcome_map and status in outcome_map and not _has_outcome_event(agent_id):
         record_event(

--- a/hooks/log_subagent.py
+++ b/hooks/log_subagent.py
@@ -12,17 +12,22 @@ Never blocks (always exit 0).
 """
 import json
 import os
-import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from metrics import (
-    record_event, EventType, detect_report_type,
+    record_event, EventType, normalize_report,
     ROLE_WORKER, ROLE_VERIFIER, ROLE_REVIEWER, ROLE_ANALYST,
     ROLE_ASSET_PRODUCER, ROLE_UNKNOWN,
     KNOWN_ROLES,
 )
 from check_worker_report import extract_files_changed
+
+# A stop the report hook rejected is an attempt, not a result. Labelling it
+# keeps a format-only rejection from reading as a terminal producer failure,
+# and keeps it from claiming the one terminal outcome event.
+OUTCOME_TERMINAL = "terminal"
+OUTCOME_REJECTED_ATTEMPT = "rejected_attempt"
 
 # Debug logging: always on. Writes to .godotmaker/traces/hook_debug.log.
 _DEBUG_LOG = os.path.join(".godotmaker", "traces", "hook_debug.log")
@@ -37,20 +42,6 @@ def _debug(msg: str) -> None:
             f.write(f"[{ts}] {msg}\n")
     except OSError:
         pass
-
-
-def extract_status(message: str) -> str:
-    match = re.search(r"### Status:\s*(DONE|PARTIAL|FAILED)", message)
-    if match:
-        return match.group(1)
-    match = re.search(r"### Overall:\s*(PASS|FAIL|PARTIAL)", message)
-    if match:
-        return match.group(1)
-    return "UNKNOWN"
-
-
-def extract_report_type(message: str) -> str:
-    return detect_report_type(message) or "unknown"
 
 
 def detect_role_from_description(description: str) -> str:
@@ -90,6 +81,25 @@ def detect_role_from_description(description: str) -> str:
 _OUTCOME_EVENTS = {
     "worker_done", "worker_partial", "worker_failed",
     "verifier_pass", "verifier_fail", "verifier_partial",
+    "asset_producer_done", "asset_producer_partial", "asset_producer_failed",
+}
+
+_OUTCOME_MAPS = {
+    ROLE_WORKER: {
+        "DONE": EventType.WORKER_DONE,
+        "PARTIAL": EventType.WORKER_PARTIAL,
+        "FAILED": EventType.WORKER_FAILED,
+    },
+    ROLE_VERIFIER: {
+        "PASS": EventType.VERIFIER_PASS,
+        "FAIL": EventType.VERIFIER_FAIL,
+        "PARTIAL": EventType.VERIFIER_PARTIAL,
+    },
+    ROLE_ASSET_PRODUCER: {
+        "DONE": EventType.ASSET_PRODUCER_DONE,
+        "PARTIAL": EventType.ASSET_PRODUCER_PARTIAL,
+        "FAILED": EventType.ASSET_PRODUCER_FAILED,
+    },
 }
 
 
@@ -165,11 +175,14 @@ def main():
     sys.exit(0)  # Never block
 
 
-def handle_stop(data: dict) -> None:
-    """Handle SubagentStop event. Called from main() or from check_worker_report.
+def handle_stop(data: dict, verdict=None) -> None:
+    """Handle SubagentStop event. Called from the on_subagent_stop dispatcher.
 
-    Extracted so check_worker_report can call it directly, ensuring serial
-    execution (log first, then validate) without parallel hook race conditions.
+    `verdict` is the report hook's `ReportVerdict` for this same stop, computed
+    before this call. When the hook rejected the report, the stop is recorded as
+    a rejected attempt and writes no terminal outcome event, so a format-only
+    rejection can neither read as a producer failure nor pre-empt the retry's
+    real result.
     """
     agent_id = data.get("agent_id") or ""
     agent_type = data.get("agent_type") or ""
@@ -179,8 +192,11 @@ def handle_stop(data: dict) -> None:
     _debug(f"  last_assistant_message: type={type(raw_message).__name__} len={len(message)}")
     if message:
         _debug(f"  message preview: {message[:200]!r}")
-    report_type = extract_report_type(message)
-    status = extract_status(message)
+
+    # One parser for hook, metrics, and the manager handoff.
+    report = normalize_report(message)
+    report_type = report.report_type
+    status = report.status
     files = extract_files_changed(message)
     if agent_type in KNOWN_ROLES:
         role = agent_type
@@ -188,6 +204,9 @@ def handle_stop(data: dict) -> None:
         role = lookup_role_from_events(agent_id)
     # Final-output capture moved to log_agent_tool.py PostToolUse — see
     # this file's header for rationale.
+
+    rejected = bool(verdict is not None and getattr(verdict, "rejected", False))
+    outcome = report.outcome or {}
 
     record_event(
         EventType.SUBAGENT_STOP,
@@ -197,29 +216,28 @@ def handle_stop(data: dict) -> None:
         report_type=report_type,
         status=status,
         files_changed=files,
+        outcome_kind=OUTCOME_REJECTED_ATTEMPT if rejected else OUTCOME_TERMINAL,
+        unit_id=outcome.get("unit_id"),
+        blockers=outcome.get("blockers", []),
+        outcome_error=report.outcome_error,
     )
+
+    if rejected:
+        return
 
     # Record outcome-specific event based on role (primary) or report_type (fallback).
     # Only record once per agent_id to avoid duplicates when check_worker_report
     # blocks and the SubagentStop hook fires multiple times on retries.
     effective_role = role if role != ROLE_UNKNOWN else report_type
-    if effective_role == ROLE_WORKER:
-        outcome_map = {
-            "DONE": EventType.WORKER_DONE,
-            "PARTIAL": EventType.WORKER_PARTIAL,
-            "FAILED": EventType.WORKER_FAILED,
-        }
-        if status in outcome_map and not _has_outcome_event(agent_id):
-            record_event(outcome_map[status], agent_id=agent_id, files=files)
-
-    elif effective_role == ROLE_VERIFIER:
-        outcome_map = {
-            "PASS": EventType.VERIFIER_PASS,
-            "FAIL": EventType.VERIFIER_FAIL,
-            "PARTIAL": EventType.VERIFIER_PARTIAL,
-        }
-        if status in outcome_map and not _has_outcome_event(agent_id):
-            record_event(outcome_map[status], agent_id=agent_id)
+    outcome_map = _OUTCOME_MAPS.get(effective_role)
+    if outcome_map and status in outcome_map and not _has_outcome_event(agent_id):
+        record_event(
+            outcome_map[status],
+            agent_id=agent_id,
+            files=files,
+            unit_id=outcome.get("unit_id"),
+            blockers=outcome.get("blockers", []),
+        )
 
 
 if __name__ == "__main__":

--- a/hooks/metrics/__init__.py
+++ b/hooks/metrics/__init__.py
@@ -24,7 +24,7 @@ from .schema import (
 )
 from .outcome import (
     NormalizedReport, OutcomeError, normalize_report, validate_outcome,
-    extract_markdown_status, find_outcome_payloads,
+    extract_markdown_status, find_outcome_payloads, outcome_matches_role,
     OUTCOME_REQUIRED_ROLES, OUTCOME_TEMPLATE, OUTCOME_VERSION,
     OUTPUT_CATEGORIES, STATUS_UNKNOWN, TERMINAL_STATUSES, VALIDATION_LEVELS,
 )
@@ -156,7 +156,7 @@ __all__ = [
     "ROLE_ASSET_PRODUCER", "ROLE_UNKNOWN",
     "KNOWN_ROLES",
     "NormalizedReport", "OutcomeError", "normalize_report", "validate_outcome",
-    "extract_markdown_status", "find_outcome_payloads",
+    "extract_markdown_status", "find_outcome_payloads", "outcome_matches_role",
     "OUTCOME_REQUIRED_ROLES", "OUTCOME_TEMPLATE", "OUTCOME_VERSION",
     "OUTPUT_CATEGORIES", "STATUS_UNKNOWN", "TERMINAL_STATUSES", "VALIDATION_LEVELS",
     "state",

--- a/hooks/metrics/__init__.py
+++ b/hooks/metrics/__init__.py
@@ -22,6 +22,12 @@ from .schema import (
     ROLE_ASSET_PRODUCER, ROLE_UNKNOWN,
     KNOWN_ROLES,
 )
+from .outcome import (
+    NormalizedReport, OutcomeError, normalize_report, validate_outcome,
+    extract_markdown_status, find_outcome_payloads,
+    OUTCOME_REQUIRED_ROLES, OUTCOME_TEMPLATE, OUTCOME_VERSION,
+    OUTPUT_CATEGORIES, STATUS_UNKNOWN, TERMINAL_STATUSES, VALIDATION_LEVELS,
+)
 from . import state
 
 
@@ -149,6 +155,10 @@ __all__ = [
     "ROLE_WORKER", "ROLE_VERIFIER", "ROLE_REVIEWER", "ROLE_ANALYST",
     "ROLE_ASSET_PRODUCER", "ROLE_UNKNOWN",
     "KNOWN_ROLES",
+    "NormalizedReport", "OutcomeError", "normalize_report", "validate_outcome",
+    "extract_markdown_status", "find_outcome_payloads",
+    "OUTCOME_REQUIRED_ROLES", "OUTCOME_TEMPLATE", "OUTCOME_VERSION",
+    "OUTPUT_CATEGORIES", "STATUS_UNKNOWN", "TERMINAL_STATUSES", "VALIDATION_LEVELS",
     "state",
     "PIPELINE_ROLES",
     "WORKER_DISPATCH_ROLES",

--- a/hooks/metrics/outcome.py
+++ b/hooks/metrics/outcome.py
@@ -1,0 +1,340 @@
+"""Machine-readable terminal outcome for pipeline subagent reports.
+
+Markdown headings are a human-readable presentation layer. The terminal
+status of an `asset-producer` run travels in a fenced JSON block instead, so
+the report hook, the metrics logger, the `/gm-asset` manager, and the stage
+manager all read one value through one parser instead of three regexes over
+free-form prose.
+
+A report carries exactly one outcome block:
+
+    ```json
+    {
+      "gm_outcome_version": 1,
+      "report_type": "asset-producer",
+      "status": "PARTIAL",
+      "unit_id": "ui_kit",
+      "outputs": {
+        "sources": [".godotmaker/asset-generation/sources/ui_source.png"],
+        "runtime": [],
+        "prompts": [],
+        "reports": [],
+        "entry_drafts": []
+      },
+      "validation": {"passed": false, "notes": "atlas regions unverified"},
+      "blockers": ["provider returned no usable surface sheet"]
+    }
+    ```
+
+Validation fails closed: a malformed block raises `OutcomeError` naming the
+offending field, so a diagnosable rejection replaces a silent `UNKNOWN`.
+"""
+import json
+import re
+from dataclasses import dataclass
+
+from .schema import (
+    KNOWN_ROLES, ROLE_ASSET_PRODUCER, ROLE_UNKNOWN, detect_report_type,
+)
+
+
+OUTCOME_VERSION = 1
+OUTCOME_VERSION_KEY = "gm_outcome_version"
+
+STATUS_UNKNOWN = "UNKNOWN"
+TERMINAL_STATUSES = ("DONE", "PARTIAL", "FAILED")
+
+# Roles whose report MUST carry a valid outcome block. Every other role still
+# travels as markdown only; this issue's scope is asset-producer and its
+# direct consumers.
+OUTCOME_REQUIRED_ROLES = frozenset({ROLE_ASSET_PRODUCER})
+
+OUTPUT_CATEGORIES = ("sources", "runtime", "prompts", "reports", "entry_drafts")
+VALIDATION_LEVELS = ("L0", "L1", "L2", "L3", "L4")
+
+TOP_LEVEL_KEYS = (
+    OUTCOME_VERSION_KEY, "report_type", "status", "unit_id",
+    "outputs", "validation", "blockers",
+)
+
+OUTCOME_TEMPLATE = """```json
+{
+  "gm_outcome_version": 1,
+  "report_type": "asset-producer",
+  "status": "DONE | PARTIAL | FAILED",
+  "unit_id": "{unit_id}",
+  "outputs": {
+    "sources": [], "runtime": [], "prompts": [], "reports": [], "entry_drafts": []
+  },
+  "validation": {"passed": true, "notes": "short note"},
+  "blockers": []
+}
+```"""
+
+# Loose markdown fallbacks. Kept case-insensitive and heading-level tolerant so
+# a legacy or slightly-off report degrades to the same value the manager reads
+# off the prose, never to a contradictory UNKNOWN.
+_MD_STATUS_RE = re.compile(
+    r"#{1,6}\s*\*{0,2}Status\*{0,2}\s*[:：]\s*\*{0,2}\s*(DONE|PARTIAL|FAILED)",
+    re.IGNORECASE,
+)
+_MD_OVERALL_RE = re.compile(
+    r"#{1,6}\s*\*{0,2}Overall\*{0,2}\s*[:：]\s*\*{0,2}\s*(PASS|FAIL|PARTIAL)",
+    re.IGNORECASE,
+)
+
+
+class OutcomeError(ValueError):
+    """A machine outcome block is present but does not satisfy the contract."""
+
+
+@dataclass(frozen=True)
+class NormalizedReport:
+    """One report read through one parser.
+
+    `report_type` and `status` are what every consumer must use. `outcome` is
+    the validated block when the report carries one, `outcome_error` explains
+    why it was rejected, and `has_outcome_block` distinguishes "no block at
+    all" from "block present but invalid".
+    """
+    report_type: str
+    status: str
+    outcome: dict | None
+    outcome_error: str | None
+    has_outcome_block: bool
+
+
+def extract_markdown_status(message: str) -> str:
+    """Best-effort status from report prose. Returns UNKNOWN when absent."""
+    if not message:
+        return STATUS_UNKNOWN
+    match = _MD_STATUS_RE.search(message)
+    if match:
+        return match.group(1).upper()
+    match = _MD_OVERALL_RE.search(message)
+    if match:
+        return match.group(1).upper()
+    return STATUS_UNKNOWN
+
+
+def _iter_fenced_blocks(message: str):
+    """Yield the body of every closed fenced code block in the message."""
+    fence = None
+    body: list[str] = []
+    for line in message.splitlines():
+        stripped = line.strip()
+        if fence is None:
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                fence = stripped[:3]
+                body = []
+            continue
+        # A closing fence is the fence characters alone, nothing else.
+        if stripped.startswith(fence) and not stripped.strip(fence[0]):
+            yield "\n".join(body)
+            fence = None
+            continue
+        body.append(line)
+
+
+def find_outcome_payloads(message: str) -> tuple[list[dict], list[str]]:
+    """Split fenced blocks that claim to be outcome blocks into (parsed, errors).
+
+    A block claims to be an outcome block by mentioning the version key. That
+    keeps an unrelated JSON sample in the report from being mistaken for one,
+    while a typo inside a real block still surfaces as an error instead of
+    being skipped.
+    """
+    payloads: list[dict] = []
+    errors: list[str] = []
+    for block in _iter_fenced_blocks(message):
+        text = block.strip()
+        if OUTCOME_VERSION_KEY not in text:
+            continue
+        try:
+            data = json.loads(text)
+        except ValueError as exc:
+            errors.append(f"outcome block is not valid JSON: {exc}")
+            continue
+        if isinstance(data, dict) and OUTCOME_VERSION_KEY in data:
+            payloads.append(data)
+        else:
+            errors.append(
+                f"outcome block must be a JSON object carrying '{OUTCOME_VERSION_KEY}'"
+            )
+    return payloads, errors
+
+
+def _require_non_empty_str(value, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise OutcomeError(f"'{field}' must be a non-empty string")
+    return value.strip()
+
+
+def _validate_outputs(value) -> dict:
+    if not isinstance(value, dict):
+        raise OutcomeError("'outputs' must be an object of path lists")
+    unknown = sorted(set(value) - set(OUTPUT_CATEGORIES))
+    if unknown:
+        raise OutcomeError(
+            f"'outputs' has unknown categories: {', '.join(unknown)}. "
+            f"Allowed: {', '.join(OUTPUT_CATEGORIES)}"
+        )
+    normalized = {}
+    for category in OUTPUT_CATEGORIES:
+        raw = value.get(category, [])
+        if not isinstance(raw, list):
+            raise OutcomeError(f"'outputs.{category}' must be an array of paths")
+        paths = []
+        for item in raw:
+            if not isinstance(item, str) or not item.strip():
+                raise OutcomeError(
+                    f"'outputs.{category}' entries must be non-empty strings"
+                )
+            paths.append(item.strip())
+        normalized[category] = paths
+    return normalized
+
+
+def _validate_validation(value) -> dict:
+    if not isinstance(value, dict):
+        raise OutcomeError("'validation' must be an object with a 'passed' boolean")
+    unknown = sorted(set(value) - {"passed", "levels", "notes"})
+    if unknown:
+        raise OutcomeError(
+            f"'validation' has unknown keys: {', '.join(unknown)}. "
+            f"Allowed: passed, levels, notes"
+        )
+    if not isinstance(value.get("passed"), bool):
+        raise OutcomeError("'validation.passed' must be true or false")
+    normalized = {"passed": value["passed"]}
+
+    if "levels" in value:
+        levels = value["levels"]
+        if not isinstance(levels, dict):
+            raise OutcomeError("'validation.levels' must be an object of L0-L4 booleans")
+        unknown_levels = sorted(set(levels) - set(VALIDATION_LEVELS))
+        if unknown_levels:
+            raise OutcomeError(
+                f"'validation.levels' has unknown levels: {', '.join(unknown_levels)}"
+            )
+        for name, passed in levels.items():
+            if not isinstance(passed, bool):
+                raise OutcomeError(f"'validation.levels.{name}' must be true or false")
+        normalized["levels"] = dict(levels)
+
+    if "notes" in value:
+        if not isinstance(value["notes"], str):
+            raise OutcomeError("'validation.notes' must be a string")
+        normalized["notes"] = value["notes"].strip()
+
+    return normalized
+
+
+def _validate_blockers(value) -> list[str]:
+    if not isinstance(value, list):
+        raise OutcomeError("'blockers' must be an array of strings")
+    blockers = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            raise OutcomeError("'blockers' entries must be non-empty strings")
+        blockers.append(item.strip())
+    return blockers
+
+
+def validate_outcome(payload: dict) -> dict:
+    """Validate and normalize one outcome payload. Raises OutcomeError."""
+    if not isinstance(payload, dict):
+        raise OutcomeError("outcome block must be a JSON object")
+
+    unknown = sorted(set(payload) - set(TOP_LEVEL_KEYS))
+    if unknown:
+        raise OutcomeError(
+            f"outcome block has unknown fields: {', '.join(unknown)}. "
+            f"Allowed: {', '.join(TOP_LEVEL_KEYS)}"
+        )
+    missing = [key for key in TOP_LEVEL_KEYS if key not in payload]
+    if missing:
+        raise OutcomeError(f"outcome block is missing fields: {', '.join(missing)}")
+
+    if payload[OUTCOME_VERSION_KEY] != OUTCOME_VERSION:
+        raise OutcomeError(
+            f"'{OUTCOME_VERSION_KEY}' must be {OUTCOME_VERSION}, "
+            f"got {payload[OUTCOME_VERSION_KEY]!r}"
+        )
+
+    report_type = _require_non_empty_str(payload["report_type"], "report_type")
+    if report_type not in KNOWN_ROLES:
+        raise OutcomeError(
+            f"'report_type' must be one of: {', '.join(sorted(KNOWN_ROLES))}"
+        )
+
+    status_raw = payload["status"]
+    if not isinstance(status_raw, str):
+        raise OutcomeError(f"'status' must be one of: {', '.join(TERMINAL_STATUSES)}")
+    status = status_raw.strip().upper()
+    if status not in TERMINAL_STATUSES:
+        raise OutcomeError(f"'status' must be one of: {', '.join(TERMINAL_STATUSES)}")
+
+    unit_id = _require_non_empty_str(payload["unit_id"], "unit_id")
+    outputs = _validate_outputs(payload["outputs"])
+    validation = _validate_validation(payload["validation"])
+    blockers = _validate_blockers(payload["blockers"])
+
+    # Cross-field rules keep the terminal record unambiguous: DONE is the only
+    # status that claims success, and a non-DONE run must say why.
+    if status == "DONE":
+        if not validation["passed"]:
+            raise OutcomeError(
+                "'status' DONE requires 'validation.passed' true; "
+                "report PARTIAL or FAILED instead"
+            )
+        if blockers:
+            raise OutcomeError(
+                "'status' DONE requires an empty 'blockers' array; "
+                "report PARTIAL or FAILED instead"
+            )
+    elif not blockers:
+        raise OutcomeError(
+            f"'status' {status} requires at least one entry in 'blockers'"
+        )
+
+    return {
+        OUTCOME_VERSION_KEY: OUTCOME_VERSION,
+        "report_type": report_type,
+        "status": status,
+        "unit_id": unit_id,
+        "outputs": outputs,
+        "validation": validation,
+        "blockers": blockers,
+    }
+
+
+def normalize_report(message: str) -> NormalizedReport:
+    """The single parse/normalize entry point every consumer shares."""
+    message = message or ""
+    md_type = detect_report_type(message) or ROLE_UNKNOWN
+    md_status = extract_markdown_status(message)
+
+    payloads, errors = find_outcome_payloads(message)
+
+    if not payloads and not errors:
+        return NormalizedReport(md_type, md_status, None, None, False)
+
+    if errors:
+        return NormalizedReport(md_type, md_status, None, "; ".join(errors), True)
+
+    if len(payloads) > 1:
+        return NormalizedReport(
+            md_type, md_status, None,
+            f"report carries {len(payloads)} outcome blocks; exactly one is allowed",
+            True,
+        )
+
+    try:
+        outcome = validate_outcome(payloads[0])
+    except OutcomeError as exc:
+        return NormalizedReport(md_type, md_status, None, str(exc), True)
+
+    return NormalizedReport(
+        outcome["report_type"], outcome["status"], outcome, None, True
+    )

--- a/hooks/metrics/outcome.py
+++ b/hooks/metrics/outcome.py
@@ -309,6 +309,17 @@ def validate_outcome(payload: dict) -> dict:
     }
 
 
+def outcome_matches_role(report: NormalizedReport, role: str | None) -> bool:
+    """True when the report carries a valid outcome block for exactly `role`.
+
+    The block declares which role produced the run, but the role a subagent was
+    dispatched as is what the pipeline actually knows. Every consumer binds the
+    two through this one predicate, so a block can never verify a run it does
+    not belong to.
+    """
+    return report.outcome is not None and report.outcome["report_type"] == role
+
+
 def normalize_report(message: str) -> NormalizedReport:
     """The single parse/normalize entry point every consumer shares."""
     message = message or ""

--- a/hooks/metrics/schema.py
+++ b/hooks/metrics/schema.py
@@ -42,6 +42,10 @@ class EventType(str, Enum):
     VERIFIER_FAIL = "verifier_fail"
     VERIFIER_PARTIAL = "verifier_partial"
 
+    ASSET_PRODUCER_DONE = "asset_producer_done"
+    ASSET_PRODUCER_PARTIAL = "asset_producer_partial"
+    ASSET_PRODUCER_FAILED = "asset_producer_failed"
+
     SKILL_READ = "skill_read"
 
     FILE_WRITE = "file_write"

--- a/hooks/on_subagent_stop.py
+++ b/hooks/on_subagent_stop.py
@@ -1,14 +1,20 @@
 #!/usr/bin/env python3
-"""SubagentStop dispatcher: log lifecycle event, then validate report.
+"""SubagentStop dispatcher: validate report, then log the lifecycle event.
 
-Single entry point for the SubagentStop hook. Reads stdin once and passes
-the data to both handlers serially:
-  1. log_subagent.handle_stop  — record metrics + save traces (never blocks)
-  2. check_worker_report.main_with_data — validate report (may block)
+Single entry point for the SubagentStop hook. Reads stdin once and runs the
+handlers serially:
+  1. check_worker_report.evaluate  — decide the verdict (no side effects)
+  2. log_subagent.handle_stop      — record metrics, labelled by that verdict
+  3. check_worker_report.apply_verdict — emit the decision (may block)
 
 This avoids the race condition that occurs when Claude Code runs multiple
 SubagentStop hooks in parallel: log_subagent reads metrics_current.jsonl
 while check_worker_report writes to it, causing JSONDecodeError crashes.
+
+Validation is evaluated before the stop is recorded so a rejected report is
+logged as a rejected attempt rather than a terminal outcome. Otherwise a
+format-only rejection lands in metrics as the run's result and the retry's
+real status is discarded by the duplicate-outcome guard.
 """
 import json
 import sys
@@ -35,13 +41,16 @@ def main():
         else:
             _debug(f"  {k}: {v!r}")
 
-    # 1. Log lifecycle event (never blocks)
-    from log_subagent import handle_stop
-    handle_stop(data)
+    # 1. Decide the verdict (pure — reads only)
+    from check_worker_report import evaluate, apply_verdict
+    verdict = evaluate(data)
 
-    # 2. Validate report (may block via sys.exit(1))
-    from check_worker_report import main_with_data
-    main_with_data(data)
+    # 2. Log lifecycle event, labelled terminal or rejected attempt (never blocks)
+    from log_subagent import handle_stop
+    handle_stop(data, verdict=verdict)
+
+    # 3. Emit the decision (may block)
+    apply_verdict(verdict)
 
 
 if __name__ == "__main__":

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -290,13 +290,14 @@ does not register a generic result directly.
    `PARTIAL`, or `FAILED`, and it is the only status you act on. Never read it
    from the markdown prose; the prose is a summary.
 
-   Confirm the block is there and well-formed yourself. The hook normally
-   rejects a report without one, but its anti-deadloop escape hatch releases a
-   subagent after repeated failures, so a report with no valid block can still
-   reach you. Such a report has no terminal status: treat the production unit
-   as unregistered, register nothing from it, and re-dispatch it once or
-   report the unit as blocked. Do not infer a status from the prose to fill
-   the gap.
+   Confirm the block is there, well-formed, and declares
+   `"report_type": "asset-producer"`. The hook normally rejects a report that
+   fails either check, but its anti-deadloop escape hatch releases a subagent
+   after repeated failures, so such a report can still reach you. A block for
+   any other role is not a producer handoff. Either way the report has no
+   terminal status: treat the production unit as unregistered, register nothing
+   from it, and re-dispatch it once or report the unit as blocked. Do not infer
+   a status from the prose to fill the gap.
 2. Confirm listed source, runtime output, prompt, report, and stable-entry draft
    files exist when claimed. `outputs` in the block lists the same paths by
    category and is what you check against.

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -287,9 +287,16 @@ does not register a generic result directly.
 
 1. Read the terminal status from the report's machine outcome block — the
    fenced JSON object carrying `gm_outcome_version`. Its `status` is `DONE`,
-   `PARTIAL`, or `FAILED`, and it is the only status you act on. Never re-read
-   it from the markdown prose: the prose is a summary, and the report hook
-   already rejected any report whose block was missing or invalid.
+   `PARTIAL`, or `FAILED`, and it is the only status you act on. Never read it
+   from the markdown prose; the prose is a summary.
+
+   Confirm the block is there and well-formed yourself. The hook normally
+   rejects a report without one, but its anti-deadloop escape hatch releases a
+   subagent after repeated failures, so a report with no valid block can still
+   reach you. Such a report has no terminal status: treat the production unit
+   as unregistered, register nothing from it, and re-dispatch it once or
+   report the unit as blocked. Do not infer a status from the prose to fill
+   the gap.
 2. Confirm listed source, runtime output, prompt, report, and stable-entry draft
    files exist when claimed. `outputs` in the block lists the same paths by
    category and is what you check against.

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -266,7 +266,9 @@ Brief shape:
 ### Scope
 - Write only the listed outputs.
 - Use only the production contract and docs it references.
-- Return the required Asset Producer Report.
+- Return the required Asset Producer Report, ending with its machine outcome
+  block. That block carries the terminal status; the markdown sections are the
+  human-readable summary.
 ```
 
 Do not dispatch one subagent per ASSETS.md row when the work is one bundle.
@@ -283,9 +285,14 @@ validates the generic result, materializes the normal report and deterministic
 draft-builder inputs, and then follows this same registration path. The manager
 does not register a generic result directly.
 
-1. Confirm status is `DONE`, `PARTIAL`, or `FAILED`.
+1. Read the terminal status from the report's machine outcome block — the
+   fenced JSON object carrying `gm_outcome_version`. Its `status` is `DONE`,
+   `PARTIAL`, or `FAILED`, and it is the only status you act on. Never re-read
+   it from the markdown prose: the prose is a summary, and the report hook
+   already rejected any report whose block was missing or invalid.
 2. Confirm listed source, runtime output, prompt, report, and stable-entry draft
-   files exist when claimed.
+   files exist when claimed. `outputs` in the block lists the same paths by
+   category and is what you check against.
 3. Confirm every entry draft came from a deterministic builder —
    `tools/asset_action_entry_draft.py` for processed action output,
    `tools/asset_curation_entry_draft.py` for a selected curation candidate,
@@ -360,8 +367,14 @@ write the bundle manifest and leave every planning row `MISSING`.
 Keep runtime entries below `ready` as `MISSING`. Do not hand-edit an ASSETS.md
 status, the root index, or a stable entry.
 
-9. Redispatch failed or incomplete production units once when the failure is
-   actionable from the report.
+9. Redispatch failed or incomplete production units once when the outcome
+   block's `blockers` make the failure actionable. Carry those blockers into the
+   redispatch brief and keep them in the stage summary — a `PARTIAL` or `FAILED`
+   unit never leaves this step without its recorded reason.
+
+A report the hook rejected is a rejected attempt, not a terminal result. Wait
+for the producer's re-emitted report and register from that one; do not treat a
+format rejection as a production failure or count it against the redispatch.
 
 Each command fails closed. Do not hand-edit
 `.godotmaker/asset-generation/manifest.json` or an entry file to make a gate

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -267,8 +267,7 @@ Brief shape:
 - Write only the listed outputs.
 - Use only the production contract and docs it references.
 - Return the required Asset Producer Report, ending with its machine outcome
-  block. That block carries the terminal status; the markdown sections are the
-  human-readable summary.
+  block.
 ```
 
 Do not dispatch one subagent per ASSETS.md row when the work is one bundle.
@@ -286,21 +285,13 @@ draft-builder inputs, and then follows this same registration path. The manager
 does not register a generic result directly.
 
 1. Read the terminal status from the report's machine outcome block — the
-   fenced JSON object carrying `gm_outcome_version`. Its `status` is `DONE`,
-   `PARTIAL`, or `FAILED`, and it is the only status you act on. Never read it
-   from the markdown prose; the prose is a summary.
-
-   Confirm the block is there, well-formed, and declares
-   `"report_type": "asset-producer"`. The hook normally rejects a report that
-   fails either check, but its anti-deadloop escape hatch releases a subagent
-   after repeated failures, so such a report can still reach you. A block for
-   any other role is not a producer handoff. Either way the report has no
-   terminal status: treat the production unit as unregistered, register nothing
-   from it, and re-dispatch it once or report the unit as blocked. Do not infer
-   a status from the prose to fill the gap.
+   fenced JSON object carrying `gm_outcome_version`. Act only on its `status`:
+   `DONE`, `PARTIAL`, or `FAILED`. Do not take the status from the markdown
+   prose. Confirm the block is present, well-formed, and declares
+   `"report_type": "asset-producer"`; without one, register nothing from that
+   report and re-dispatch the production unit once or report it as blocked.
 2. Confirm listed source, runtime output, prompt, report, and stable-entry draft
-   files exist when claimed. `outputs` in the block lists the same paths by
-   category and is what you check against.
+   files exist when claimed. Check them against `outputs` in the block.
 3. Confirm every entry draft came from a deterministic builder —
    `tools/asset_action_entry_draft.py` for processed action output,
    `tools/asset_curation_entry_draft.py` for a selected curation candidate,
@@ -377,12 +368,7 @@ status, the root index, or a stable entry.
 
 9. Redispatch failed or incomplete production units once when the outcome
    block's `blockers` make the failure actionable. Carry those blockers into the
-   redispatch brief and keep them in the stage summary — a `PARTIAL` or `FAILED`
-   unit never leaves this step without its recorded reason.
-
-A report the hook rejected is a rejected attempt, not a terminal result. Wait
-for the producer's re-emitted report and register from that one; do not treat a
-format rejection as a production failure or count it against the redispatch.
+   redispatch brief and the stage summary.
 
 Each command fails closed. Do not hand-edit
 `.godotmaker/asset-generation/manifest.json` or an entry file to make a gate

--- a/tests/hooks/helpers.py
+++ b/tests/hooks/helpers.py
@@ -91,6 +91,53 @@ def write_metrics(events: list[dict]):
             f.write(json.dumps(e) + "\n")
 
 
+def asset_producer_outcome(status="DONE", unit_id="ui_kit", blockers=None,
+                           passed=None, **overrides):
+    """Render a valid asset-producer machine outcome block as report markdown.
+
+    Defaults are internally consistent: DONE passes with no blockers, PARTIAL
+    and FAILED carry one. `overrides` replace top-level fields verbatim so a
+    test can inject an invalid value.
+    """
+    if blockers is None:
+        blockers = [] if status == "DONE" else ["provider returned no usable sheet"]
+    if passed is None:
+        passed = status == "DONE"
+    payload = {
+        "gm_outcome_version": 1,
+        "report_type": "asset-producer",
+        "status": status,
+        "unit_id": unit_id,
+        "outputs": {
+            "sources": [".godotmaker/asset-generation/sources/ui_source.png"],
+            "runtime": [],
+            "prompts": [],
+            "reports": [],
+            "entry_drafts": [],
+        },
+        "validation": {"passed": passed, "notes": "checked"},
+        "blockers": blockers,
+    }
+    payload.update(overrides)
+    return "### Machine Outcome\n```json\n" + json.dumps(payload, indent=2) + "\n```"
+
+
+def read_metrics(event=None):
+    """Read .godotmaker/metrics_current.jsonl, optionally filtered by event name."""
+    events = []
+    try:
+        with open(".godotmaker/metrics_current.jsonl", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    events.append(json.loads(line))
+    except FileNotFoundError:
+        return []
+    if event is not None:
+        events = [e for e in events if e.get("event") == event]
+    return events
+
+
 def cleanup_metrics():
     """Remove test metrics artifacts."""
     import shutil

--- a/tests/hooks/test_asset_producer_outcome.py
+++ b/tests/hooks/test_asset_producer_outcome.py
@@ -37,13 +37,28 @@ def producer_report(status="DONE", unit_id="ui_kit", drop_section=None, **kwargs
     return body + asset_producer_outcome(status=status, unit_id=unit_id, **kwargs)
 
 
-def stop(agent_id, message):
+def stop(agent_id, message, agent_type="asset-producer"):
     return run_hook(DISPATCHER, {
         "hook_event_name": "SubagentStop",
         "agent_id": agent_id,
-        "agent_type": "asset-producer",
+        "agent_type": agent_type,
         "last_assistant_message": message,
     })
+
+
+def worker_report(status="DONE", report_type="worker", unit_id="player_movement"):
+    """A complete worker report carrying an outcome block for `report_type`."""
+    return (
+        "## Report: PlayerMovement\n\n"
+        f"### Status: {status}\n\n"
+        "### Files Changed\n- player_system.gd: created\n\n"
+        "### Tests\n- test/test_player.gd: 3 tests, 3 passed\n"
+        "- Commands run: godot --headless\n\n"
+        "### Build\n- Status: PASS\n\n"
+        "### Memory Entry\nLearned about movement\n\n"
+        + asset_producer_outcome(status=status, unit_id=unit_id,
+                                 report_type=report_type)
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -327,6 +342,78 @@ class TestRejectedAttempt:
         assert record["outcome_kind"] == "rejected_attempt"
         assert "unit_id" in record["outcome_error"]
         assert read_metrics("asset_producer_failed") == []
+
+
+class TestRoleBinding:
+    """The dispatched role outranks whatever the report claims to be.
+
+    Without this, an asset-producer subagent could hand back a worker report
+    plus a schema-valid worker outcome block: the markdown gate would pass it as
+    a worker while the logger recorded an asset-producer result, leaving one
+    record that is neither role's handoff.
+    """
+
+    def test_worker_block_from_a_producer_agent_is_blocked(self):
+        _, _, parsed = stop("ap-cross", worker_report())
+        assert is_blocked(parsed)
+        assert "report_type 'worker'" in parsed["reason"]
+        assert "dispatched as asset-producer" in parsed["reason"]
+
+    def test_worker_block_from_a_producer_agent_writes_no_producer_result(self):
+        stop("ap-cross2", worker_report())
+        record = read_metrics("subagent_stop")[0]
+        assert record["role"] == "asset-producer"
+        assert record["outcome_kind"] != "terminal"
+        for event in ("asset_producer_done", "asset_producer_partial",
+                      "asset_producer_failed", "worker_done"):
+            assert read_metrics(event) == [], f"{event} written across roles"
+
+    def test_producer_block_from_a_worker_agent_is_blocked(self):
+        """The inverse binding holds too — a worker cannot claim a producer outcome."""
+        message = producer_report("DONE")
+        _, _, parsed = stop("w-cross", message, agent_type="worker")
+        assert is_blocked(parsed)
+        assert "report_type 'asset-producer'" in parsed["reason"]
+
+    def test_producer_block_from_a_worker_agent_writes_no_worker_result(self):
+        stop("w-cross2", producer_report("DONE"), agent_type="worker")
+        record = read_metrics("subagent_stop")[0]
+        assert record["outcome_kind"] != "terminal"
+        assert read_metrics("worker_done") == []
+        assert read_metrics("asset_producer_done") == []
+
+    def test_matching_role_still_passes(self):
+        _, _, parsed = stop("ap-match", producer_report("DONE"))
+        assert not is_blocked(parsed)
+        assert len(read_metrics("asset_producer_done")) == 1
+
+    def test_cross_role_block_survives_force_allow(self):
+        """classify_stop re-checks the equality, so the escape hatch cannot
+        launder a worker block into an asset-producer result."""
+        for _ in range(2):
+            _, _, parsed = stop("ap-cross3", worker_report())
+            assert is_blocked(parsed)
+
+        _, _, parsed = stop("ap-cross3", worker_report())
+        assert not is_blocked(parsed), "force-allow still releases the agent"
+
+        stops = read_metrics("subagent_stop")
+        assert stops[-1]["outcome_kind"] == "unverified"
+        assert not [s for s in stops if s["outcome_kind"] == "terminal"]
+        assert read_metrics("asset_producer_done") == []
+
+    def test_cross_role_block_is_not_a_result_without_an_active_role(self):
+        """No pipeline role means the hook validates nothing; the equality
+        re-check in classify_stop is the only thing standing here."""
+        cleanup_metrics()
+        _, code, parsed = stop("ap-cross4", worker_report())
+        assert code == 0
+        assert not is_blocked(parsed)
+
+        record = read_metrics("subagent_stop")[0]
+        assert record["role"] == "asset-producer"
+        assert record["outcome_kind"] == "unverified"
+        assert read_metrics("asset_producer_done") == []
 
 
 class TestForceAllowNeverTerminal:

--- a/tests/hooks/test_asset_producer_outcome.py
+++ b/tests/hooks/test_asset_producer_outcome.py
@@ -313,6 +313,12 @@ class TestRejectedAttempt:
         assert len(partial) == 1
         assert partial[0]["blockers"]
 
+    def test_missing_block_is_an_attempt_too(self):
+        stop("ap-noblock2", producer_report("DONE").split("### Machine Outcome")[0])
+        record = read_metrics("subagent_stop")[0]
+        assert record["outcome_kind"] == "rejected_attempt"
+        assert read_metrics("asset_producer_done") == []
+
     def test_invalid_block_is_an_attempt_not_a_producer_failure(self):
         message = producer_report("DONE").replace('"unit_id": "ui_kit"', '"unit_id": ""')
         _, _, parsed = stop("ap-badblock", message)
@@ -321,3 +327,73 @@ class TestRejectedAttempt:
         assert record["outcome_kind"] == "rejected_attempt"
         assert "unit_id" in record["outcome_error"]
         assert read_metrics("asset_producer_failed") == []
+
+
+class TestForceAllowNeverTerminal:
+    """The anti-deadloop escape hatch releases the agent, it does not accept
+    the report. An unvalidated report must not claim the terminal outcome.
+    """
+
+    INVALID = producer_report("DONE", unit_id="")
+
+    def _exhaust_block_limit(self, agent_id, message):
+        """Two rejections, so the third stop hits BLOCK_LIMIT force-allow."""
+        for _ in range(2):
+            _, _, parsed = stop(agent_id, message)
+            assert is_blocked(parsed)
+
+    def test_third_invalid_attempt_is_unverified_not_terminal(self):
+        self._exhaust_block_limit("ap-force", self.INVALID)
+
+        _, code, parsed = stop("ap-force", self.INVALID)
+        assert code == 0
+        assert not is_blocked(parsed), "force-allow must release the agent"
+
+        stops = read_metrics("subagent_stop")
+        assert len(stops) == 3
+        assert [s["outcome_kind"] for s in stops] == [
+            "rejected_attempt", "rejected_attempt", "unverified",
+        ]
+        assert not [s for s in stops if s["outcome_kind"] == "terminal"]
+
+    def test_force_allowed_report_writes_no_outcome_event(self):
+        self._exhaust_block_limit("ap-force2", self.INVALID)
+        stop("ap-force2", self.INVALID)
+
+        for event in ("asset_producer_done", "asset_producer_partial",
+                      "asset_producer_failed"):
+            assert read_metrics(event) == [], f"{event} written for an unvalidated report"
+
+    def test_missing_block_cannot_be_force_allowed_into_a_result(self):
+        """The markdown fallback must not supply a status the block never had."""
+        no_block = producer_report("DONE").split("### Machine Outcome")[0]
+        self._exhaust_block_limit("ap-force3", no_block)
+        stop("ap-force3", no_block)
+
+        record = read_metrics("subagent_stop")[-1]
+        assert record["outcome_kind"] == "unverified"
+        assert record["status"] == "DONE", "the prose status is still recorded, just not trusted"
+        assert record["unit_id"] is None
+        assert read_metrics("asset_producer_done") == []
+
+    def test_force_allow_warning_tells_the_manager_it_is_unverified(self):
+        self._exhaust_block_limit("ap-force4", self.INVALID)
+        stdout, _, _ = stop("ap-force4", self.INVALID)
+        assert stdout == "", "force-allow must not print a block decision"
+
+        gate = read_metrics("gate_check")[-1]
+        assert gate["result"] == "force_allow"
+        assert gate["report_type"] == "asset-producer"
+
+    def test_a_valid_retry_after_force_allow_is_still_terminal(self):
+        """The escape hatch must not permanently poison the agent's outcome."""
+        self._exhaust_block_limit("ap-force5", self.INVALID)
+        stop("ap-force5", self.INVALID)
+        assert read_metrics("asset_producer_partial") == []
+
+        stop("ap-force5", producer_report("PARTIAL"))
+        stops = read_metrics("subagent_stop")
+        assert stops[-1]["outcome_kind"] == "terminal"
+        partial = read_metrics("asset_producer_partial")
+        assert len(partial) == 1
+        assert partial[0]["blockers"]

--- a/tests/hooks/test_asset_producer_outcome.py
+++ b/tests/hooks/test_asset_producer_outcome.py
@@ -1,0 +1,323 @@
+"""Tests for the shared asset-producer terminal outcome protocol.
+
+Covers the parser/normalizer, the fail-closed hook gate, and the end-to-end
+agreement between the hook's classification and what metrics persists —
+including the case the protocol exists for: a first attempt rejected on format
+followed by a valid retry must leave exactly one terminal record.
+"""
+import json
+
+import pytest
+
+from metrics.outcome import (
+    OutcomeError, normalize_report, validate_outcome, extract_markdown_status,
+)
+
+from .helpers import (
+    asset_producer_outcome, cleanup_metrics, is_blocked, read_metrics,
+    run_hook, write_current_role,
+)
+
+DISPATCHER = "on_subagent_stop.py"
+
+
+def producer_report(status="DONE", unit_id="ui_kit", drop_section=None, **kwargs):
+    """A complete asset-producer report, optionally with one heading removed."""
+    body = (
+        f"## Asset Producer Report: {unit_id}\n\n"
+        f"### Status: {status}\n\n"
+        "### Production Unit\n- First-class Asset Skill: ui-kit\n\n"
+        "### Outputs\n- Sources: .godotmaker/asset-generation/sources/ui_source.png\n\n"
+        "### Tools\n- python tools/asset_sheet_process.py --snap-mode autoslice\n\n"
+        "### Validation\n- File existence: PASS\n\n"
+        "### Handoff\nRegister the ui_kit entry.\n\n"
+    )
+    if drop_section:
+        body = body.replace(drop_section, "### Removed")
+    return body + asset_producer_outcome(status=status, unit_id=unit_id, **kwargs)
+
+
+def stop(agent_id, message):
+    return run_hook(DISPATCHER, {
+        "hook_event_name": "SubagentStop",
+        "agent_id": agent_id,
+        "agent_type": "asset-producer",
+        "last_assistant_message": message,
+    })
+
+
+@pytest.fixture(autouse=True)
+def clean():
+    cleanup_metrics()
+    write_current_role("asset")
+    yield
+    cleanup_metrics()
+
+
+class TestOutcomeParser:
+    """The single parser/normalizer every consumer shares."""
+
+    @pytest.mark.parametrize("status", ["DONE", "PARTIAL", "FAILED"])
+    def test_status_and_type_come_from_the_block(self, status):
+        report = normalize_report(producer_report(status))
+        assert report.report_type == "asset-producer"
+        assert report.status == status
+        assert report.outcome_error is None
+        assert report.outcome["unit_id"] == "ui_kit"
+
+    def test_block_wins_over_contradicting_prose(self):
+        """A mangled heading no longer degrades the machine status."""
+        message = (
+            "Production stopped early.\n\n"
+            "**Status:** DONE\n\n"
+            + asset_producer_outcome("PARTIAL")
+        )
+        report = normalize_report(message)
+        assert report.report_type == "asset-producer"
+        assert report.status == "PARTIAL"
+        assert report.outcome["blockers"]
+
+    def test_blockers_survive_normalization(self):
+        message = producer_report("FAILED", blockers=["provider quota exhausted"])
+        report = normalize_report(message)
+        assert report.outcome["blockers"] == ["provider quota exhausted"]
+
+    def test_no_block_falls_back_to_markdown(self):
+        report = normalize_report(
+            "## Asset Producer Report: ui_kit\n\n### Status: PARTIAL\n"
+        )
+        assert report.has_outcome_block is False
+        assert report.outcome is None
+        assert report.report_type == "asset-producer"
+        assert report.status == "PARTIAL"
+
+    def test_markdown_status_is_case_and_level_tolerant(self):
+        """The old status regex returned UNKNOWN here while the parent read PARTIAL."""
+        assert extract_markdown_status("#### status: partial") == "PARTIAL"
+        assert extract_markdown_status("### **Status:** FAILED") == "FAILED"
+        assert extract_markdown_status("no status here") == "UNKNOWN"
+
+    def test_unrelated_json_block_is_not_an_outcome(self):
+        message = (
+            "```json\n{\"asset_type\": \"ui-kit\", \"outputs\": []}\n```\n\n"
+            + asset_producer_outcome("DONE")
+        )
+        report = normalize_report(message)
+        assert report.status == "DONE"
+
+    def test_two_blocks_are_ambiguous(self):
+        message = asset_producer_outcome("DONE") + "\n\n" + asset_producer_outcome("FAILED")
+        report = normalize_report(message)
+        assert report.outcome is None
+        assert "exactly one" in report.outcome_error
+
+    def test_malformed_json_is_reported_not_skipped(self):
+        message = "```json\n{\"gm_outcome_version\": 1, oops}\n```"
+        report = normalize_report(message)
+        assert report.has_outcome_block is True
+        assert report.outcome is None
+        assert "not valid JSON" in report.outcome_error
+
+
+class TestOutcomeValidation:
+    """Fail closed, and name the offending field."""
+
+    def _payload(self, **overrides):
+        block = asset_producer_outcome(**overrides)
+        return json.loads(block.split("```json\n", 1)[1].rsplit("\n```", 1)[0])
+
+    @pytest.mark.parametrize("field", [
+        "gm_outcome_version", "report_type", "status", "unit_id",
+        "outputs", "validation", "blockers",
+    ])
+    def test_missing_field_rejected(self, field):
+        payload = self._payload()
+        del payload[field]
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert field in str(exc.value)
+
+    def test_unknown_top_level_field_rejected(self):
+        payload = self._payload()
+        payload["tag"] = "v0.1.0"
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert "tag" in str(exc.value)
+
+    def test_bad_status_rejected(self):
+        payload = self._payload()
+        payload["status"] = "SUCCESS"
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert "status" in str(exc.value)
+
+    def test_lowercase_status_normalized(self):
+        payload = self._payload()
+        payload["status"] = "done"
+        assert validate_outcome(payload)["status"] == "DONE"
+
+    def test_empty_unit_id_rejected(self):
+        payload = self._payload()
+        payload["unit_id"] = "   "
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert "unit_id" in str(exc.value)
+
+    def test_unknown_output_category_rejected(self):
+        payload = self._payload()
+        payload["outputs"]["manifest_entry"] = []
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert "manifest_entry" in str(exc.value)
+
+    def test_non_bool_validation_passed_rejected(self):
+        payload = self._payload()
+        payload["validation"]["passed"] = "true"
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert "validation.passed" in str(exc.value)
+
+    def test_done_with_failed_validation_rejected(self):
+        payload = self._payload(status="DONE", passed=False)
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert "validation.passed" in str(exc.value)
+
+    def test_done_with_blockers_rejected(self):
+        payload = self._payload(status="DONE", blockers=["still missing frames"])
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert "blockers" in str(exc.value)
+
+    @pytest.mark.parametrize("status", ["PARTIAL", "FAILED"])
+    def test_non_done_without_blockers_rejected(self, status):
+        payload = self._payload(status=status, blockers=[])
+        with pytest.raises(OutcomeError) as exc:
+            validate_outcome(payload)
+        assert "blockers" in str(exc.value)
+
+
+class TestHookGate:
+    """The hook is fail-closed on the block, with a locatable diagnostic."""
+
+    def test_valid_report_allowed(self):
+        _, _, parsed = stop("ap-ok", producer_report("DONE"))
+        assert not is_blocked(parsed)
+
+    def test_missing_outcome_block_blocked(self):
+        message = producer_report("DONE").split("### Machine Outcome")[0]
+        _, _, parsed = stop("ap-noblock", message)
+        assert is_blocked(parsed)
+        assert "outcome block" in parsed["reason"]
+
+    def test_invalid_field_diagnostic_names_the_field(self):
+        message = producer_report("PARTIAL", blockers=[], passed=False)
+        _, _, parsed = stop("ap-noblockers", message)
+        assert is_blocked(parsed)
+        assert "blockers" in parsed["reason"]
+
+    def test_other_roles_are_unaffected(self):
+        """Only asset-producer must carry a block; the worker protocol is untouched."""
+        worker = (
+            "## Report: PlayerMovement\n\n"
+            "### Status: DONE\n\n"
+            "### Files Changed\n- player_system.gd: created\n\n"
+            "### Tests\n- test/test_player.gd: 3 tests, 3 passed\n"
+            "- Commands run: godot --headless\n\n"
+            "### Build\n- Status: PASS\n\n"
+            "### Memory Entry\nLearned about movement"
+        )
+        _, _, parsed = run_hook(DISPATCHER, {
+            "hook_event_name": "SubagentStop",
+            "agent_id": "w-plain",
+            "agent_type": "worker",
+            "last_assistant_message": worker,
+        })
+        assert not is_blocked(parsed)
+
+
+class TestTerminalConsistency:
+    """Hook classification, metrics, and the outcome block agree."""
+
+    @pytest.mark.parametrize("status,event", [
+        ("DONE", "asset_producer_done"),
+        ("PARTIAL", "asset_producer_partial"),
+        ("FAILED", "asset_producer_failed"),
+    ])
+    def test_status_classified_identically_everywhere(self, status, event):
+        _, _, parsed = stop(f"ap-{status}", producer_report(status))
+        assert not is_blocked(parsed)
+
+        stops = read_metrics("subagent_stop")
+        assert len(stops) == 1
+        assert stops[0]["report_type"] == "asset-producer"
+        assert stops[0]["status"] == status
+        assert stops[0]["outcome_kind"] == "terminal"
+        assert stops[0]["unit_id"] == "ui_kit"
+
+        outcomes = read_metrics(event)
+        assert len(outcomes) == 1
+        assert outcomes[0]["agent_id"] == f"ap-{status}"
+
+    def test_valid_partial_is_never_unknown(self):
+        """The upstream symptom: parent read PARTIAL, metrics wrote UNKNOWN."""
+        stop("ap-partial", producer_report("PARTIAL"))
+        record = read_metrics("subagent_stop")[0]
+        assert record["status"] == "PARTIAL"
+        assert record["report_type"] == "asset-producer"
+
+    def test_blockers_reach_the_persisted_record(self):
+        stop("ap-blocked", producer_report("FAILED", blockers=["provider quota exhausted"]))
+        assert read_metrics("subagent_stop")[0]["blockers"] == ["provider quota exhausted"]
+        assert read_metrics("asset_producer_failed")[0]["blockers"] == [
+            "provider quota exhausted"
+        ]
+
+
+class TestRejectedAttempt:
+    """A format rejection is an attempt, not a terminal outcome."""
+
+    def test_format_rejection_then_valid_retry(self):
+        rejected = producer_report("DONE", drop_section="### Handoff")
+        _, _, parsed = stop("ap-retry", rejected)
+        assert is_blocked(parsed), "missing heading must still fail closed"
+
+        _, _, parsed = stop("ap-retry", producer_report("DONE"))
+        assert not is_blocked(parsed)
+
+        stops = read_metrics("subagent_stop")
+        assert len(stops) == 2
+        assert stops[0]["outcome_kind"] == "rejected_attempt"
+        assert stops[1]["outcome_kind"] == "terminal"
+
+        terminal = [s for s in stops if s["outcome_kind"] == "terminal"]
+        assert len(terminal) == 1, "a retried run has exactly one terminal record"
+        assert len(read_metrics("asset_producer_done")) == 1
+
+    def test_rejected_attempt_is_still_classified_not_unknown(self):
+        """A rejected attempt keeps its identity, so it never reads as a failure."""
+        stop("ap-attempt", producer_report("DONE", drop_section="### Tools"))
+        record = read_metrics("subagent_stop")[0]
+        assert record["outcome_kind"] == "rejected_attempt"
+        assert record["report_type"] == "asset-producer"
+        assert record["status"] == "DONE"
+
+    def test_rejected_attempt_does_not_overwrite_the_final_result(self):
+        """A DONE attempt rejected on format must not pre-empt a PARTIAL retry."""
+        stop("ap-overwrite", producer_report("DONE", drop_section="### Validation"))
+        assert read_metrics("asset_producer_done") == []
+
+        stop("ap-overwrite", producer_report("PARTIAL"))
+        assert read_metrics("asset_producer_done") == []
+        partial = read_metrics("asset_producer_partial")
+        assert len(partial) == 1
+        assert partial[0]["blockers"]
+
+    def test_invalid_block_is_an_attempt_not_a_producer_failure(self):
+        message = producer_report("DONE").replace('"unit_id": "ui_kit"', '"unit_id": ""')
+        _, _, parsed = stop("ap-badblock", message)
+        assert is_blocked(parsed)
+        record = read_metrics("subagent_stop")[0]
+        assert record["outcome_kind"] == "rejected_attempt"
+        assert "unit_id" in record["outcome_error"]
+        assert read_metrics("asset_producer_failed") == []

--- a/tests/hooks/test_check_worker_report.py
+++ b/tests/hooks/test_check_worker_report.py
@@ -1,6 +1,9 @@
 """Tests for check_worker_report.py hook."""
 import pytest
-from .helpers import run_hook, is_blocked, cleanup_metrics, write_current_role
+from .helpers import (
+    run_hook, is_blocked, cleanup_metrics, write_current_role,
+    asset_producer_outcome,
+)
 
 HOOK = "check_worker_report.py"
 
@@ -38,7 +41,8 @@ COMPLETE_ASSET_PRODUCER = (
     "### Outputs\n- Sources: .godotmaker/asset-generation/sources/ui_source.png\n\n"
     "### Tools\n- python tools/asset_sheet_process.py --snap-mode autoslice\n\n"
     "### Validation\n- File existence: PASS\n\n"
-    "### Handoff\nUpdate ASSETS.md row ui_kit to generated."
+    "### Handoff\nUpdate ASSETS.md row ui_kit to generated.\n\n"
+    + asset_producer_outcome("DONE")
 )
 
 COMPLETE_ANALYST = (

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -187,9 +187,10 @@ def test_gm_asset_manager_reads_the_machine_outcome():
 
     # The hook's anti-deadloop escape hatch can release a report with no valid
     # block, so the manager may not assume the hook filtered those out.
-    assert "Confirm the block is there and well-formed yourself." in skill
+    assert 'declares `"report_type": "asset-producer"`' in skill
     assert "anti-deadloop escape hatch releases a subagent after repeated failures" in skill
-    assert "Such a report has no terminal status" in skill
+    assert "A block for any other role is not a producer handoff." in skill
+    assert "the report has no terminal status" in skill
     assert "register nothing from it" in skill
     assert "Do not infer a status from the prose to fill the gap." in skill
 

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -1,5 +1,11 @@
+import json
 import re
 from pathlib import Path
+
+from metrics.outcome import (
+    OUTCOME_VERSION, OUTCOME_VERSION_KEY, OUTPUT_CATEGORIES, TERMINAL_STATUSES,
+    TOP_LEVEL_KEYS, VALIDATION_LEVELS,
+)
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -140,6 +146,44 @@ def test_gm_asset_manager_dispatches_asset_producer_units():
     assert "Use only provider outputs or user-provided assets as raw visual sources." in producer
     assert "Do not create procedural, placeholder, or fallback images" in producer
     assert "leave affected stable entry drafts unwritten" in producer
+
+
+def test_asset_producer_outcome_template_matches_its_enforcer():
+    """The template the producer is told to emit is the one the hook accepts.
+
+    Bound field-by-field to `metrics/outcome.py`, not by token presence: a
+    template that drifts from the enforced key set is exactly how the hook,
+    metrics, and the manager ended up disagreeing on a terminal status.
+    """
+    producer = _read("agents/asset-producer.md")
+
+    assert "## Machine Outcome Rules" in producer
+    section = producer.split("### Machine Outcome", 1)[1]
+    template = re.search(r"```json\n(.*?)\n```", section, re.DOTALL)
+    assert template, "agents/asset-producer.md lost its machine outcome template"
+    payload = json.loads(template.group(1))
+
+    assert set(payload) == set(TOP_LEVEL_KEYS)
+    assert payload[OUTCOME_VERSION_KEY] == OUTCOME_VERSION
+    assert payload["report_type"] == "asset-producer"
+    assert payload["status"] == " | ".join(TERMINAL_STATUSES)
+    assert set(payload["outputs"]) == set(OUTPUT_CATEGORIES)
+    assert set(payload["validation"]["levels"]) == set(VALIDATION_LEVELS)
+    assert payload["blockers"] == []
+
+    # The cross-field rules the hook rejects on must be stated to the producer.
+    assert "`status` `DONE` requires `validation.passed` true" in producer
+    assert "requires at least one blocker" in producer
+
+
+def test_gm_asset_manager_reads_the_machine_outcome():
+    """The manager consumes the same block, not the prose beside it."""
+    skill = _flat(_read("skills/core/gm-asset/SKILL.md"))
+
+    assert f"the fenced JSON object carrying `{OUTCOME_VERSION_KEY}`" in skill
+    assert "Never re-read it from the markdown prose" in skill
+    assert "when the outcome block's `blockers` make the failure actionable" in skill
+    assert "A report the hook rejected is a rejected attempt, not a terminal result." in skill
 
 
 def test_first_class_asset_skills_are_the_only_entry_points():

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -181,9 +181,17 @@ def test_gm_asset_manager_reads_the_machine_outcome():
     skill = _flat(_read("skills/core/gm-asset/SKILL.md"))
 
     assert f"the fenced JSON object carrying `{OUTCOME_VERSION_KEY}`" in skill
-    assert "Never re-read it from the markdown prose" in skill
+    assert "Never read it from the markdown prose" in skill
     assert "when the outcome block's `blockers` make the failure actionable" in skill
     assert "A report the hook rejected is a rejected attempt, not a terminal result." in skill
+
+    # The hook's anti-deadloop escape hatch can release a report with no valid
+    # block, so the manager may not assume the hook filtered those out.
+    assert "Confirm the block is there and well-formed yourself." in skill
+    assert "anti-deadloop escape hatch releases a subagent after repeated failures" in skill
+    assert "Such a report has no terminal status" in skill
+    assert "register nothing from it" in skill
+    assert "Do not infer a status from the prose to fill the gap." in skill
 
 
 def test_first_class_asset_skills_are_the_only_entry_points():

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -172,8 +172,9 @@ def test_asset_producer_outcome_template_matches_its_enforcer():
     assert payload["blockers"] == []
 
     # The cross-field rules the hook rejects on must be stated to the producer.
-    assert "`status` `DONE` requires `validation.passed` true" in producer
-    assert "requires at least one blocker" in producer
+    assert "Use `status` `DONE` only with `validation.passed` true" in producer
+    assert "write at least one blocker" in producer
+    assert "Set `report_type` to `asset-producer`." in producer
 
 
 def test_gm_asset_manager_reads_the_machine_outcome():
@@ -181,18 +182,15 @@ def test_gm_asset_manager_reads_the_machine_outcome():
     skill = _flat(_read("skills/core/gm-asset/SKILL.md"))
 
     assert f"the fenced JSON object carrying `{OUTCOME_VERSION_KEY}`" in skill
-    assert "Never read it from the markdown prose" in skill
+    assert "Do not take the status from the markdown prose." in skill
     assert "when the outcome block's `blockers` make the failure actionable" in skill
-    assert "A report the hook rejected is a rejected attempt, not a terminal result." in skill
 
-    # The hook's anti-deadloop escape hatch can release a report with no valid
-    # block, so the manager may not assume the hook filtered those out.
-    assert 'declares `"report_type": "asset-producer"`' in skill
-    assert "anti-deadloop escape hatch releases a subagent after repeated failures" in skill
-    assert "A block for any other role is not a producer handoff." in skill
-    assert "the report has no terminal status" in skill
-    assert "register nothing from it" in skill
-    assert "Do not infer a status from the prose to fill the gap." in skill
+    # The manager verifies the block itself rather than assuming the hook
+    # filtered every invalid one out.
+    assert "Confirm the block is present, well-formed, and declares" in skill
+    assert '`"report_type": "asset-producer"`' in skill
+    assert "without one, register nothing from that report" in skill
+    assert "re-dispatch the production unit once or report it as blocked" in skill
 
 
 def test_first_class_asset_skills_are_the_only_entry_points():


### PR DESCRIPTION
## Summary

Unify asset-producer terminal outcomes around a validated, machine-readable report block so hooks, metrics, and the asset-stage handoff consume the same status and blockers.

## Motivation

Fixes #156

## Changes

- [x] Add shared outcome parsing, normalization, validation, and runtime-role binding.
- [x] Record rejected and unverified attempts separately from verified terminal outcomes.
- [x] Update the asset-producer and asset-stage guidance, hook documentation, release note, and regression coverage.

## Testing

- [x] New or updated tests pass (`python -m pytest` — 2342 passed, 7 skipped).
- [x] Gitleaks passes or no secret-bearing files were touched (no secret-bearing files were added; repository CI verification is pending).
- [x] Manual testing complete, if applicable (exercised rejected retries, force-allow handling, role mismatches, and all three terminal statuses).

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] **Not performance-sensitive**
- [ ] **Performance-sensitive**; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable: this change is not performance-sensitive.
```

</details>

## Version Compatibility

Does this PR change behaviors, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
