### PR TITLE
fix: seal asset no-work resume

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -86,6 +86,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Ensure `/gm-asset` records an asset-stage completion event when its resume check finds no current-tag work.
+
 - A validated background-map now registers as a ready `single -> Texture2D` stable entry through its own finalize builder, instead of stopping at `source_ready` with no way to reach a worker; registration binds to the image bytes its L0-L4 run recorded, so regenerating onto the same stable path fails closed.
 
 - An asset production unit now ends the asset stage with one consistent status, so a retried report no longer reads as a failure and a partial result keeps its blockers instead of being recorded as unknown.

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -38,7 +38,13 @@ Proceed when either check has current-tag work:
 2. Current-tag scene references whose `references/scene_{name}.png` or report
    is missing or stale against `SCENES.md` and the Visual Asset Contract.
 
-If both checks are empty, stop with:
+If both checks are empty, record the completed asset stage before stopping:
+
+```bash
+python tools/append_stage_event.py asset
+```
+
+Then stop with:
 
 ```text
 No MISSING assets and no missing scene references for the current tag. Recommended next: /gm-build.

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -148,6 +148,16 @@ def test_gm_asset_manager_dispatches_asset_producer_units():
     assert "leave affected stable entry drafts unwritten" in producer
 
 
+def test_asset_no_work_resume_check_writes_the_asset_stage_event():
+    skill = _read("skills/core/gm-asset/SKILL.md")
+    resume_check = skill[skill.index("## Resume Check"):skill.index("## Manager Rules")]
+
+    assert "python tools/append_stage_event.py asset" in resume_check
+    assert resume_check.index("python tools/append_stage_event.py asset") < resume_check.index(
+        "No MISSING assets and no missing scene references for the current tag."
+    )
+
+
 def test_asset_producer_outcome_template_matches_its_enforcer():
     """The template the producer is told to emit is the one the hook accepts.
 


### PR DESCRIPTION
## Summary

Make `/gm-asset` record the existing `asset` stage event when its Resume Check finds no current-tag work.

## Motivation

The no-work STOP path previously had the same external shape as a blocked or partial asset run: successful process exit with no new stage event.

## Changes

- [x] Record the existing asset stage event before the no-work STOP message.
- [x] Add a contract test that pins the event command and its required ordering.

## Testing

- [x] New or updated tests pass (`python -m pytest tests/test_asset_runtime_contract_docs.py -q`)
- [x] Gitleaks passes or no secret-bearing files were touched (no secret-bearing files touched)
- [x] Manual testing completed, if applicable (the published skill contract is covered by the ordering assertion)

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

The change uses the existing stage-event format and requires no migration.

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
