### PR TITLE
Fix reference asset output registration

### DIFF
--- a/docs/wiki/05-tools/asset-tools.md
+++ b/docs/wiki/05-tools/asset-tools.md
@@ -14,17 +14,20 @@ python tools/asset_result_registration.py --assets-md ASSETS.md --tag <tag> \
   --request <request.json> --result <result.json> --godot-path <godot_path>
 ```
 
-The request owns the output set. `scene-prop-set` and `compact-prop-pack` use
-their fixed `spec.slots`; `platform-strip` uses its `spec.segments` and selected
-`spec.kind`; `ui-kit` and `card-kit` use their `styleboxes`, `atlas_regions`,
-and optional `theme`. Other multi-output families use `spec.outputs`, where
-each item has `name`, `role` (`runtime` or `reference`), and, for runtime
-assets, the final `godot_type`. The command rejects missing, duplicate, extra,
-role-mismatched, or type-mismatched outputs before it writes any row. Runtime
-files must be project-local, present, loadable by Godot, and match their
-declared type.
+The request owns the runtime output set. `scene-prop-set` and
+`compact-prop-pack` use their fixed `spec.slots`; `platform-strip` uses
+`spec.segments` and its selected `spec.kind`; `ui-kit` and `card-kit` use their
+`styleboxes`, `atlas_regions`, and optional `theme`. Other runtime families
+derive their single runtime output from the request. They do not accept a
+parallel `spec.outputs` declaration. The command rejects missing, duplicate,
+extra, role-mismatched, or type-mismatched runtime outputs before it writes any
+row. Runtime files must be project-local, present, loadable by Godot, and match
+their declared type.
 
-Reference outputs become `source_ready` and never enter worker handoff.
+Reference outputs returned by runtime families are validated source evidence,
+not catalog rows. Only reference-only families such as `screen-reference`
+register a `source_ready` row; their reference path is project-relative (for
+example `references/title_screen.png`) and never enters worker handoff.
 
 ## Worker snapshot
 

--- a/docs/zh/wiki/05-tools/asset-tools.md
+++ b/docs/zh/wiki/05-tools/asset-tools.md
@@ -17,15 +17,17 @@ python tools/asset_result_registration.py --assets-md ASSETS.md --tag <tag> \
   --request <request.json> --result <result.json> --godot-path <godot_path>
 ```
 
-request 决定输出集合。`scene-prop-set` 和 `compact-prop-pack` 使用固定的
-`spec.slots`；`platform-strip` 使用 `spec.segments` 和选定的 `spec.kind`；
-`ui-kit` 与 `card-kit` 使用其 `styleboxes`、`atlas_regions` 和可选的 `theme`。
-其他多输出 family 才在 `spec.outputs` 中列出每一项的 `name`、`role`（`runtime`
-或 `reference`），以及 runtime 输出的最终 `godot_type`。写入前会拒绝缺少、
-重复、额外、角色不匹配或类型不匹配的输出。runtime 文件还必须位于项目内、
-确实存在、能被 Godot 加载，且实际类型匹配声明。
+request 决定 runtime 输出集合。`scene-prop-set` 和 `compact-prop-pack` 使用
+固定的 `spec.slots`；`platform-strip` 使用 `spec.segments` 和选定的
+`spec.kind`；`ui-kit` 与 `card-kit` 使用其 `styleboxes`、`atlas_regions` 和可选的
+`theme`。其他 runtime family 从 request 推导唯一 runtime 输出，不接受并行的
+`spec.outputs` 声明。写入前会拒绝缺少、重复、额外、角色不匹配或类型不匹配的
+runtime 输出。runtime 文件还必须位于项目内、确实存在、能被 Godot 加载，且实际
+类型匹配声明。
 
-reference 输出会变为 `source_ready`，不会进入 worker 的 runtime handoff。
+runtime family 返回的 reference 输出是已验证的源证据，不是目录行。只有
+`screen-reference` 等 reference-only family 会登记 `source_ready` 行；其路径为
+项目相对路径（例如 `references/title_screen.png`），不会进入 worker runtime handoff。
 
 ## 读取 worker snapshot
 

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -208,7 +208,7 @@ One production unit may return many outputs. Register all runtime outputs togeth
 
 - Validate the generic result with `tools/asset_skill_contract_check.py`.
 - On a failed validation, report the failure and do not register it.
-- On success, retain sources and evidence in the producer report and send only the request/result to direct registration. Each runtime output needs a named logical asset row; reference outputs remain non-runtime.
+- On success, retain sources and evidence in the producer report and send only the request/result to direct registration. Each runtime output needs a named logical asset row. For runtime families, reference outputs are validated evidence only and are not registered; only reference-only families register a `source_ready` reference row.
 - The manager consumes the validated result directly. It never reads or writes registration drafts, manifests, or family-specific adapter state.
 ### Provider
 - {references/providers/<provider>.md}
@@ -263,8 +263,10 @@ python tools/asset_result_registration.py --assets-md ASSETS.md --tag <tag> \
 ```
 
    Missing, duplicated, unexpected, out-of-project, missing, unloadable, or
-   wrong-type outputs fail closed and leave all rows unchanged. A `reference`
-   output becomes `source_ready` and is never a worker runtime asset.
+   wrong-type runtime outputs fail closed and leave all rows unchanged. Runtime-family
+   reference outputs remain validated evidence and do not create rows; a
+   reference-only family output becomes `source_ready` and is never a worker
+   runtime asset.
 
 4. Do not create stable entries, manifest pointers, root indexes, bundle
    manifests, or family-specific entry drafts. Do not use an anchor output for
@@ -276,9 +278,10 @@ python tools/asset_result_registration.py --assets-md ASSETS.md --tag <tag> \
 
 For current-tag rows only, use the result-registration command above. Runtime
 rows are complete only with `Status: generated`, an explicit Runtime Type, and
-a final loadable Runtime Path. Reference/source-only rows use
+a final loadable Runtime Path. Only reference-only family rows use
 `Runtime Type: reference` and `Status: source_ready`; they never enter a worker
-snapshot. `Generation Params` may retain production inputs and evidence links,
+snapshot. Reference outputs returned by runtime families remain result evidence,
+not rows. `Generation Params` may retain production inputs and evidence links,
 but never runtime metadata or a manifest pointer.
 
 ## Plan Discipline
@@ -295,8 +298,9 @@ or leave a fix task for a later role.
 ## Completion
 
 Runtime rows are complete at `generated` only after direct registration.
-Reference-only rows complete at `source_ready`. If any output cannot be
-validated, report the failing production unit and leave its rows unchanged.
+Reference-only rows complete at `source_ready`; runtime-family reference outputs
+remain result evidence. If any output cannot be validated, report the failing
+production unit and leave its rows unchanged.
 
 After ASSETS.md has no current-tag `MISSING` rows except deferred audio:
 

--- a/skills/core/gm-asset/references/asset-result-registration.md
+++ b/skills/core/gm-asset/references/asset-result-registration.md
@@ -13,9 +13,12 @@ Runtime Path must describe the final resource a worker loads. A PNG is valid
 for `Texture2D`; `AtlasTexture`, `SpriteFrames`, `Theme`,
 `StyleBoxTexture`, and `TileSet` must use their final native resource path.
 
-`reference` outputs are source/reference evidence, not runtime assets. They
-use Runtime Type `reference`, finish as `source_ready`, and are excluded from
-all worker snapshots.
+For runtime families, `reference` outputs are already-validated source or
+canonical evidence: they do not create a logical row, enter the registration
+comparison set, or appear in worker snapshots. A reference-only family such as
+`screen-reference` registers its one reference output with Runtime Type
+`reference` and Status `source_ready`; its path is a project-local relative
+path such as `references/title_screen.png`, not `res://`.
 
 ## Atomic registration
 
@@ -28,9 +31,10 @@ python tools/asset_result_registration.py --assets-md ASSETS.md --tag <tag> \
 ```
 
 The command fails before changing `ASSETS.md` if the declared and returned
-logical output sets differ, an output is duplicated or unknown, a path escapes
-the project or does not exist, or Godot cannot load the resource as its stated
-type. It never writes only a subset of a multi-output production unit.
+runtime logical output sets differ, a runtime output is duplicated or unknown,
+a path escapes the project or does not exist, or Godot cannot load a runtime
+resource as its stated type. It never writes only a subset of a multi-output
+production unit.
 
 ## Worker handoff
 

--- a/tests/tools/test_asset_result_registration.py
+++ b/tests/tools/test_asset_result_registration.py
@@ -159,7 +159,7 @@ def test_reference_row_completes_without_entering_worker_runtime_snapshot(tmp_pa
         json.dumps(
             {
                 "asset_type": "screen-reference",
-                "outputs": [{"role": "reference", "name": "screen_ref", "path": "res://references/screen_ref.png"}],
+                "outputs": [{"role": "reference", "name": "screen_ref", "path": "references/screen_ref.png"}],
                 "sources": [],
                 "previews": [],
                 "validation": {"passed": True},
@@ -175,9 +175,47 @@ def test_reference_row_completes_without_entering_worker_runtime_snapshot(tmp_pa
 
     register_result(assets_md, result, tag=TAG, request_path=request, loader=_loader)
 
-    assert "| reference | res://references/screen_ref.png | source_ready |" in assets_md.read_text(encoding="utf-8")
+    assert "| reference | references/screen_ref.png | source_ready |" in assets_md.read_text(encoding="utf-8")
     with pytest.raises(AssetResultRegistrationError, match="expected generated"):
         runtime_snapshot(assets_md, tag=TAG, asset_ids=["screen_ref"])
+
+
+@pytest.mark.parametrize(
+    ("reference_path", "error"),
+    [
+        ("res://references/screen_ref.png", "project-local relative path"),
+        ("../outside.png", "resolves outside the project"),
+    ],
+)
+def test_reference_only_registration_rejects_nonlocal_paths(tmp_path, reference_path, error):
+    assets_md = tmp_path / "ASSETS.md"
+    _assets_md(assets_md, ["screen_ref"])
+    result = tmp_path / "reference-result.json"
+    result.write_text(
+        json.dumps(
+            {
+                "asset_type": "screen-reference",
+                "outputs": [
+                    {"role": "reference", "name": "screen_ref", "path": reference_path}
+                ],
+                "sources": [],
+                "previews": [],
+                "validation": {"passed": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    request = tmp_path / "request.json"
+    request.write_text(
+        json.dumps({"asset_type": "screen-reference", "asset_id": "screen_ref", "brief": "reference"}),
+        encoding="utf-8",
+    )
+    original = assets_md.read_text(encoding="utf-8")
+
+    with pytest.raises(AssetResultRegistrationError, match=error):
+        register_result(assets_md, result, tag=TAG, request_path=request, loader=_loader)
+
+    assert assets_md.read_text(encoding="utf-8") == original
 
 
 def test_missing_runtime_file_or_failed_godot_check_keeps_the_whole_unit_missing(tmp_path):
@@ -471,3 +509,163 @@ def test_variant_contract_rejects_a_sibling_variants_godot_type(
         register_result(assets_md, result, tag=TAG, request_path=request, loader=lambda *_: None)
 
     assert assets_md.read_text(encoding="utf-8") == original
+
+
+@pytest.mark.parametrize(
+    ("family", "spec", "runtime_outputs"),
+    [
+        (
+            "scene-prop-set",
+            {
+                "version": 1,
+                "atlas": {"width": 16, "height": 16},
+                "slots": [{"name": "prop", "rect": [0, 0, 16, 16], "source": "source.png"}],
+            },
+            [("prop", "AtlasTexture")],
+        ),
+        (
+            "compact-prop-pack",
+            {"slots": [{"name": "prop"}]},
+            [("prop", "AtlasTexture")],
+        ),
+        (
+            "platform-strip",
+            {"kind": "single", "segments": [{"name": "platform"}]},
+            [("platform", "Texture2D")],
+        ),
+        ("fx-bundle", {"mode": "animated"}, [("effect", "SpriteFrames")]),
+        ("tileset", {}, [("tiles", "TileSet")]),
+        (
+            "ui-kit",
+            {
+                "styleboxes": [{"output_name": "panel"}],
+                "atlas_regions": [{"output_name": "icon"}],
+                "theme": None,
+            },
+            [("panel", "StyleBoxTexture"), ("icon", "AtlasTexture")],
+        ),
+        (
+            "card-kit",
+            {
+                "styleboxes": [{"output_name": "card"}],
+                "atlas_regions": [{"output_name": "badge"}],
+                "theme": None,
+            },
+            [("card", "StyleBoxTexture"), ("badge", "AtlasTexture")],
+        ),
+    ],
+)
+def test_runtime_family_reference_outputs_are_evidence_not_registration_rows(
+    tmp_path, family, spec, runtime_outputs
+):
+    assets_md = tmp_path / "ASSETS.md"
+    names = [name for name, _ in runtime_outputs]
+    _assets_md(assets_md, names)
+    request = tmp_path / "request.json"
+    request.write_text(
+        json.dumps(
+            {
+                "asset_type": family,
+                "asset_id": names[0],
+                "brief": "runtime asset with validated reference evidence",
+                "spec": spec,
+            }
+        ),
+        encoding="utf-8",
+    )
+    outputs = []
+    for name, godot_type in runtime_outputs:
+        artifact = tmp_path / "assets" / "generated" / family / f"{name}.tres"
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_bytes(b"artifact")
+        outputs.append(
+            {
+                "role": "runtime",
+                "name": name,
+                "path": "res://" + artifact.relative_to(tmp_path).as_posix(),
+                "godot_type": godot_type,
+            }
+        )
+    outputs.append(
+        {"role": "reference", "name": "canonical", "path": "references/evidence.png"}
+    )
+    result = tmp_path / "result.json"
+    result.write_text(
+        json.dumps(
+            {
+                "asset_type": family,
+                "outputs": outputs,
+                "sources": [],
+                "previews": [],
+                "validation": {"passed": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    registered = register_result(
+        assets_md, result, tag=TAG, request_path=request, loader=lambda *_: None
+    )
+
+    assert registered["updated"] == names
+    text = assets_md.read_text(encoding="utf-8")
+    assert "canonical" not in text
+    assert all("| generated |" in line for line in text.splitlines() if "| prop |" in line)
+
+
+@pytest.mark.parametrize("user_canonical", [True, False])
+def test_character_bundle_registers_with_user_or_generated_canonical_evidence(
+    tmp_path, user_canonical
+):
+    asset_id = "hero"
+    assets_md = tmp_path / "ASSETS.md"
+    _assets_md(assets_md, [asset_id])
+    runtime = tmp_path / "assets" / "generated" / "character-bundle" / "hero.tres"
+    runtime.parent.mkdir(parents=True)
+    runtime.write_bytes(b"sprite frames")
+    request_data = {
+        "asset_type": "character-bundle",
+        "asset_id": asset_id,
+        "brief": "hero actions",
+    }
+    if user_canonical:
+        request_data["references"] = [
+            {"role": "canonical", "path": "references/hero.png"}
+        ]
+    request = tmp_path / "request.json"
+    request.write_text(json.dumps(request_data), encoding="utf-8")
+    outputs = [
+        {
+            "role": "runtime",
+            "path": "res://" + runtime.relative_to(tmp_path).as_posix(),
+            "godot_type": "SpriteFrames",
+        }
+    ]
+    if not user_canonical:
+        outputs.append(
+            {
+                "role": "reference",
+                "name": "canonical",
+                "path": "assets/generated/character-bundle/hero/hero_canonical.png",
+            }
+        )
+    result = tmp_path / "result.json"
+    result.write_text(
+        json.dumps(
+            {
+                "asset_type": "character-bundle",
+                "outputs": outputs,
+                "sources": [],
+                "previews": [],
+                "validation": {"passed": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    registered = register_result(
+        assets_md, result, tag=TAG, request_path=request, loader=lambda *_: None
+    )
+
+    assert registered["updated"] == [asset_id]
+    assert "canonical" not in assets_md.read_text(encoding="utf-8")

--- a/tools/asset_result_registration.py
+++ b/tools/asset_result_registration.py
@@ -23,7 +23,7 @@ from asset_build_record import (
     read_validation_record,
 )
 from asset_skill_contract_check import AssetContractError, check_request, check_result
-from asset_family_registry import FamilyRegistryError, variant_for_request
+from asset_family_registry import FamilyRegistryError, spec as family_spec, variant_for_request
 
 
 RUNTIME_STATUS = "generated"
@@ -91,6 +91,30 @@ def _res_to_file(project_root: Path, resource_path: str) -> Path:
     return candidate
 
 
+def _reference_to_file(project_root: Path, reference_path: str) -> Path:
+    """Resolve a reference-only result path without treating it as ``res://``."""
+    if (
+        not isinstance(reference_path, str)
+        or not reference_path
+        or reference_path.startswith("res://")
+        or Path(reference_path).is_absolute()
+    ):
+        raise AssetResultRegistrationError(
+            "reference path must be a project-local relative path: "
+            f"{reference_path!r}"
+        )
+    candidate = (project_root / reference_path).resolve()
+    try:
+        candidate.relative_to(project_root.resolve())
+    except ValueError as exc:
+        raise AssetResultRegistrationError(
+            f"reference path resolves outside the project: {reference_path}"
+        ) from exc
+    if not candidate.is_file():
+        raise AssetResultRegistrationError(f"reference file is missing: {reference_path}")
+    return candidate
+
+
 def _logical_id(output: dict[str, Any], *, single: bool, request_asset_id: str | None) -> str:
     name = output.get("name")
     if isinstance(name, str) and name.strip():
@@ -122,7 +146,19 @@ def _asset_outputs(
     if result["validation"].get("passed") is not True:
         raise AssetResultRegistrationError("Asset Skill result validation did not pass")
 
-    outputs = result["outputs"]
+    try:
+        reference_only = family_spec(result["asset_type"]).is_reference_only
+    except FamilyRegistryError as exc:
+        raise AssetResultRegistrationError(str(exc)) from exc
+
+    # Runtime-family reference outputs are validated production evidence, not
+    # logical assets. Reference-only families (currently screen-reference)
+    # retain their reference output because it is the asset being registered.
+    outputs = [
+        output
+        for output in result["outputs"]
+        if output["role"] == "runtime" or reference_only
+    ]
     records: dict[str, dict[str, str]] = {}
     for output in outputs:
         logical_id = _logical_id(
@@ -481,7 +517,6 @@ def register_result(
     _assert_validation_record_matches(project_root, request, outputs)
 
     for logical_id, output in outputs.items():
-        _res_to_file(project_root, output["path"])
         index, cells = matches[logical_id]
         if cells[columns["Status"]] not in {"MISSING", RUNTIME_STATUS, REFERENCE_STATUS}:
             raise AssetResultRegistrationError(
@@ -489,6 +524,7 @@ def register_result(
                 f"{cells[columns['Status']]!r}"
             )
         if output["role"] == "runtime":
+            _res_to_file(project_root, output["path"])
             if loader is not None:
                 loader(project_root, output["path"], output["type"])
             elif godot_path is None:
@@ -497,6 +533,8 @@ def register_result(
                 )
             else:
                 _godot_loader(godot_path, project_root, output["path"], output["type"])
+        else:
+            _reference_to_file(project_root, output["path"])
 
     rewritten = list(lines)
     updated: list[str] = []


### PR DESCRIPTION
## Summary

Fix reference-output registration semantics for asset results.

## Motivation

Runtime-family reference outputs are validated as evidence but no longer participate in runtime output registration. The reference-only screen-reference family retains registration with safe project-relative paths.

## Changes

- Register only runtime outputs for runtime families; retain reference outputs as validated evidence.
- Register screen-reference with safe project-relative paths and `source_ready` status.
- Add regression coverage for runtime families, character canonical paths, and reference path validation.

## Testing

- [x] New or updated tests pass: targeted Python regression suite passed (317 passed, 59 skipped).
- [x] Gitleaks passes or no secret-bearing files were touched: CI Secret Scan passed.
- [x] Manual testing complete, if applicable: not applicable; this change is covered by contract and path-validation tests.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive.
- [ ] Performance-sensitive; benchmark results are attached below or linked.

<details>
<summary>Benchmark Results</summary>

Not applicable.

</details>

## Version Compatibility

This PR corrects registration behavior without changing a release compatibility contract or adding migrations.

- [x] **No** - no migration needed.
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

## Migration Upgrade Gate

Not applicable: no migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [x] Result attached or summarized below: no migration is included.

## Checklist

- [x] Code follows project conventions: CI Python lint passed.
- [x] ECS systems declare proper read/write metadata, if applicable: not applicable; no ECS systems are changed.
- [x] No hardcoded secrets or API keys: CI Secret Scan passed.
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR: maintenance-only contract and documentation correction; the affected wiki and skill documentation are updated.
