### PR TITLE
Fix asset seal contract

### DIFF
--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -35,11 +35,16 @@ Stop when any required input is missing:
 
 Proceed when either check has current-tag work:
 
-1. Current-tag Asset Table rows with status `MISSING`.
+1. Any current-tag `ASSETS.md` row, including an Audio table row, with status
+   `MISSING`. Under Manager Rule 9, mark unavailable audio rows `deferred`
+   before considering the no-work path; only explicitly deferred audio is
+   exempt from this check.
 2. Current-tag scene references whose `references/scene_{name}.png` or report
    is missing or stale against `SCENES.md` and the Visual Asset Contract.
 
-If both checks are empty, record the completed asset stage before stopping:
+If neither check has work — no current-tag row is `MISSING`, unavailable audio
+is explicitly `deferred`, and all current-tag scene references are current —
+record the completed asset stage before stopping:
 
 ```bash
 python tools/append_stage_event.py asset
@@ -302,7 +307,8 @@ Reference-only rows complete at `source_ready`; runtime-family reference outputs
 remain result evidence. If any output cannot be validated, report the failing
 production unit and leave its rows unchanged.
 
-After ASSETS.md has no current-tag `MISSING` rows except deferred audio:
+After ASSETS.md has no current-tag `MISSING` rows and all unavailable
+current-tag audio rows are explicitly `deferred`:
 
 1. From the project root run:
 

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -17,6 +17,10 @@ declaration.
 4. Keep one multi-output family invocation together. Do not infer its members
    from `ASSETS.md` or from a result after generation.
 5. Dispatch independent units in batches of at most three.
+6. Plan Asset Table rows only for registered logical outputs. For a runtime
+   family, each row name must match a declared runtime output name. Canonical
+   images, action sheets, source grids, and other provenance remain in the
+   request, result, and reports; do not plan them as rows.
 
 ## Visual anchors
 

--- a/skills/core/gm-gdd/SKILL.md
+++ b/skills/core/gm-gdd/SKILL.md
@@ -243,7 +243,8 @@ The decomposer overwrites root `PLAN.md`, `STRUCTURE.md`, `SCENES.md` with the c
 - [ ] `ASSETS.md` exists and any new rows are tagged correctly (per `templates/ASSETS.md` and `gm-asset/SKILL.md`)
 - [ ] `ASSETS.md` Visual Asset Contract covers current-tag gameplay-visible objects with runtime size, scene/mechanic use, readability requirement, and source relationship
 - [ ] `ASSETS.md` applies the Gameplay Actor Asset Rows contract to gameplay
-      actors introduced or changed in this tag
+      actors introduced or changed in this tag: only final runtime outputs are
+      rows; canonical and action-source material remains production evidence
 - [ ] `ASSETS.md` Visual Asset Contract binds large character UI display slots
       to portrait/display rows instead of gameplay runtime frame rows
 - [ ] `ASSETS.md` Visual Asset Contract gives every current-tag gameplay actor

--- a/templates/ASSETS.md
+++ b/templates/ASSETS.md
@@ -13,24 +13,29 @@
 ## Visual Style Source
 
 Initial visual seed text lives in `STYLE.md`. Generated scene references,
-canonical asset references, and manifest source relationships are the primary
-style anchors after they exist.
+character-bundle identity anchors, and manifest source relationships are the
+primary style anchors after they exist.
 
 ## Gameplay Actor Asset Rows
 
 For current-tag gameplay actors:
 
-1. Add a `character_canonical` row for the canonical full-body reference.
-2. Add one or more `character_action_source` rows for action sheets derived
-   from the canonical reference.
-3. Add one or more `character_frame_output` rows for processed runtime frames
-   or grid sheets.
-4. Add `character_portrait` rows when a current-tag character appears in a
+1. Add one runtime row for the actor's final `character-bundle`
+   `SpriteFrames` output (for example, `player_animation_runtime`). The row
+   name must exactly match the character-bundle request's `asset_id` and
+   runtime output name so direct registration can complete it.
+2. Keep canonical images, action sheets, source grids, and curation details in
+   the character-bundle request, result, and reports. They are provenance and
+   production evidence, not Asset Table rows.
+3. Add portrait rows when a current-tag character appears in a
    large UI display slot.
-5. Bind gameplay runtime rows and UI display rows separately in the Visual
+   Portrait rows use the supported `background-map` family and its runtime
+   path convention.
+4. Bind gameplay runtime rows and UI display rows separately in the Visual
    Asset Contract.
-6. Set action names from current-tag gameplay behavior and artifact mappings.
-7. Use static single-image rows only for explicitly static, non-gameplay,
+5. Set character-bundle action names from current-tag gameplay behavior and
+   artifact mappings.
+6. Use static single-image rows only for explicitly static, non-gameplay,
    UI-only, locked-preview, statue, or abstract-token roles.
 
 ## Asset Table
@@ -39,17 +44,17 @@ For current-tag gameplay actors:
      `Tag` is the tag that introduced the asset. A row is one logical asset.
      Runtime Type and Runtime Path are the sole worker handoff: they must name
      the final loadable Godot resource, never a source sheet, atlas, candidate,
-     report, or manifest pointer. Reference/source-only rows use Runtime Type
-     `reference`, complete as `source_ready`, and never enter a runtime snapshot. -->
+     report, or manifest pointer. Reference-only rows use Runtime Type
+     `reference`, complete as `source_ready`, and never enter a runtime snapshot.
+     Runtime-family source and reference outputs remain result evidence, not
+     additional rows. -->
 
 | # | Tag | Name | Type | Size | Generation Params | Runtime Type | Runtime Path | Status |
 |---|-----|------|------|------|-------------------|--------------|--------------|--------|
-| 1 | v0.1.0 | player_canonical | reference | full body | family=character_canonical; role=player | reference | res://references/characters/player_canonical.png | MISSING |
-| 2 | v0.1.0 | player_action_source | source-only | action set | family=character_action_source; derived_from=player_canonical; actions=from_current_tag_behavior | reference | res://.godotmaker/asset-generation/sources/player_actions.png | MISSING |
-| 3 | v0.1.0 | player_animation_runtime | animation | frame output | family=character-bundle; derived_from=player_action_source | SpriteFrames | res://assets/generated/character-bundle/player_animation_runtime/player_animation_runtime.tres | MISSING |
-| 4 | v0.1.0 | player_portrait | portrait | 256x256 px | family=background-map; role=player; derived_from=player_canonical | Texture2D | res://assets/generated/character-bundle/player_portrait/player_portrait.png | MISSING |
-| 5 | v0.1.0 | action_button | ui | 96x48 px | family=ui-kit; component=button | Theme | res://assets/generated/ui-kit/action_button/action_button.tres | MISSING |
-| 6 | v0.1.0 | background_sky | background | 1280x720 | family=background-map | Texture2D | res://assets/generated/background-map/background_sky/background_sky.png | MISSING |
+| 1 | v0.1.0 | player_animation_runtime | animation | frame output | family=character-bundle; actions=from_current_tag_behavior | SpriteFrames | res://assets/generated/character-bundle/player_animation_runtime/player_animation_runtime.tres | MISSING |
+| 2 | v0.1.0 | player_portrait | portrait | 256x256 px | family=background-map; role=player; source=character-bundle identity anchor | Texture2D | res://assets/generated/background-map/player_portrait/player_portrait.png | MISSING |
+| 3 | v0.1.0 | action_button | ui | 96x48 px | family=ui-kit; component=button | Theme | res://assets/generated/ui-kit/action_button/action_button.tres | MISSING |
+| 4 | v0.1.0 | background_sky | background | 1280x720 | family=background-map | Texture2D | res://assets/generated/background-map/background_sky/background_sky.png | MISSING |
 | ... | ... | ... | ... | ... | ... | ... | ... | ... |
 
 ## Visual Asset Contract
@@ -64,38 +69,38 @@ For current-tag gameplay actors:
 
 | Tag | Scene / Mechanic | Visible Object | Asset Row / Path | Runtime Size | Visual Role | Readability Requirement | Source |
 |-----|------------------|----------------|------------------|--------------|-------------|-------------------------|--------|
-| v0.1.0 | Gameplay / [v0.1.0-M1] | player character | player_animation_runtime / assets/generated/character-bundle/player_animation_runtime/player_animation_runtime.png | 8% viewport height / 58px tall at 1280x720 | controllable player | readable silhouette and current-tag actions visible in frame sequences | derived from player_canonical |
-| v0.1.0 | Character Select | player portrait | player_portrait / assets/generated/character-bundle/player_portrait/player_portrait.png | 140x140 px card slot | selectable character identity | readable in UI slots larger than gameplay runtime frames | derived from player_canonical |
+| v0.1.0 | Gameplay / [v0.1.0-M1] | player character | player_animation_runtime / assets/generated/character-bundle/player_animation_runtime/player_animation_runtime.tres | 8% viewport height / 58px tall at 1280x720 | controllable player | readable silhouette and current-tag actions visible in frame sequences | derived from character-bundle identity anchor |
+| v0.1.0 | Character Select | player portrait | player_portrait / assets/generated/background-map/player_portrait/player_portrait.png | 140x140 px card slot | selectable character identity | readable in UI slots larger than gameplay runtime frames | derived from character-bundle identity anchor |
 | v0.1.0 | Main Menu | title text | UI text | viewport-relative | menu identity | readable at target resolution | procedural/UI |
-| v0.1.0 | HUD / [v0.1.0-M1] | action button | action_button / assets/generated/ui-kit/action_button/action_button.png | 96x48 px target | HUD control | readable touch target at target resolution | derived from UI component sheet |
+| v0.1.0 | HUD / [v0.1.0-M1] | action button | action_button / assets/generated/ui-kit/action_button/action_button.tres | 96x48 px target | HUD control | readable touch target at target resolution | derived from UI component sheet |
 
 ## 2D Animation Sources
 
 <!-- Source sheets and selected runtime outputs for animated 2D assets. -->
 
-### player_action_source (tag: v0.1.0)
-- **Family:** character_action_source
-- **Output:** assets/generated/character-bundle/player_animation_runtime/player_animation_runtime.png
-- **Derived from:** player_canonical
+### player_animation_runtime (tag: v0.1.0)
+- **Family:** character-bundle
+- **Output:** assets/generated/character-bundle/player_animation_runtime/player_animation_runtime.tres
+- **Identity anchor:** retained in character-bundle result evidence
 - **Actions:** current-tag player behavior
 - **Frames:** per action metadata
 - **FPS:** 8
 - **Loop:** per action metadata
 - **Curation report:** .godotmaker/asset-generation/curation/player_actions.json
 - **Selected candidate:** accepted character action sheet
-- **Processing status:** ready
+- **Curation state:** ready
 
-### {action_source_name} (tag: vX.Y.Z)
-- **Family:** character_action_source
+### {animation_runtime_name} (tag: vX.Y.Z)
+- **Family:** character-bundle
 - **Output:** ...
-- **Derived from:** ...
+- **Identity anchor:** ...
 - **Actions:** ...
 - **Frames:** ...
 - **FPS:** ...
 - **Loop:** ...
 - **Curation report:** ...
 - **Selected candidate:** ...
-- **Processing status:** ...
+- **Curation state:** ...
 
 ## Visual Curation Records
 

--- a/tests/test_playable_unit_contract_docs.py
+++ b/tests/test_playable_unit_contract_docs.py
@@ -107,6 +107,30 @@ def test_visual_asset_contract_flows_through_build_and_evaluate():
     assert "Visual Verification` section" in fixgap
 
 
+def test_gameplay_actor_asset_rows_only_track_registerable_runtime_outputs():
+    assets = _read("templates/ASSETS.md")
+    gdd = _read("skills/core/gm-gdd/SKILL.md")
+    planner = _read("skills/core/gm-asset/references/asset-planner.md")
+
+    assert "not Asset Table rows" in assets
+    assert "must exactly match the character-bundle request's `asset_id`" in assets
+    assert "player_canonical |" not in assets
+    assert "player_action_source |" not in assets
+    assert "player_animation_runtime/player_animation_runtime.tres" in assets
+    assert "player_portrait/player_portrait.png" in assets
+    assert "only final runtime outputs are" in gdd
+    assert "do not plan them as rows" in planner
+
+
+def test_asset_resume_and_completion_use_the_same_missing_row_boundary():
+    asset_manager = _read("skills/core/gm-asset/SKILL.md")
+
+    assert "including an Audio table row" in asset_manager
+    assert "only explicitly deferred audio is" in asset_manager
+    assert "no current-tag row is `MISSING`, unavailable audio" in asset_manager
+    assert "all unavailable\ncurrent-tag audio rows are explicitly `deferred`" in asset_manager
+
+
 def test_evaluate_requires_runtime_playable_unit_proof():
     evaluate = _read("skills/core/gm-evaluate/SKILL.md")
     schema = _read("config/stage_schemas.json")


### PR DESCRIPTION
## Summary

Align the asset documentation and skill contracts so gameplay actor tables contain only registerable runtime outputs, allowing completed asset tags to seal.

## Motivation

Canonical and action-source evidence was being represented as `MISSING` runtime rows even though those references are intentionally not registered. This left actor asset tags permanently incomplete.

Related public GitHub issue: N/A

## Changes

- [x] Limit gameplay actor Asset Table rows to registerable `character-bundle` runtime outputs.
- [x] Keep canonical and action-source material as production evidence, and align template runtime paths and families.
- [x] Require deferred audio before the asset no-work path can seal a tag.

## Testing

- [x] New or updated tests pass: `python -m pytest tests/test_playable_unit_contract_docs.py tests/tools/test_asset_result_registration.py tests/assets/test_animated_bundle_skill_contracts.py` and `python -m pytest tests/test_asset_skill_contract_docs.py tests/test_ui_card_asset_skills.py`.
- [x] GitLeaks passes or no secret-bearing files were touched: CI Secret Scan passed.
- [x] Manual testing completed, if applicable: N/A; documentation and workflow-contract change covered by contract tests.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive.
- [ ] Performance-sensitive; benchmark results are attached below or linked.

<details>
<summary>Benchmark Results</summary>

N/A — not performance-sensitive.

</details>

## Version Compatibility

Does this PR change behaviors, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed.
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md)).

> If "Yes": run `python tools/migrate.py --new <slug>` to scaffold
> `migrations/<utc-timestamp>_<slug>.py`. The script must define
> `migrate(target: Path) -> None` and be idempotent. The bump level does
> NOT gate migrations; PATCH releases can ship them too.

### Migration Upgrade Gate

Not applicable — no migration script was added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions.
- [x] ECS systems declare proper read/write metadata, if applicable: N/A.
- [x] No hardcoded secrets or API keys.
- [x] `docs/update/next.md` update is not applicable because this is a documentation/maintenance-only PR.
