### PR TITLE
Complete provided-row runtime handoff

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -93,6 +93,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Accepting a user-provided asset now fills the row's `Runtime Type` and `res://` `Runtime Path` in the same edit, so a `provided` row is always resolvable into a worker runtime snapshot instead of failing with incomplete runtime columns.
+
 - Ensure `/gm-asset` records an asset-stage completion event when its resume check finds no current-tag work.
 
 - A validated background-map registers its `single -> Texture2D` result directly in `ASSETS.md`; registration binds to the image bytes its validation run recorded, so regenerating onto the same output path fails closed.

--- a/skills/core/gm-asset/SKILL.md
+++ b/skills/core/gm-asset/SKILL.md
@@ -134,7 +134,10 @@ When image candidates exist:
 
 1. Dispatch `analyst` with only the candidate paths.
 2. Use the analyst report and `assets/manifest.json`.
-3. Update high-confidence `direct_runtime` current-tag rows to `provided`.
+3. Update high-confidence `direct_runtime` current-tag rows to `provided`, and
+   fill `Runtime Type` and the `res://` `Runtime Path` of the accepted file in
+   the same edit. A `provided` row with incomplete runtime columns cannot be
+   resolved into a worker snapshot.
 4. Keep `source_for_processing` rows in the generated visual production plan.
 5. Leave uncertain files unchanged.
 

--- a/skills/core/gm-asset/references/asset-planner.md
+++ b/skills/core/gm-asset/references/asset-planner.md
@@ -16,13 +16,20 @@ declaration.
 3. Record source, output, prompt, and report paths in the production brief.
 4. Keep one multi-output family invocation together. Do not infer its members
    from `ASSETS.md` or from a result after generation.
-5. Keep logical output names unique within the tag. A completed row is owned by
-   its production unit and must never be reused by a different request.
+5. Keep logical output names unique across the whole Asset Table, not only
+   within the current tag. Snapshot resolution matches rows by name across all
+   tags, and prior-tag rows are immutable — a later-tag redesign of an asset
+   must plan a new logical name instead of repeating a prior-tag row name. A
+   completed row is owned by its production unit and must never be reused by a
+   different request.
 6. Dispatch independent units in batches of at most three.
 7. Plan Asset Table rows only for registered logical outputs. For a runtime
    family, each row name must match a declared runtime output name. Canonical
    images, action sheets, source grids, and other provenance remain in the
    request, result, and reports; do not plan them as rows.
+8. Record `family=<asset_type>` in every planned row's Generation Params.
+   Re-registration ownership of completed reference rows is checked against
+   that field; a row without it cannot be re-registered by its own unit.
 
 ## Visual Anchor Gate
 

--- a/tests/tools/test_asset_result_registration.py
+++ b/tests/tools/test_asset_result_registration.py
@@ -292,6 +292,33 @@ def test_snapshot_accepts_provided_runtime_from_an_earlier_tag(tmp_path):
 
 
 @pytest.mark.parametrize(
+    ("runtime_type", "runtime_path", "error"),
+    [
+        ("-", "-", "not a runtime resource"),
+        ("Texture2D", "assets/user/hero.png", "clean project-local res:// path"),
+    ],
+)
+def test_snapshot_rejects_provided_rows_with_incomplete_runtime_columns(
+    tmp_path, runtime_type, runtime_path, error
+):
+    """A `provided` row is resolvable only once its runtime columns are filled."""
+    assets_md = tmp_path / "ASSETS.md"
+    runtime_file = tmp_path / "assets" / "user" / "hero.png"
+    runtime_file.parent.mkdir(parents=True)
+    runtime_file.write_bytes(b"png")
+    assets_md.write_text(
+        "# Assets\n\n"
+        "| # | Tag | Name | Type | Size | Generation Params | Runtime Type | Runtime Path | Status |\n"
+        "|---|-----|------|------|------|-------------------|--------------|--------------|--------|\n"
+        f"| 1 | v0.1.0 | hero | sprite | 64x64 | direct_runtime | {runtime_type} | {runtime_path} | provided |\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(AssetResultRegistrationError, match=error):
+        runtime_snapshot(assets_md, tag="v0.1.0", asset_ids=["hero"])
+
+
+@pytest.mark.parametrize(
     ("reference_path", "error"),
     [
         ("res://references/screen_ref.png", "project-local relative path"),


### PR DESCRIPTION
## Summary

Completes the user-provided asset handoff: a `provided` row now gets its `Runtime Type` and `res://` `Runtime Path` filled when it is accepted, so it can always be resolved into a worker runtime snapshot.

## Motivation

The snapshot resolver accepts complete `provided` rows, but the accept flow only instructed changing the row status — a row updated per the documented flow failed snapshot resolution with incomplete runtime columns. Related public issue: N/A.

## Changes

- [x] `/gm-asset` user-provided flow fills `Runtime Type` and the `res://` `Runtime Path` in the same edit that marks a row `provided`.
- [x] Planner rules pin catalog-wide logical-name uniqueness (snapshot resolves names across tags) and the `family=<asset_type>` Generation Params field that re-registration ownership reads.
- [x] Regression: snapshot rejects `provided` rows with unfilled runtime columns or non-`res://` paths with a clear error.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant) — full `python -m pytest -q`: 1714 passed, 71 skipped; `python -m ruff check .` passed; `git diff --check` passed.
- [x] Gitleaks passes or no secret-bearing files were touched — docs and tests only.
- [ ] Manual testing completed, if applicable — not applicable; contract-text and test change.

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

Documentation and test changes only; no on-disk state changes.

### Migration Upgrade Gate

Required if a migration script is added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>` — not applicable; no migration script.
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"` — not applicable; no migration script.
- [ ] Post-upgrade on-disk state was inspected and matches expectations — not applicable; no migration script.
- [ ] Re-running `tools/publish.py` produces no further migration changes — not applicable; no migration script.
- [ ] Result attached or summarized below — not applicable; no migration script.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR
