### PR TITLE
feat: add evaluator handoff

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -44,6 +44,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 - Added a shared Godot artifact compiler interface and registry under `skills/assets/_shared/` that routes on the frozen source-layout to artifact-type compatibility set, keeps compiler receipts out of the worker-facing artifact, requires each compiler to actually rebuild an artifact distinct from its source image, serves `Texture2D` through Godot's default import, and fails closed on unregistered or mismatched combinations (#107).
 - Added shared direct-output validation under `skills/assets/_shared/` for processed sources, compiled artifacts, a real headless Godot import and `ResourceLoader.load` type match, and type-specific structure checks (#108).
 - Added a deterministic `theme_recipe` compiler with a closed JSON schema for Theme colors, font sizes, constants, fonts, icons, StyleBoxes, and type variations; invalid class types, properties, resources, and StyleBox references fail closed before a loadable Theme is written.
+- FixGap can hand evaluator-owned E2E evidence back to Evaluate without claiming a normal repair completion.
 - Added a Phantom Camera supporting skill for optional Godot camera addon guidance.
 
 ## Changed

--- a/skills/core/gm-evaluate/SKILL.md
+++ b/skills/core/gm-evaluate/SKILL.md
@@ -35,14 +35,11 @@ Read `.godotmaker/stage.jsonl` (treat as empty if missing) — each line is `{"r
   > If you need to redo this step or have other plans, just tell me."
 - If the **last event** is `role == "fixgap"` with exactly
   `outcome == "handoff"`, `next_role == "evaluate"`, and
-  `reason == "evaluator_owned_e2e"` → proceed as an Evaluator handoff.
-  Read the handoff notes in GAP.md plus the referenced runtime evidence before
-  Phase 2. Repair the owned `e2e/` scenario/assertion/capture timing, then
-  re-run the affected checks and write a new evaluation. Do not ignore the
-  handoff and return the same unresolved evaluator-owned failure to FixGap.
-- Any other `fixgap` event carrying `outcome` is unsupported. STOP and ask for
-  a fresh `/gm-fixgap` run; never infer a route from GAP.md, MEMORY.md, or
-  final prose.
+  `reason == "evaluator_owned_e2e"` → read the handoff notes and referenced
+  runtime evidence; repair the `e2e/` scenario/assertion/capture timing;
+  re-run affected checks; write a new evaluation.
+- Any other `fixgap` event carrying `outcome` → STOP. Ask the user to run
+  `/gm-fixgap`.
 - Otherwise → proceed (evaluate is naturally re-invoked after each verify pass).
 
 ## Resolve `godot` binary

--- a/skills/core/gm-evaluate/SKILL.md
+++ b/skills/core/gm-evaluate/SKILL.md
@@ -33,6 +33,16 @@ Read `.godotmaker/stage.jsonl` (treat as empty if missing) — each line is `{"r
 - If the **last event** has `role == "evaluate"` AND `.godotmaker/evaluation.json` exists → STOP. Tell the user:
   > "Evaluate already ran at {timestamp} with no verify since. Recommended next: /gm-accept (if approved) or /gm-fixgap (if rejected).
   > If you need to redo this step or have other plans, just tell me."
+- If the **last event** is `role == "fixgap"` with exactly
+  `outcome == "handoff"`, `next_role == "evaluate"`, and
+  `reason == "evaluator_owned_e2e"` → proceed as an Evaluator handoff.
+  Read the handoff notes in GAP.md plus the referenced runtime evidence before
+  Phase 2. Repair the owned `e2e/` scenario/assertion/capture timing, then
+  re-run the affected checks and write a new evaluation. Do not ignore the
+  handoff and return the same unresolved evaluator-owned failure to FixGap.
+- Any other `fixgap` event carrying `outcome` is unsupported. STOP and ask for
+  a fresh `/gm-fixgap` run; never infer a route from GAP.md, MEMORY.md, or
+  final prose.
 - Otherwise → proceed (evaluate is naturally re-invoked after each verify pass).
 
 ## Resolve `godot` binary

--- a/skills/core/gm-fixgap/SKILL.md
+++ b/skills/core/gm-fixgap/SKILL.md
@@ -284,31 +284,22 @@ Your context window is finite. Protect it:
 
 ## When Done
 
-### Evaluator-owned E2E handoff (narrow alternative)
+### E2E handoff
 
-This is **not** ordinary FixGap completion. Use it only when all runtime
-requirements assigned to FixGap are already satisfied and the remaining
-failure is exclusively an Evaluator-owned E2E assertion, scenario, capture,
-or capture-timing defect. Do not use it for a game bug, a missing runtime test
-interface, or a GAP task that a worker can still fix.
+Handoff only after runtime GAP work is complete and the remaining failure is
+an E2E assertion, scenario, capture, or capture-timing defect.
 
-Before handing off:
-
-1. Preserve every affected GAP task as non-`verified`; do not archive GAP.md
-   and do not claim the FixGap iteration succeeded.
-2. Add an `Evaluator handoff` note to each affected task with the source
-   evaluation, the runtime evidence location, and the failing E2E/capture
-   location. Keep the task available for `/gm-evaluate` to consume.
-3. Append exactly this structured routing event from the project root:
+1. Keep affected GAP tasks non-`verified`; do not archive GAP.md.
+2. Add an `Evaluator handoff` note with the source evaluation, runtime evidence
+   location, and failing E2E/capture location.
+3. From the project root, run:
 
    ```text
    python tools/append_stage_event.py fixgap --outcome=handoff --next_role=evaluate --reason=evaluator_owned_e2e
    ```
 
-   Do not hand-write JSON, substitute another role or reason, or add a normal
-   `fixgap` completion event as well.
-4. Commit the handoff note with `git add -A && git commit -m "chore(fixgap): evaluator handoff <Tag>"`.
-5. Inform the user: `FixGap handed evaluator-owned E2E evidence back to /gm-evaluate.`
+4. Commit with `git add -A && git commit -m "chore(fixgap): evaluator handoff <Tag>"`.
+5. Inform the user: `FixGap handed off E2E evidence to /gm-evaluate.`
 
 ### Ordinary completion
 

--- a/skills/core/gm-fixgap/SKILL.md
+++ b/skills/core/gm-fixgap/SKILL.md
@@ -284,6 +284,34 @@ Your context window is finite. Protect it:
 
 ## When Done
 
+### Evaluator-owned E2E handoff (narrow alternative)
+
+This is **not** ordinary FixGap completion. Use it only when all runtime
+requirements assigned to FixGap are already satisfied and the remaining
+failure is exclusively an Evaluator-owned E2E assertion, scenario, capture,
+or capture-timing defect. Do not use it for a game bug, a missing runtime test
+interface, or a GAP task that a worker can still fix.
+
+Before handing off:
+
+1. Preserve every affected GAP task as non-`verified`; do not archive GAP.md
+   and do not claim the FixGap iteration succeeded.
+2. Add an `Evaluator handoff` note to each affected task with the source
+   evaluation, the runtime evidence location, and the failing E2E/capture
+   location. Keep the task available for `/gm-evaluate` to consume.
+3. Append exactly this structured routing event from the project root:
+
+   ```text
+   python tools/append_stage_event.py fixgap --outcome=handoff --next_role=evaluate --reason=evaluator_owned_e2e
+   ```
+
+   Do not hand-write JSON, substitute another role or reason, or add a normal
+   `fixgap` completion event as well.
+4. Commit the handoff note with `git add -A && git commit -m "chore(fixgap): evaluator handoff <Tag>"`.
+5. Inform the user: `FixGap handed evaluator-owned E2E evidence back to /gm-evaluate.`
+
+### Ordinary completion
+
 After all GAP.md tasks are `verified`, the final reviewer added no new tasks, and GAP.md has been archived:
 
 1. From the project root run `python tools/append_stage_event.py fixgap` to append a `{"role": "fixgap", "ts": "<server-generated UTC>"}` line to `.godotmaker/stage.jsonl`. Do NOT hand-write the JSON or the timestamp — the helper exists so the timestamp comes from the system clock, not your own output.

--- a/tests/test_fixgap_evaluate_handoff_contract.py
+++ b/tests/test_fixgap_evaluate_handoff_contract.py
@@ -17,7 +17,6 @@ def test_fixgap_handoff_uses_the_fixed_stage_event_contract():
     assert "--outcome=handoff" in fixgap
     assert "--next_role=evaluate" in fixgap
     assert "--reason=evaluator_owned_e2e" in fixgap
-    assert "not** ordinary FixGap completion" in fixgap
     assert "do not archive GAP.md" in fixgap
     assert "non-`verified`" in fixgap
 
@@ -28,5 +27,5 @@ def test_evaluate_consumes_only_the_evaluator_owned_handoff():
     assert 'outcome == "handoff"' in evaluate
     assert 'next_role == "evaluate"' in evaluate
     assert 'reason == "evaluator_owned_e2e"' in evaluate
-    assert "Repair the owned `e2e/` scenario/assertion/capture timing" in evaluate
-    assert "never infer a route from GAP.md, MEMORY.md, or\n  final prose" in evaluate
+    assert "repair the `e2e/` scenario/assertion/capture timing" in evaluate
+    assert "Ask the user to run\n  `/gm-fixgap`." in evaluate

--- a/tests/test_fixgap_evaluate_handoff_contract.py
+++ b/tests/test_fixgap_evaluate_handoff_contract.py
@@ -1,0 +1,32 @@
+"""Contract tests for the narrow FixGap → Evaluate routing handoff."""
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXGAP = REPO_ROOT / "skills" / "core" / "gm-fixgap" / "SKILL.md"
+EVALUATE = REPO_ROOT / "skills" / "core" / "gm-evaluate" / "SKILL.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_fixgap_handoff_uses_the_fixed_stage_event_contract():
+    fixgap = _read(FIXGAP)
+
+    assert "--outcome=handoff" in fixgap
+    assert "--next_role=evaluate" in fixgap
+    assert "--reason=evaluator_owned_e2e" in fixgap
+    assert "not** ordinary FixGap completion" in fixgap
+    assert "do not archive GAP.md" in fixgap
+    assert "non-`verified`" in fixgap
+
+
+def test_evaluate_consumes_only_the_evaluator_owned_handoff():
+    evaluate = _read(EVALUATE)
+
+    assert 'outcome == "handoff"' in evaluate
+    assert 'next_role == "evaluate"' in evaluate
+    assert 'reason == "evaluator_owned_e2e"' in evaluate
+    assert "Repair the owned `e2e/` scenario/assertion/capture timing" in evaluate
+    assert "never infer a route from GAP.md, MEMORY.md, or\n  final prose" in evaluate


### PR DESCRIPTION
## Summary

Adds the fixed FixGap-to-Evaluate handoff contract for evaluator-owned E2E and capture evidence.

## Motivation

Why is this change needed? Allows evaluator-owned failures to return to the evaluator without falsely sealing a normal FixGap repair.

## Changes

- [x] Document the fixed handoff event and non-completion boundary.
- [x] Require Evaluate to consume and repair the owned E2E/capture evidence.

## Testing

- [x] New or updated tests pass (targeted handoff and stage-event tests: 23 passed)
- [x] Gitleaks passes or no secret-bearing files were touched
- [x] Manual testing not applicable; this changes skill contracts and tests.

Full suite: `python -m pytest tests/ -x -q` passes (1739 passed, 72 skipped).

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated
