### PR TITLE
fix(asset): finalize Codex screen references after claim

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -96,7 +96,7 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
-- Screen references now claim successful Codex images before final validation and use proportional cover cropping to avoid transparent canvas edges.
+- Screen references now claim successful Codex images before final validation and use proportional cover cropping to avoid transparent canvas edges (#180) — @RandallLiuXin.
 
 - Accepting a user-provided asset now fills the row's `Runtime Type` and `res://` `Runtime Path` in the same edit, so a `provided` row is always resolvable into a worker runtime snapshot instead of failing with incomplete runtime columns.
 

--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -96,6 +96,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Fixed
 
+- Screen references now claim successful Codex images before final validation and use proportional cover cropping to avoid transparent canvas edges.
+
 - Accepting a user-provided asset now fills the row's `Runtime Type` and `res://` `Runtime Path` in the same edit, so a `provided` row is always resolvable into a worker runtime snapshot instead of failing with incomplete runtime columns.
 
 - Ensure `/gm-asset` records an asset-stage completion event when its resume check finds no current-tag work.

--- a/skills/assets/screen-reference/SKILL.md
+++ b/skills/assets/screen-reference/SKILL.md
@@ -51,6 +51,13 @@ camera/viewpoint, visible gameplay objects, approximate layout, HUD or UI safe
 regions, style language, target aspect/orientation, and each supplied reference
 role. Do not add labels, callouts, debug overlays, or unrequested objects.
 
+Treat object positions and sizes in the provider image as approximate visual
+direction. The raw provider source is not required to satisfy the final canvas
+or object pixel dimensions. Once the provider returns a readable image, claim
+it to the deterministic raw-source path before applying final canvas checks.
+Pixel-exact runtime sprite dimensions remain the responsibility of runtime
+Asset Skills such as `compact-prop-pack` and `fx-bundle`, not this reference.
+
 For every accepted image, retain these deterministic paths:
 
 1. prompt: `.godotmaker/asset-generation/prompts/<asset_id>.txt`;
@@ -87,12 +94,17 @@ python tools/asset_image_finalize.py \
   --label <asset_id> \
   --require-aspect <WIDTH:HEIGHT> \
   --resize <WIDTHxHEIGHT> \
+  --fit cover \
   > .godotmaker/asset-generation/reports/<asset_id>_finalize.json
 ```
 
-If aspect validation or finalization fails, STOP. Keep the captured finalize
-report as result evidence; the reference result has no runtime artifact and is
-registered as `source_ready` by the manager.
+The explicit `cover` fit proportionally scales and center-crops the raw image
+to fill the final canvas without transparent padding. After finalization,
+require the report dimensions to equal `spec.size` and validate the finalized
+reference. If aspect validation, finalization, or finalized-output validation
+fails, STOP. Keep the captured finalize report as result evidence; the
+reference result has no runtime artifact and is registered as `source_ready`
+by the manager.
 
 ## Result
 

--- a/skills/core/gm-asset/references/providers/codex.md
+++ b/skills/core/gm-asset/references/providers/codex.md
@@ -21,6 +21,19 @@ For each generated image:
 8. Do not report a project `source_path` as `generated_path`.
 9. Do not create placeholder or procedural images when generation fails.
 
+## Provider Success Boundary
+
+The provider step owns generation and source handoff, not final asset
+validation. A generation attempt succeeds when `image_gen` returns exactly one
+current-turn path and that path is a readable image that the claim step can
+copy. Do not reject the raw provider image because its canvas dimensions,
+aspect fit, background edges, object positions, or object pixel sizes differ
+from the final production-unit contract.
+
+Claim a successful raw image first. Then let the named production unit run its
+controlled finalization and validate the finalized output. This boundary is
+the same for Active Codex Runtime and for another coding agent invoking Codex.
+
 ## Reference Images
 
 References are optional. When a production unit supplies one or more required
@@ -137,6 +150,9 @@ For each asset:
 8. When an asset has references, pass every source_path reference to `image_gen`
    through `referenced_image_paths` and report the attached paths and roles.
 9. Do not create placeholder or procedural images.
+10. Treat a readable current-turn image as provider success. Do not measure the
+    raw image against final canvas, background-edge, layout, or object-pixel
+    requirements; claim it so the production unit can finalize and validate it.
 
 Assets:
 - id: <asset_id>

--- a/tests/test_asset_runtime_contract_docs.py
+++ b/tests/test_asset_runtime_contract_docs.py
@@ -40,3 +40,14 @@ def test_reference_only_assets_never_become_worker_runtime_inputs():
     assert "do not create a logical row" in registration
     assert "must not enter worker runtime handoff" in screen_reference
     assert "a reference-only asset" in worker_dispatch
+
+
+def test_codex_screen_reference_claims_raw_image_before_final_validation():
+    provider = _read("skills/core/gm-asset/references/providers/codex.md")
+    screen_reference = _read("skills/assets/screen-reference/SKILL.md")
+
+    assert "The provider step owns generation and source handoff" in provider
+    assert "Do not reject the raw provider image" in provider
+    assert "claim it so the production unit can finalize and validate it" in provider
+    assert "--fit cover" in screen_reference
+    assert "Pixel-exact runtime sprite dimensions remain" in screen_reference

--- a/tests/tools/test_asset_image_finalize.py
+++ b/tests/tools/test_asset_image_finalize.py
@@ -146,6 +146,65 @@ def test_finalize_keeps_matching_aspect_without_padding(tmp_path):
         )
 
 
+def test_finalize_cover_crops_near_aspect_source_without_transparent_edge(tmp_path):
+    source = tmp_path / "generated" / "scene.png"
+    output = tmp_path / "references" / "scene.png"
+    make_png(source, size=(1672, 941), color=(20, 80, 160, 255))
+
+    result = finalize_image_asset(
+        source,
+        output,
+        resize="1280x720",
+        require_aspect="16:9",
+        fit="cover",
+    )
+
+    assert (result["width"], result["height"]) == (1280, 720)
+    assert result["fit"] == "cover"
+    with Image.open(output) as image:
+        rgba = image.convert("RGBA")
+        assert all(
+            rgba.getpixel(point)[3] == 255
+            for point in ((0, 0), (1279, 0), (0, 719), (1279, 719))
+        )
+
+
+def test_finalize_cover_requires_resize(tmp_path):
+    source = tmp_path / "generated" / "scene.png"
+    make_png(source)
+
+    with pytest.raises(ImageFinalizeError, match="--fit cover requires --resize"):
+        finalize_image_asset(source, tmp_path / "references" / "scene.png", fit="cover")
+
+
+def test_cli_cover_crops_without_transparent_edge(tmp_path):
+    source = tmp_path / "generated" / "scene.png"
+    output = tmp_path / "references" / "scene.png"
+    make_png(source, size=(1672, 941), color=(20, 80, 160, 255))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(TOOLS_DIR / "asset_image_finalize.py"),
+            "--source", str(source),
+            "--out", str(output),
+            "--resize", "1280x720",
+            "--require-aspect", "16:9",
+            "--fit", "cover",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    data = json.loads(result.stdout)
+    assert data["fit"] == "cover"
+    with Image.open(output) as image:
+        rgba = image.convert("RGBA")
+        assert rgba.getpixel((1279, 719))[3] == 255
+
+
 def test_finalize_keeps_magenta_background_by_default(tmp_path):
     source = tmp_path / "generated" / "boss.png"
     output = tmp_path / "assets" / "sprites" / "boss.png"

--- a/tools/asset_image_finalize.py
+++ b/tools/asset_image_finalize.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import shutil
 import sys
 import tempfile
@@ -137,6 +138,28 @@ def _fit_with_padding(image, size: tuple[int, int]):
     return canvas
 
 
+def _fit_with_crop(image, size: tuple[int, int]):
+    """Resize preserving aspect ratio, cropping to exactly ``size``.
+
+    The image is scaled until it covers the target canvas, then center-cropped.
+    ``ceil`` is required here: rounding a nearly matching source aspect down by
+    one pixel would reintroduce the uncovered edge this mode is meant to avoid.
+    """
+    from PIL import Image
+
+    target_w, target_h = size
+    src_w, src_h = image.size
+    scale = max(target_w / src_w, target_h / src_h)
+    fit_w = max(target_w, math.ceil(src_w * scale))
+    fit_h = max(target_h, math.ceil(src_h * scale))
+    fitted = image.resize((fit_w, fit_h), Image.Resampling.LANCZOS)
+    left = (fit_w - target_w) // 2
+    top = (fit_h - target_h) // 2
+    cropped = fitted.crop((left, top, left + target_w, top + target_h))
+    fitted.close()
+    return cropped
+
+
 def _origin_path_for(output: Path) -> Path:
     """Archive location for the untouched original of a finalized asset.
 
@@ -162,6 +185,7 @@ def finalize_image_asset(
     label: str | None = None,
     archive_original: bool = True,
     background: str = "none",
+    fit: str = "contain",
 ) -> dict[str, object]:
     """Copy or transform a generated source image into its final path."""
     source = Path(source)
@@ -175,6 +199,10 @@ def finalize_image_asset(
     required_aspect = _parse_aspect(require_aspect)
     if background not in {"none", "magenta"}:
         raise ImageFinalizeError("--background must be none or magenta")
+    if fit not in {"contain", "cover"}:
+        raise ImageFinalizeError("--fit must be contain or cover")
+    if fit != "contain" and requested_size is None:
+        raise ImageFinalizeError("--fit cover requires --resize")
     if aspect_tolerance < 0:
         raise ImageFinalizeError("--aspect-tolerance must be non-negative")
     image = _load_image(source)
@@ -219,7 +247,11 @@ def finalize_image_asset(
             except SheetProcessError as exc:
                 raise ImageFinalizeError(str(exc)) from exc
         if requested_size is not None:
-            image = _fit_with_padding(image, requested_size)
+            image = (
+                _fit_with_crop(image, requested_size)
+                if fit == "cover"
+                else _fit_with_padding(image, requested_size)
+            )
         if image_format.lower() == "png" and image.mode not in {"RGB", "RGBA"}:
             image = image.convert("RGBA" if "A" in image.getbands() else "RGB")
 
@@ -258,6 +290,8 @@ def finalize_image_asset(
         result["origin"] = origin_saved
     if requested_size is not None:
         result["resize"] = f"{requested_size[0]}x{requested_size[1]}"
+        if fit != "contain":
+            result["fit"] = fit
     if background_cleanup is not None:
         result["background"] = "magenta"
         result["background_cleanup"] = background_cleanup
@@ -276,6 +310,12 @@ def _main() -> int:
     parser.add_argument("--source", required=True, help="Generated source image path")
     parser.add_argument("--out", required=True, help="Final project image path")
     parser.add_argument("--resize", default=None, help="Optional WIDTHxHEIGHT resize")
+    parser.add_argument(
+        "--fit",
+        default="contain",
+        choices=["contain", "cover"],
+        help="Resize fit mode: transparent padding or center crop",
+    )
     parser.add_argument(
         "--require-aspect",
         default=None,
@@ -315,6 +355,7 @@ def _main() -> int:
             label=args.label,
             archive_original=args.archive_original,
             background=args.background,
+            fit=args.fit,
         )
     except ImageFinalizeError as exc:
         print(json.dumps({"ok": False, "error": str(exc)}))


### PR DESCRIPTION
## Summary

Codex-generated screen references now treat raw image generation as a provider handoff, then apply deterministic full-canvas finalization before final validation.

## Motivation

Codex image generation can return a near-target canvas whose proportional contain resize leaves a one-pixel transparent edge. Raw provider images were also being judged against final canvas and object-pixel requirements before the controlled post-processing step could run.

## Changes

- [x] Define one Codex provider success boundary: claim a readable current-turn image before production-unit validation.
- [x] Add an explicit `cover` fit mode that proportionally scales and center-crops full-screen references without changing the default `contain` behavior.
- [x] Keep pixel-exact runtime sprite validation separate from approximate screen-reference composition.
- [x] Add function, CLI, and contract regression coverage plus release notes.

## Testing

- [x] New or updated tests pass (`pytest` / gdUnit4 where relevant)
- [x] Gitleaks passes or no secret-bearing files were touched
- [ ] Manual testing completed, if applicable

Automated evidence:

- `python -m pytest tests/tools/test_asset_image_finalize.py tests/test_asset_runtime_contract_docs.py --tb=short`: 27 passed
- Asset publication and registration chain: 215 passed
- `python -m pytest --tb=short`: 1812 passed, 3 skipped
- Ruff and `git diff --check`: passed
- Gitleaks: 464 commits scanned, no leaks found
- Same-version Codex framework replay-publish completed in an existing test project; framework file hashes matched and project state hashes were unchanged
- End-to-end Codex asset rerun remains for manual verification

## Benchmark Verification

Required only for performance-sensitive changes.

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

<details>
<summary>Benchmark Results</summary>

```text
Not applicable.
```

</details>

## Version Compatibility

Does this PR change behavior, move files, rename config keys, or break existing target projects?

- [x] **No** - no migration needed
- [ ] **Yes** - migration script added to `migrations/` ([guide](migrations/README.md))

### Migration Upgrade Gate

Not applicable; no migration was added or modified.

- [ ] Real GodotMaker game project pinned at the previous version was upgraded via `python tools/publish.py <target>`
- [ ] Post-upgrade `<target>/.godotmaker/applied_migrations.json` contains the new migration ID with `source: "executed"`
- [ ] Post-upgrade on-disk state was inspected and matches expectations
- [ ] Re-running `tools/publish.py` produces no further migration changes
- [ ] Result attached or summarized below

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] `docs/update/next.md` updated, unless this is a docs-only typo or maintenance-only PR