### PR TITLE
fix: enforce major clean reinitialization

### DIFF
--- a/docs/update/next.md
+++ b/docs/update/next.md
@@ -49,6 +49,8 @@ If no category fits, add a new one following [Keep a Changelog](https://keepacha
 
 ## Changed
 
+- MAJOR upgrades now fail closed unless `--force` is present, and an authorized clean re-initialization resets incompatible current-pipeline gates and reports while preserving game content plus evaluation, gap, and asset-provenance history.
+
 - Generated assets now use `ASSETS.md` as the single runtime catalog: each
   logical asset row records its final Godot type and loadable path directly.
   Multi-output asset production registers all declared outputs atomically, and

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -133,10 +133,13 @@ MAJOR version bumps indicate breaking changes that cannot be handled
 by incremental migration. `publish.py` refuses to upgrade across MAJOR
 boundaries without `--force`, which performs a clean re-initialization.
 
-Full rebuild cleans all framework-managed content:
+Full rebuild re-deploys framework code and removes incompatible current state:
 - The selected runner's `skills/`, `agents/`, `config/`, and `templates/`
 - `.godotmaker/hooks/`, `.godotmaker/stage_schemas.json`
-- `.godotmaker/state.json`, `.godotmaker/metrics*.jsonl`
+- Current pipeline state: `.godotmaker/state.json`, `pipeline_state.json`,
+  `stage.jsonl`, `current_role`, `evaluation.json`, `verify_report.json`,
+  and `final_report.json`
+- `.godotmaker/metrics*.jsonl`
 - `.godotmaker/applied_migrations.json` (re-baselined after re-deploy)
 - `tools/`
 - The selected runner's hook config or plugin adapter (force-overwritten)
@@ -144,6 +147,9 @@ Full rebuild cleans all framework-managed content:
 Preserved (user configuration):
 - `CLAUDE.md` / `AGENTS.md`, the selected runner's `godotmaker.yaml`,
   `.godotmaker/config.yaml`
+- Game code, scenes, assets, planning documents, and historical evidence such
+  as `.godotmaker/evaluation-runs/`, `.godotmaker/gaps/`, and
+  `.godotmaker/asset-generation/`
 
 After re-deploy, `publish.py` calls `baseline_applied()` to mark every
 current migration as applied without running it — same as a fresh install.

--- a/docs/wiki/05-tools/publish.md
+++ b/docs/wiki/05-tools/publish.md
@@ -124,10 +124,10 @@ python tools/publish.py --agent opencode --force /path/to/my-game
 
 1. Clears the selected agent's skill directory before re-deploying, removing any skills left over from a previous version.
 2. Overwrites the selected runner's hook config or adapter (`.claude/settings.json`, `.codex/hooks.json`, or `.opencode/plugins/godotmaker-hooks.js`) even if you've already customized it.
-3. Skips the confirmation prompts for minor and major upgrades.
+3. Skips the minor-upgrade confirmation and explicitly authorizes the clean re-initialization required for a major upgrade.
 4. Allows downgrades.
 
-For **major** upgrades with `--force`, the clean-up is more thorough: the selected agent's `skills/`, `agents/`, `config/`, and `templates/` folders, `.godotmaker/hooks/`, `tools/`, and the runtime state files are all wiped and rebuilt from scratch.
+For **major** upgrades with `--force`, the clean-up is more thorough: the selected agent's `skills/`, `agents/`, `config/`, and `templates/` folders, `.godotmaker/hooks/`, `tools/`, and current pipeline state (`state.json`, `pipeline_state.json`, `stage.jsonl`, `current_role`, `evaluation.json`, `verify_report.json`, `final_report.json`, metrics, schemas, and the migration tracker) are wiped and rebuilt from scratch. Historical evidence under `.godotmaker/evaluation-runs/`, `.godotmaker/gaps/`, and `.godotmaker/asset-generation/` is preserved.
 
 ## What is preserved on upgrade
 

--- a/docs/zh/versioning.md
+++ b/docs/zh/versioning.md
@@ -118,16 +118,21 @@ python tools/migrate.py --new fix-state-path
 
 MAJOR 版本变更意味着无法通过增量迁移处理的破坏性变更。`publish.py` 拒绝跨 MAJOR 边界升级，除非使用 `--force`，该选项会执行干净的重新初始化。
 
-全量重建会清除所有框架管理的内容：
+全量重建会重新部署框架代码，并清除不兼容的当前状态：
 - 所选 runner 的 `skills/`、`agents/`、`config/`、`templates/`
 - `.godotmaker/hooks/`、`.godotmaker/stage_schemas.json`
-- `.godotmaker/state.json`、`.godotmaker/metrics*.jsonl`
+- 当前流水线状态：`.godotmaker/state.json`、`pipeline_state.json`、
+  `stage.jsonl`、`current_role`、`evaluation.json`、`verify_report.json`、
+  `final_report.json`
+- `.godotmaker/metrics*.jsonl`
 - `.godotmaker/applied_migrations.json`（重新部署后会重建 baseline）
 - `tools/`
 - 所选 runner 的 hook config 或 plugin adapter（强制覆盖）
 
 保留（用户配置）：
 - `CLAUDE.md` / `AGENTS.md`、所选 runner 的 `godotmaker.yaml`、`.godotmaker/config.yaml`
+- 游戏代码、场景、素材、规划文档，以及 `.godotmaker/evaluation-runs/`、
+  `.godotmaker/gaps/`、`.godotmaker/asset-generation/` 等历史证据
 
 重新部署完后，`publish.py` 调用 `baseline_applied()` 把所有当前迁移
 标记为已应用而不执行——跟全新安装一样。迁移时间戳序列本身是单调全局的，

--- a/docs/zh/wiki/05-tools/publish.md
+++ b/docs/zh/wiki/05-tools/publish.md
@@ -109,10 +109,10 @@ python tools/publish.py --agent opencode --force /path/to/my-game
 
 1. 重新部署前清空所选 agent 的技能目录，移除旧版本遗留的技能文件。
 2. 即使你已自定义过所选 runner 的 hook config 或 adapter（`.claude/settings.json`、`.codex/hooks.json` 或 `.opencode/plugins/godotmaker-hooks.js`），也会强制覆盖。
-3. 跳过 minor 和 major 升级的确认提示。
+3. 跳过 minor 升级的确认提示，并显式授权 major 升级所需的干净重新初始化。
 4. 允许降级。
 
-对于加了 `--force` 的 **major** 升级，清理范围更大：所选 agent 的 `skills/`、`agents/`、`config/`、`templates/`，`.godotmaker/hooks/`、`tools/` 以及运行时状态文件都会被清空并从头重建。
+对于加了 `--force` 的 **major** 升级，清理范围更大：所选 agent 的 `skills/`、`agents/`、`config/`、`templates/`，`.godotmaker/hooks/`、`tools/`，以及当前流水线状态（`state.json`、`pipeline_state.json`、`stage.jsonl`、`current_role`、`evaluation.json`、`verify_report.json`、`final_report.json`、metrics、schema 和迁移 tracker）都会被清空并从头重建。`.godotmaker/evaluation-runs/`、`.godotmaker/gaps/` 和 `.godotmaker/asset-generation/` 下的历史证据会被保留。
 
 ## 升级时哪些内容会被保留
 

--- a/tests/tools/test_migrate.py
+++ b/tests/tools/test_migrate.py
@@ -642,12 +642,11 @@ class TestSelectMigrationAction:
         from publish import select_migration_action
         assert select_migration_action("MAJOR", force=True) == "baseline"
 
-    def test_major_without_force_defensive_run(self):
-        """MAJOR without --force is filtered out by check_version_upgrade,
-        so this path is unreachable in production. Test the defensive
-        default anyway."""
+    def test_major_without_force_fails_closed(self):
+        """No caller may route a MAJOR upgrade through incremental migration."""
         from publish import select_migration_action
-        assert select_migration_action("MAJOR", force=False) == "run"
+        with pytest.raises(ValueError, match="require --force"):
+            select_migration_action("MAJOR", force=False)
 
     def test_same_runs(self):
         from publish import select_migration_action
@@ -849,26 +848,70 @@ class TestPublishMainMigrationRouting:
         assert len(env["baseline_calls"]) == 1
         assert env["run_calls"] == []
 
-    def test_major_force_cleanup_removes_applied_migrations_file(
+    def test_major_without_force_exits_before_publish_or_migrations(
         self, env, monkeypatch
     ):
-        """The MAJOR --force cleanup loop must delete an existing
-        applied_migrations.json (so the subsequent baseline starts fresh).
-        Replaces the previous source-text grep test with a real one."""
+        """The top-level entry point must not let a prompt bypass MAJOR reset."""
+        import publish
+
+        self._force_source_version(monkeypatch, 1, 0, 0)
+        self._seed_target_version(env["target"], "0.8.2")
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda _: pytest.fail("MAJOR without --force must not prompt"),
+        )
+        monkeypatch.setattr(
+            publish,
+            "publish_skills",
+            lambda *_args, **_kwargs: pytest.fail("publish must not start"),
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            self._run_main(monkeypatch, env["target"])
+
+        assert exc_info.value.code == 1
+        assert env["baseline_calls"] == []
+        assert env["run_calls"] == []
+
+    def test_major_force_cleanup_resets_incompatible_runtime_state(
+        self, env, monkeypatch
+    ):
+        """MAJOR --force resets gates and current-run reports before baseline."""
         self._force_source_version(monkeypatch, 1, 0, 0)
         self._seed_target_version(env["target"], "0.4.0")
 
-        applied_file = env["target"] / ".godotmaker" / "applied_migrations.json"
-        applied_file.write_text(
-            '{"applied":[{"id":"old_v","applied_at":"x","source":"executed"}]}'
-        )
-        assert applied_file.exists()
+        godotmaker_dir = env["target"] / ".godotmaker"
+        reset_files = [
+            "state.json",
+            "metrics.jsonl",
+            "metrics_current.jsonl",
+            "pipeline_state.json",
+            "stage.jsonl",
+            "current_role",
+            "evaluation.json",
+            "verify_report.json",
+            "final_report.json",
+            "stage_schemas.json",
+            "applied_migrations.json",
+        ]
+        for name in reset_files:
+            (godotmaker_dir / name).write_text("old runtime state")
+
+        # Historical evidence and user-authored project content are not reset.
+        evidence = godotmaker_dir / "evaluation-runs" / "1" / "evaluation.json"
+        evidence.parent.mkdir(parents=True)
+        evidence.write_text("historical evidence")
+        gdd = env["target"] / "GDD.md"
+        gdd.write_text("user design")
 
         self._run_main(monkeypatch, env["target"], force=True)
 
         # baseline_applied is mocked, so the file is NOT recreated here;
         # we only verify the cleanup loop did its job.
-        assert not applied_file.exists()
+        for name in reset_files:
+            assert not (godotmaker_dir / name).exists()
+        assert evidence.read_text() == "historical evidence"
+        assert gdd.read_text() == "user design"
         assert len(env["baseline_calls"]) == 1
         assert env["run_calls"] == []
 
@@ -1085,10 +1128,15 @@ class TestCheckVersionUpgrade:
         assert result.proceed is True
         assert result.level == "MINOR"
 
-    def test_major_upgrade_without_force_prompts(self, tmp_path, monkeypatch):
+    def test_major_upgrade_without_force_is_blocked_without_prompt(
+        self, tmp_path, monkeypatch
+    ):
         from publish import check_version_upgrade
         repo, target = self._setup_versions(tmp_path, "1.0.0", "0.4.0")
-        monkeypatch.setattr("builtins.input", lambda _: "n")
+        monkeypatch.setattr(
+            "builtins.input",
+            lambda _: pytest.fail("MAJOR without --force must not prompt"),
+        )
         result = check_version_upgrade(repo, target, force=False)
         assert result.proceed is False
         assert result.level == "MAJOR"

--- a/tools/publish.py
+++ b/tools/publish.py
@@ -304,14 +304,8 @@ def check_version_upgrade(repo_root: Path, target: Path, force: bool
     # MAJOR upgrade — block incremental, require --force for clean re-init
     if level == "MAJOR" and not force:
         print("  MAJOR upgrades require --force (clean re-initialization).")
-        print("  This will wipe .claude/skills/ and .godotmaker/hooks/ and re-deploy.")
-        try:
-            answer = input("  Proceed with MAJOR upgrade? [y/N] ").strip().lower()
-        except (EOFError, KeyboardInterrupt):
-            answer = ""
-        if answer not in ("y", "yes"):
-            print("  Upgrade cancelled.")
-            return VersionCheckResult(False, level, target_ver, source_ver)
+        print("  Re-run this command with --force to authorize the reset.")
+        return VersionCheckResult(False, level, target_ver, source_ver)
 
     # MINOR upgrades require confirmation (unless --force)
     elif level == "MINOR" and not force:
@@ -342,11 +336,11 @@ def select_migration_action(level: str, force: bool) -> str:
       auto-created, then any pending migrations run normally through
       the standard pending-application path.
 
-    MAJOR without `--force` is filtered out by check_version_upgrade()
-    before this function is called, so the (level="MAJOR", force=False)
-    case is unreachable in practice; if it does arrive (defensive),
-    treating it as "run" is harmless because publish would have aborted.
+    MAJOR without `--force` is invalid. Raise instead of falling back to
+    incremental migrations so a future caller cannot bypass the version gate.
     """
+    if level == "MAJOR" and not force:
+        raise ValueError("MAJOR upgrades require --force")
     if level == "FRESH" or (level == "MAJOR" and force):
         return "baseline"
     return "run"
@@ -1410,8 +1404,8 @@ def main():
                         help="Coding agent target to publish for "
                              "(default: claude-code)")
     parser.add_argument("--force", action="store_true",
-                        help="Clean existing agent skills before publishing; "
-                             "skip upgrade confirmation prompts")
+                        help="Authorize a MAJOR clean re-init, clean existing "
+                             "agent skills, and skip MINOR confirmation")
     parser.add_argument("--no-config-review", action="store_true",
                         help="Do not pause after creating .godotmaker/config.yaml")
     args = parser.parse_args()
@@ -1475,6 +1469,12 @@ def main():
             target / ".godotmaker" / "state.json",
             target / ".godotmaker" / "metrics.jsonl",
             target / ".godotmaker" / "metrics_current.jsonl",
+            target / ".godotmaker" / "pipeline_state.json",
+            target / ".godotmaker" / "stage.jsonl",
+            target / ".godotmaker" / "current_role",
+            target / ".godotmaker" / "evaluation.json",
+            target / ".godotmaker" / "verify_report.json",
+            target / ".godotmaker" / "final_report.json",
             target / ".godotmaker" / "stage_schemas.json",
             target / ".godotmaker" / "applied_migrations.json",
         ]:


### PR DESCRIPTION
## Summary

Make MAJOR upgrades fail closed without --force and make the authorized clean re-initialization reset every incompatible current-pipeline checkpoint, including the App/CLI pipeline_state.json checkpoint.

This PR must merge before release PR #182. After it merges, #182 should be updated from main so this change is included in v1.0.0 release notes.

## Motivation

The current MAJOR gate prints that --force is required but still accepts a y response and proceeds. The cleanup also leaves stage.jsonl, current_role, current reports, and pipeline_state.json behind, so a 0.x project can resume incompatible state after a supposed clean re-init.

## Changes

- [x] Block MAJOR publish immediately when --force is absent; no confirmation prompt can bypass it.
- [x] Make migration routing fail closed for MAJOR without --force.
- [x] Reset current pipeline gates, reports, metrics, schema, and migration tracker during MAJOR --force.
- [x] Preserve game content and durable evaluation, gap, trace, and asset-provenance history.
- [x] Document the exact English and Chinese cleanup contract.

## Testing

- [x] New or updated tests pass: 192 targeted tests passed.
- [x] Full suite passes: 1813 passed, 3 skipped.
- [x] Ruff passes.
- [x] MkDocs strict build passes.
- [x] Gitleaks passes.
- [x] Manual smoke completed in a disposable project.

Manual smoke: a target stamped 0.8.2 with seeded pipeline_state.json, stage.jsonl, current_role, evaluation/verify/final reports, metrics, schema, and migration tracker was published from a temporary 1.0.0 source. Without --force the command exited 1 and left version/state untouched. With --force it installed 1.0.0, removed all current-state files, redeployed the schema, baselined 7 migrations, and preserved GDD.md, pipeline_state.history.jsonl, evaluation-runs, and asset-generation provenance.

## Benchmark Verification

- [x] Not performance-sensitive
- [ ] Performance-sensitive; benchmark results are attached below or linked

## Version Compatibility

This intentionally changes only the MAJOR upgrade path. No migration is added: MAJOR upgrades are defined as non-incremental, skip migrations, clean incompatible current state, and baseline the current migration set after redeploy.

## Checklist

- [x] Code follows project conventions
- [x] ECS systems declare proper read/write metadata, if applicable
- [x] No hardcoded secrets or API keys
- [x] docs/update/next.md updated